### PR TITLE
feat(web): compact, centered chat layout

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -136,3 +136,23 @@
     font-family: 'JetBrains Mono', monospace;
   }
 }
+
+
+/* Brand text selection */
+::selection {
+  background-color: hsl(var(--primary) / 0.24);
+}
+
+/* Staggered entrance delays for animate-in utilities */
+.stagger-1 {
+  animation-delay: 80ms;
+}
+.stagger-2 {
+  animation-delay: 160ms;
+}
+.stagger-3 {
+  animation-delay: 240ms;
+}
+.stagger-4 {
+  animation-delay: 320ms;
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -50,6 +50,7 @@ const ChatScreen = () => {
             activeError={activeError}
             activeStatus={activeStatus}
             messages={messages}
+            onPickSuggestion={submitMessage}
             onRetry={retry}
             renderActions={renderActions}
             status={status}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -13,6 +13,7 @@ const ChatScreen = () => {
   const setModel = useUiStore((s) => s.setModel);
   const sidebarOpen = useUiStore((s) => s.sidebarOpen);
   const toggleSidebar = useUiStore((s) => s.toggleSidebar);
+  const setSidebarOpen = useUiStore((s) => s.setSidebarOpen);
 
   const { data: modelList } = useModels();
   const {
@@ -39,6 +40,9 @@ const ChatScreen = () => {
         <Sidebar
           activeId={activeId}
           conversations={conversations}
+          onClose={() => {
+            setSidebarOpen(false);
+          }}
           onDelete={onDelete}
           onNewChat={onNewChat}
           onRename={onRename}

--- a/web/components/ai-elements/conversation.tsx
+++ b/web/components/ai-elements/conversation.tsx
@@ -29,7 +29,7 @@ export const ConversationContent = ({
   ...props
 }: ConversationContentProps) => (
   <StickToBottom.Content
-    className={cn("flex flex-col gap-8 p-4", className)}
+    className={cn("flex min-h-full flex-col px-4 py-6", className)}
     {...props}
   />
 );

--- a/web/components/ai-elements/message.tsx
+++ b/web/components/ai-elements/message.tsx
@@ -37,8 +37,10 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
-      "group flex w-full max-w-[95%] flex-col gap-2",
-      from === "user" ? "is-user ml-auto justify-end" : "is-assistant",
+      "group flex w-full flex-col gap-2 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-2 motion-safe:duration-500",
+      from === "user"
+        ? "is-user ml-auto max-w-[85%] items-end"
+        : "is-assistant max-w-full",
       className
     )}
     {...props}
@@ -54,8 +56,8 @@ export const MessageContent = ({
 }: MessageContentProps) => (
   <div
     className={cn(
-      "is-user:dark flex w-fit min-w-0 max-w-full flex-col gap-2 overflow-hidden text-sm",
-      "group-[.is-user]:ml-auto group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
+      "is-user:dark flex w-fit min-w-0 max-w-full flex-col gap-2 overflow-hidden text-sm leading-relaxed",
+      "group-[.is-user]:ml-auto group-[.is-user]:rounded-2xl group-[.is-user]:rounded-br-md group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-2.5 group-[.is-user]:text-foreground group-[.is-user]:shadow-sm",
       "group-[.is-assistant]:text-foreground",
       className
     )}

--- a/web/components/chat/composer.tsx
+++ b/web/components/chat/composer.tsx
@@ -89,9 +89,9 @@ export const Composer = ({
   };
 
   return (
-    <div className="border-t border-border bg-background px-3 py-3 sm:px-4">
+    <div className="bg-background px-3 pb-3 pt-2 sm:px-4">
       <div className="mx-auto w-full max-w-3xl">
-        <div className="flex flex-col rounded-2xl border border-input bg-card shadow-sm transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50">
+        <div className="flex flex-col rounded-3xl border border-input bg-card shadow-lg shadow-black/5 transition-[color,box-shadow] focus-within:border-ring/70 focus-within:ring-4 focus-within:ring-ring/15 dark:shadow-black/25">
           <textarea
             aria-label={t('composer.message')}
             className="field-sizing-content max-h-48 min-h-[52px] w-full resize-none bg-transparent px-4 pt-3 pb-2 text-sm outline-none placeholder:text-muted-foreground disabled:opacity-50"
@@ -144,7 +144,7 @@ export const Composer = ({
             </Select>
             <Button
               aria-label={isBusy ? t('composer.stop') : t('composer.send')}
-              className="size-9 shrink-0 rounded-full"
+              className="size-9 shrink-0 rounded-full transition-transform active:scale-95"
               data-testid="composer-submit"
               disabled={
                 (disabled ?? false) || (!isBusy && value.trim().length === 0)
@@ -157,6 +157,9 @@ export const Composer = ({
             </Button>
           </div>
         </div>
+        <p className="mt-2 text-center text-xs text-muted-foreground">
+          {t('composer.disclaimer')}
+        </p>
       </div>
     </div>
   );

--- a/web/components/chat/thread.tsx
+++ b/web/components/chat/thread.tsx
@@ -5,7 +5,6 @@ import type { MyUIMessage } from '@/lib/api-types';
 import {
   Conversation,
   ConversationContent,
-  ConversationEmptyState,
   ConversationScrollButton,
 } from '@/components/ai-elements/conversation';
 import {
@@ -21,6 +20,7 @@ export type ThreadProps = {
   activeError?: { code: string; message: string };
   activeStatus?: { label: string; tool?: string };
   messages: MyUIMessage[];
+  onPickSuggestion?: (text: string) => void;
   onRetry?: () => void;
   renderActions?: (message: MyUIMessage) => ReactNode;
   status: 'error' | 'ready' | 'streaming' | 'submitted';
@@ -32,10 +32,55 @@ const userText = (message: MyUIMessage): string =>
     .map((p) => p.text)
     .join('');
 
+const SUGGESTIONS = [
+  'Кои се роковите за пријавување на испити?',
+  'Како се пресметува просечната оценка?',
+  'Кои предмети се задолжителни во прва година?',
+  'Како да аплицирам за изборни предмети?',
+] as const;
+
+const STAGGER = ['stagger-1', 'stagger-2', 'stagger-3', 'stagger-4'];
+
+const CHIP =
+  'group rounded-xl border border-border bg-card/60 px-4 py-3 text-left text-sm text-foreground/90 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:bg-card hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-2 motion-safe:fill-mode-both';
+
+const Welcome = ({ onPick }: { onPick?: (text: string) => void }) => (
+  <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center gap-6 py-12 text-center motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-95 motion-safe:slide-in-from-bottom-4 motion-safe:duration-700">
+    <img
+      alt="ФИНКИ Хаб"
+      className="h-16 w-16 object-contain drop-shadow-sm"
+      src="/logo.png"
+    />
+    <div className="space-y-2">
+      <h2 className="text-2xl font-bold tracking-tight">
+        {t('thread.emptyTitle')}
+      </h2>
+      <p className="text-muted-foreground">{t('thread.emptyDescription')}</p>
+    </div>
+    {onPick ? (
+      <div className="grid w-full grid-cols-1 gap-2.5 sm:grid-cols-2">
+        {SUGGESTIONS.map((s, i) => (
+          <button
+            className={`${CHIP} ${STAGGER[i] ?? ''}`}
+            key={s}
+            onClick={() => {
+              onPick(s);
+            }}
+            type="button"
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+    ) : null}
+  </div>
+);
+
 export const Thread = ({
   activeError,
   activeStatus,
   messages,
+  onPickSuggestion,
   onRetry,
   renderActions,
   status,
@@ -48,48 +93,47 @@ export const Thread = ({
     <Conversation className="flex-1">
       <ConversationContent>
         {messages.length === 0 ? (
-          <ConversationEmptyState
-            description={t('thread.emptyDescription')}
-            title={t('thread.emptyTitle')}
-          />
+          <Welcome onPick={onPickSuggestion} />
         ) : (
-          messages.map((m) => {
-            if (m.role === 'user') {
-              return (
-                <Message
-                  from="user"
-                  key={m.id}
-                >
-                  <MessageContent>
-                    <MessageResponse>{userText(m)}</MessageResponse>
-                  </MessageContent>
-                </Message>
-              );
-            }
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
+            {messages.map((m) => {
+              if (m.role === 'user') {
+                return (
+                  <Message
+                    from="user"
+                    key={m.id}
+                  >
+                    <MessageContent>
+                      <MessageResponse>{userText(m)}</MessageResponse>
+                    </MessageContent>
+                  </Message>
+                );
+              }
 
-            const isLastAssistant = m.id === lastAssistantId;
-            return (
-              <AssistantMessage
-                actions={renderActions ? renderActions(m) : undefined}
-                errorPart={isLastAssistant ? activeError : undefined}
-                key={m.id}
-                message={m}
-                onRetry={onRetry}
-                pending={isLastAssistant && streaming}
-                statusPart={
-                  isLastAssistant && streaming ? activeStatus : undefined
-                }
-              />
-            );
-          })
+              const isLastAssistant = m.id === lastAssistantId;
+              return (
+                <AssistantMessage
+                  actions={renderActions ? renderActions(m) : undefined}
+                  errorPart={isLastAssistant ? activeError : undefined}
+                  key={m.id}
+                  message={m}
+                  onRetry={onRetry}
+                  pending={isLastAssistant && streaming}
+                  statusPart={
+                    isLastAssistant && streaming ? activeStatus : undefined
+                  }
+                />
+              );
+            })}
+            {awaitingReply ? (
+              <Message from="assistant">
+                <MessageContent>
+                  <TypingIndicator />
+                </MessageContent>
+              </Message>
+            ) : null}
+          </div>
         )}
-        {awaitingReply ? (
-          <Message from="assistant">
-            <MessageContent>
-              <TypingIndicator />
-            </MessageContent>
-          </Message>
-        ) : null}
       </ConversationContent>
       <ConversationScrollButton />
     </Conversation>

--- a/web/components/shell/conversation-list.tsx
+++ b/web/components/shell/conversation-list.tsx
@@ -23,8 +23,8 @@ export const ConversationList = ({
     {conversations.map((c) => (
       <li
         aria-current={c.id === activeId ? 'true' : undefined}
-        className={`group flex items-center justify-between rounded-md px-2 py-1.5 text-sm hover:bg-muted ${
-          c.id === activeId ? 'bg-muted font-medium' : ''
+        className={`group flex items-center justify-between gap-1 rounded-lg px-2.5 py-2 text-sm text-foreground/80 transition-colors duration-150 hover:bg-muted/70 ${
+          c.id === activeId ? 'bg-muted font-medium text-foreground' : ''
         }`}
         data-testid={`conversation-${c.id}`}
         key={c.id}
@@ -41,7 +41,7 @@ export const ConversationList = ({
         <span className="flex items-center gap-1 opacity-0 group-hover:opacity-100">
           <button
             aria-label={t('conversation.rename')}
-            className="rounded p-1 hover:bg-background"
+            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
             onClick={() => {
               // eslint-disable-next-line no-alert -- lightweight rename UX; spec §9 uses the native prompt
               const next = prompt(t('conversation.renamePrompt'), c.title);
@@ -58,7 +58,7 @@ export const ConversationList = ({
           </button>
           <button
             aria-label={t('conversation.delete')}
-            className="rounded p-1 hover:bg-background"
+            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-background hover:text-destructive"
             onClick={() => {
               onDelete(c.id);
             }}

--- a/web/components/shell/header.tsx
+++ b/web/components/shell/header.tsx
@@ -20,8 +20,8 @@ const GitHubIcon = () => (
 );
 
 export const Header = ({ onToggleSidebar }: HeaderProps) => (
-  <header className="border-b">
-    <div className="flex h-16 items-center gap-3 px-4">
+  <header className="z-30 shrink-0 border-b border-border/60 bg-background">
+    <div className="flex h-14 items-center gap-3 px-4">
       <IconButton
         aria-label={t('header.toggleSidebar')}
         onClick={onToggleSidebar}
@@ -33,10 +33,10 @@ export const Header = ({ onToggleSidebar }: HeaderProps) => (
       </IconButton>
       <img
         alt="ФИНКИ Хаб"
-        className="h-10 w-10 shrink-0 object-contain"
+        className="h-9 w-9 shrink-0 object-contain"
         src="/logo.png"
       />
-      <h1 className="min-w-0 flex-1 text-base font-bold leading-tight tracking-tight sm:text-xl">
+      <h1 className="min-w-0 flex-1 truncate text-base font-bold leading-tight tracking-tight sm:text-lg">
         {t('header.title')}
       </h1>
       <div className="ml-auto flex shrink-0 items-center gap-2">

--- a/web/components/shell/sidebar.tsx
+++ b/web/components/shell/sidebar.tsx
@@ -4,10 +4,12 @@ import type { ConversationRow } from '@/lib/db';
 
 import { ConversationList } from '@/components/shell/conversation-list';
 import { t } from '@/lib/i18n';
+import { cn } from '@/lib/utils';
 
 export type SidebarProps = {
   activeId: null | string;
   conversations: ConversationRow[];
+  onClose: () => void;
   onDelete: (id: string) => void;
   onNewChat: () => void;
   onRename: (id: string, title: string) => void;
@@ -15,50 +17,82 @@ export type SidebarProps = {
   open: boolean;
 };
 
+const closeIfMobile = (onClose: () => void) => {
+  if (
+    typeof matchMedia === 'function' &&
+    matchMedia('(max-width: 767px)').matches
+  ) {
+    onClose();
+  }
+};
+
 export const Sidebar = ({
   activeId,
   conversations,
+  onClose,
   onDelete,
   onNewChat,
   onRename,
   onSelect,
   open,
 }: SidebarProps) => {
-  if (!open) {
-    return (
-      <aside
-        aria-label={t('sidebar.label')}
-        className="w-0 overflow-hidden"
-        data-collapsed="true"
-      />
-    );
-  }
+  const handleSelect = (id: string) => {
+    onSelect(id);
+    closeIfMobile(onClose);
+  };
+
+  const handleNewChat = () => {
+    onNewChat();
+    closeIfMobile(onClose);
+  };
 
   return (
-    <aside
-      aria-label={t('sidebar.label')}
-      className="flex w-64 shrink-0 flex-col gap-3 border-r border-border bg-muted/30 p-3"
-    >
-      <button
-        className="inline-flex items-center justify-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-muted"
-        onClick={onNewChat}
-        type="button"
+    <>
+      {open ? (
+        <button
+          aria-label={t('header.toggleSidebar')}
+          className="fixed inset-0 z-40 bg-black/40 md:hidden"
+          onClick={onClose}
+          type="button"
+        />
+      ) : null}
+      <aside
+        aria-hidden={!open}
+        aria-label={t('sidebar.label')}
+        className={cn(
+          'fixed inset-y-0 left-0 z-50 w-64 shrink-0 overflow-hidden border-r border-border/60 bg-background transition-transform duration-300 ease-in-out md:static md:z-auto md:bg-muted/30 md:transition-[width]',
+          open
+            ? 'translate-x-0 md:w-64'
+            : '-translate-x-full md:w-0 md:translate-x-0',
+        )}
+        data-collapsed={!open}
       >
-        <Plus
-          aria-hidden="true"
-          className="size-4"
-        />
-        {t('sidebar.new')}
-      </button>
-      <nav className="flex-1 overflow-y-auto">
-        <ConversationList
-          activeId={activeId}
-          conversations={conversations}
-          onDelete={onDelete}
-          onRename={onRename}
-          onSelect={onSelect}
-        />
-      </nav>
-    </aside>
+        <div className="flex h-full w-64 flex-col gap-3 p-3">
+          <button
+            className="group inline-flex items-center gap-2 rounded-xl border border-border bg-card px-3 py-2.5 text-sm font-medium shadow-sm transition-all duration-200 hover:border-primary/40 hover:bg-muted hover:shadow active:scale-[0.99]"
+            onClick={handleNewChat}
+            type="button"
+          >
+            <Plus
+              aria-hidden="true"
+              className="size-4 transition-transform duration-200 group-hover:rotate-90"
+            />
+            {t('sidebar.new')}
+          </button>
+          <nav className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+            <p className="px-2 pb-1.5 pt-1 text-xs font-medium uppercase tracking-wide text-muted-foreground/70">
+              {t('sidebar.history')}
+            </p>
+            <ConversationList
+              activeId={activeId}
+              conversations={conversations}
+              onDelete={onDelete}
+              onRename={onRename}
+              onSelect={handleSelect}
+            />
+          </nav>
+        </div>
+      </aside>
+    </>
   );
 };

--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -20,6 +20,7 @@ export const messages = {
   'header.theme': 'Промени тема',
   'header.title': 'ФИНКИ Хаб / Чат',
   'header.toggleSidebar': 'Прикажи/сокриј странична лента',
+  'sidebar.history': 'Разговори',
   'sidebar.label': 'Странична лента',
   'sidebar.new': 'Нов разговор',
   'sidebar.toggle': 'Прикажи/сокриј странична лента',

--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -4,6 +4,8 @@ export const messages = {
   'actions.like': 'Допаѓа',
   'actions.regenerate': 'Регенерирај',
   'app.title': 'ФИНКИ Хаб',
+  'composer.disclaimer':
+    'ФИНКИ Хаб може да направи грешки. Проверете важни информации.',
   'composer.message': 'Порака',
   'composer.model': 'Модел',
   'composer.placeholder': 'Напиши порака…',

--- a/web/test/shell.test.tsx
+++ b/web/test/shell.test.tsx
@@ -190,6 +190,7 @@ describe('Sidebar', () => {
       <Sidebar
         activeId="c1"
         conversations={rows}
+        onClose={noop()}
         onDelete={noop()}
         onNewChat={onNewChat}
         onRename={noop()}
@@ -205,11 +206,12 @@ describe('Sidebar', () => {
     expect(onNewChat).toHaveBeenCalledOnce();
   });
 
-  it('hides its content when collapsed', () => {
-    render(
+  it('marks the sidebar as collapsed when closed', () => {
+    const { container } = render(
       <Sidebar
         activeId={null}
         conversations={rows}
+        onClose={noop()}
         onDelete={noop()}
         onNewChat={noop()}
         onRename={noop()}
@@ -218,7 +220,10 @@ describe('Sidebar', () => {
       />,
     );
 
-    expect(screen.queryByText(FIRST_TITLE)).not.toBeInTheDocument();
+    const aside = container.querySelector('aside');
+
+    expect(aside).toHaveAttribute('data-collapsed', 'true');
+    expect(aside).toHaveAttribute('aria-hidden', 'true');
   });
 });
 


### PR DESCRIPTION
Reworks the chat into a compact, centered column like ChatGPT/Claude instead of full-width, with a lighter visual pass and subtle motion.

- Centered `max-w-3xl` conversation column + welcome screen with suggestion chips
- Chat-bubble messages, floating composer card, slimmer header/sidebar
- Responsive sidebar: overlay drawer on mobile, inline collapse on desktop
- Entrance/stagger animations via `tw-animate-css` (motion-safe)

Verified: `tsc` clean, 100 tests pass, Playwright QA at 375/768/1280 in light + dark.