### PR TITLE
feat(web): streaming + UX improvements

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -30,6 +30,7 @@ const ChatScreen = () => {
     renderActions,
     retry,
     status,
+    streamStartedAt,
     submitMessage,
   } = useConversations(model);
 
@@ -58,6 +59,7 @@ const ChatScreen = () => {
             onRetry={retry}
             renderActions={renderActions}
             status={status}
+            streamStartedAt={streamStartedAt}
           />
           <Composer
             model={model}

--- a/web/components/chat/elapsed-timer.tsx
+++ b/web/components/chat/elapsed-timer.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { formatDuration } from '@/lib/duration';
+
+export type ElapsedTimerProps = {
+  startedAt: number;
+};
+
+export const ElapsedTimer = ({ startedAt }: ElapsedTimerProps) => {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    setNow(Date.now());
+    const id = setInterval(() => {
+      setNow(Date.now());
+    }, 200);
+
+    return () => {
+      clearInterval(id);
+    };
+  }, [startedAt]);
+
+  return (
+    <span
+      className="text-xs tabular-nums text-muted-foreground/70"
+      data-testid="elapsed-timer"
+    >
+      {formatDuration(Math.max(0, now - startedAt))}
+    </span>
+  );
+};

--- a/web/components/chat/message.tsx
+++ b/web/components/chat/message.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react';
 
+import { Clock3 } from 'lucide-react';
+
 import type { MyUIMessage } from '@/lib/api-types';
 
 import {
@@ -7,8 +9,10 @@ import {
   MessageContent,
   MessageResponse,
 } from '@/components/ai-elements/message';
+import { ElapsedTimer } from '@/components/chat/elapsed-timer';
 import { SearchStatus } from '@/components/chat/search-status';
 import { TypingIndicator } from '@/components/chat/typing-indicator';
+import { formatDuration } from '@/lib/duration';
 import { t } from '@/lib/i18n';
 
 export type AssistantMessageProps = {
@@ -18,7 +22,10 @@ export type AssistantMessageProps = {
   onRetry?: () => void;
   pending?: boolean;
   statusPart?: { label: string; tool?: string };
+  streamStartedAt?: null | number;
 };
+
+type Timing = NonNullable<MyUIMessage['metadata']>['timing'];
 
 const lastText = (message: MyUIMessage): null | string => {
   const texts = message.parts.filter(
@@ -28,6 +35,60 @@ const lastText = (message: MyUIMessage): null | string => {
   return last ? last.text : null;
 };
 
+const MessageTiming = ({ timing }: { timing: Timing }) => {
+  if (timing === undefined) {
+    return null;
+  }
+
+  return (
+    <div
+      className="mt-1 inline-flex items-center gap-1 text-xs tabular-nums text-muted-foreground/70"
+      data-testid="message-timing"
+    >
+      <Clock3
+        aria-hidden="true"
+        className="size-3"
+      />
+      <span>
+        {formatDuration(timing.totalMs)}
+        {timing.ttftMs === null
+          ? null
+          : ` · ${t('thread.firstToken')} ${formatDuration(timing.ttftMs)}`}
+      </span>
+    </div>
+  );
+};
+
+const MessageError = ({
+  errorPart,
+  onRetry,
+}: {
+  errorPart: { code: string; message: string };
+  onRetry?: () => void;
+}) => (
+  <div
+    className="mt-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm"
+    role="alert"
+  >
+    {errorPart.code === 'interrupted' ? (
+      <p className="text-muted-foreground">{t('error.interrupted')}</p>
+    ) : (
+      <div className="flex flex-col gap-2">
+        <p className="text-destructive">{errorPart.message}</p>
+        {onRetry ? (
+          <button
+            className="self-start rounded-md border border-border px-3 py-1 text-sm hover:bg-muted"
+            onClick={onRetry}
+            type="button"
+          >
+            {t('error.retry')}
+          </button>
+        ) : null}
+      </div>
+    )}
+  </div>
+);
+
 export const AssistantMessage = ({
   actions,
   errorPart,
@@ -35,11 +96,16 @@ export const AssistantMessage = ({
   onRetry,
   pending,
   statusPart,
+  streamStartedAt,
 }: AssistantMessageProps) => {
   const text = lastText(message);
   const showChip = Boolean(statusPart) && !text;
   const showDots = Boolean(pending) && !text && !statusPart && !errorPart;
-  const isInterrupted = errorPart?.code === 'interrupted';
+  const timing = message.metadata?.timing;
+  const liveTimer =
+    typeof streamStartedAt === 'number' ? (
+      <ElapsedTimer startedAt={streamStartedAt} />
+    ) : null;
 
   return (
     <Message from="assistant">
@@ -49,35 +115,27 @@ export const AssistantMessage = ({
             <MessageResponse>{text}</MessageResponse>
           </div>
         ) : null}
+        {pending || text === null ? null : <MessageTiming timing={timing} />}
         {showChip && statusPart ? (
-          <SearchStatus
-            label={statusPart.label}
-            tool={statusPart.tool}
-          />
-        ) : null}
-        {showDots ? <TypingIndicator /> : null}
-        {errorPart ? (
-          <div
-            className="mt-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm"
-            role="alert"
-          >
-            {isInterrupted ? (
-              <p className="text-muted-foreground">{t('error.interrupted')}</p>
-            ) : (
-              <div className="flex flex-col gap-2">
-                <p className="text-destructive">{errorPart.message}</p>
-                {onRetry ? (
-                  <button
-                    className="self-start rounded-md border border-border px-3 py-1 text-sm hover:bg-muted"
-                    onClick={onRetry}
-                    type="button"
-                  >
-                    {t('error.retry')}
-                  </button>
-                ) : null}
-              </div>
-            )}
+          <div className="flex items-center gap-2">
+            <SearchStatus
+              label={statusPart.label}
+              tool={statusPart.tool}
+            />
+            {liveTimer}
           </div>
+        ) : null}
+        {showDots ? (
+          <div className="flex items-center gap-2">
+            <TypingIndicator />
+            {liveTimer}
+          </div>
+        ) : null}
+        {errorPart ? (
+          <MessageError
+            errorPart={errorPart}
+            onRetry={onRetry}
+          />
         ) : null}
         {actions === undefined || actions === null ? null : (
           <div className="mt-2">{actions}</div>

--- a/web/components/chat/thread.tsx
+++ b/web/components/chat/thread.tsx
@@ -12,6 +12,7 @@ import {
   MessageContent,
   MessageResponse,
 } from '@/components/ai-elements/message';
+import { ElapsedTimer } from '@/components/chat/elapsed-timer';
 import { AssistantMessage } from '@/components/chat/message';
 import { TypingIndicator } from '@/components/chat/typing-indicator';
 import { t } from '@/lib/i18n';
@@ -24,6 +25,7 @@ export type ThreadProps = {
   onRetry?: () => void;
   renderActions?: (message: MyUIMessage) => ReactNode;
   status: 'error' | 'ready' | 'streaming' | 'submitted';
+  streamStartedAt?: null | number;
 };
 
 const userText = (message: MyUIMessage): string =>
@@ -84,6 +86,7 @@ export const Thread = ({
   onRetry,
   renderActions,
   status,
+  streamStartedAt,
 }: ThreadProps) => {
   const lastAssistantId = messages.findLast((m) => m.role === 'assistant')?.id;
   const streaming = status === 'streaming' || status === 'submitted';
@@ -122,13 +125,21 @@ export const Thread = ({
                   statusPart={
                     isLastAssistant && streaming ? activeStatus : undefined
                   }
+                  streamStartedAt={
+                    isLastAssistant ? streamStartedAt : undefined
+                  }
                 />
               );
             })}
             {awaitingReply ? (
               <Message from="assistant">
                 <MessageContent>
-                  <TypingIndicator />
+                  <div className="flex items-center gap-2">
+                    <TypingIndicator />
+                    {typeof streamStartedAt === 'number' ? (
+                      <ElapsedTimer startedAt={streamStartedAt} />
+                    ) : null}
+                  </div>
                 </MessageContent>
               </Message>
             ) : null}

--- a/web/e2e/chat.spec.ts
+++ b/web/e2e/chat.spec.ts
@@ -69,6 +69,7 @@ test.describe('chat streaming (mocked BFF)', () => {
     const chip = page.getByTestId('search-status');
     await expect(chip).toBeVisible();
     await expect(chip).toContainText('Пребарувам');
+    await expect(page.getByTestId('elapsed-timer')).toBeVisible();
 
     const answer = page.getByTestId('answer-text');
     await expect(answer).toContainText('Резултатите од испитите се објавуваат');
@@ -78,6 +79,10 @@ test.describe('chat streaming (mocked BFF)', () => {
     await expect(autolink).toBeVisible();
 
     await expect(page.getByText(PREAMBLE)).toHaveCount(0);
+
+    const timing = page.getByTestId('message-timing');
+    await expect(timing).toBeVisible();
+    await expect(timing).toContainText('прв токен');
 
     await page.getByTestId('like-button').click();
     await expect.poll(() => feedbackBody).not.toBeNull();

--- a/web/lib/api-types.ts
+++ b/web/lib/api-types.ts
@@ -66,6 +66,7 @@ export type MyDataParts = {
 export type MyMetadata = {
   inferenceModel?: string;
   responseId?: string;
+  timing?: { totalMs: number; ttftMs: null | number };
 };
 
 export type MyUIMessage = UIMessage<MyMetadata, MyDataParts>;

--- a/web/lib/duration.ts
+++ b/web/lib/duration.ts
@@ -1,0 +1,2 @@
+export const formatDuration = (ms: number): string =>
+  ms >= 1_000 ? `${(ms / 1_000).toFixed(1)}s` : `${Math.round(ms)}ms`;

--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -26,6 +26,7 @@ export const messages = {
   'sidebar.toggle': 'Прикажи/сокриј странична лента',
   'thread.emptyDescription': 'Прашај нешто за студиите на ФИНКИ.',
   'thread.emptyTitle': 'Започни разговор',
+  'thread.firstToken': 'прв токен',
   'thread.thinking': 'Размислувам…',
 } as const;
 

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -3,6 +3,7 @@
 import { useChat } from '@ai-sdk/react';
 import {
   type ReactNode,
+  type RefObject,
   useCallback,
   useEffect,
   useRef,
@@ -47,6 +48,13 @@ const priorUserText = (
     .map((p) => p.text)
     .join('');
 
+const hasAssistantText = (message: MyUIMessage): boolean =>
+  message.role === 'assistant' &&
+  message.parts.some(
+    (p): p is { text: string; type: 'text' } =>
+      p.type === 'text' && p.text.length > 0,
+  );
+
 const renderAnswerActions =
   (
     messages: MyUIMessage[],
@@ -64,6 +72,41 @@ const renderAnswerActions =
       />
     ) : null;
 
+const useStreamTiming = ({
+  firstTokenAtRef,
+  messages,
+  setStreamStartedAt,
+  startedAtRef,
+  status,
+}: {
+  firstTokenAtRef: RefObject<null | number>;
+  messages: MyUIMessage[];
+  setStreamStartedAt: (value: null | number) => void;
+  startedAtRef: RefObject<null | number>;
+  status: 'error' | 'ready' | 'streaming' | 'submitted';
+}): void => {
+  useEffect(() => {
+    if (status === 'submitted') {
+      const now = Date.now();
+      startedAtRef.current = now;
+      firstTokenAtRef.current = null;
+      setStreamStartedAt(now);
+    } else if (status === 'ready' || status === 'error') {
+      setStreamStartedAt(null);
+    }
+  }, [status, firstTokenAtRef, setStreamStartedAt, startedAtRef]);
+
+  useEffect(() => {
+    if (firstTokenAtRef.current !== null || startedAtRef.current === null) {
+      return;
+    }
+    const last = messages.at(-1);
+    if (last !== undefined && hasAssistantText(last)) {
+      firstTokenAtRef.current = Date.now();
+    }
+  }, [messages, firstTokenAtRef, startedAtRef]);
+};
+
 export const useConversations = (model: string) => {
   const activeId = useUiStore((s) => s.activeConversationId);
   const setActiveId = useUiStore((s) => s.setActiveConversationId);
@@ -76,6 +119,9 @@ export const useConversations = (model: string) => {
     undefined | { code: string; message: string }
   >();
   const convoIdRef = useRef<null | string>(activeId);
+  const startedAtRef = useRef<null | number>(null);
+  const firstTokenAtRef = useRef<null | number>(null);
+  const [streamStartedAt, setStreamStartedAt] = useState<null | number>(null);
 
   const refreshConversations = useCallback(async () => {
     setConversations(await listConversations());
@@ -104,7 +150,27 @@ export const useConversations = (model: string) => {
       },
       onFinish: ({ message }) => {
         setActiveStatus(undefined);
-        fireAndForget(persistFinished(message));
+        const startedAt = startedAtRef.current;
+        const finalized: MyUIMessage =
+          startedAt === null
+            ? message
+            : {
+                ...message,
+                metadata: {
+                  ...message.metadata,
+                  timing: {
+                    totalMs: Date.now() - startedAt,
+                    ttftMs:
+                      firstTokenAtRef.current === null
+                        ? null
+                        : firstTokenAtRef.current - startedAt,
+                  },
+                },
+              };
+        setMessages((prev) =>
+          prev.map((m) => (m.id === finalized.id ? finalized : m)),
+        );
+        fireAndForget(persistFinished(finalized));
       },
       transport: buildChatTransport(() => ({ model })),
     });
@@ -112,6 +178,14 @@ export const useConversations = (model: string) => {
   useEffect(() => {
     fireAndForget(refreshConversations());
   }, [refreshConversations]);
+
+  useStreamTiming({
+    firstTokenAtRef,
+    messages,
+    setStreamStartedAt,
+    startedAtRef,
+    status,
+  });
 
   useEffect(() => {
     convoIdRef.current = activeId;
@@ -224,6 +298,7 @@ export const useConversations = (model: string) => {
     renderActions: renderAnswerActions(messages, status, regenerate),
     retry,
     status,
+    streamStartedAt,
     submitMessage,
   };
 };

--- a/web/test/duration.test.ts
+++ b/web/test/duration.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatDuration } from '@/lib/duration';
+
+describe('formatDuration', () => {
+  it('renders sub-second values in milliseconds', () => {
+    expect(formatDuration(0)).toBe('0ms');
+    expect(formatDuration(850)).toBe('850ms');
+    expect(formatDuration(999)).toBe('999ms');
+  });
+
+  it('rounds fractional milliseconds', () => {
+    expect(formatDuration(123.4)).toBe('123ms');
+    expect(formatDuration(123.6)).toBe('124ms');
+  });
+
+  it('renders one-second-and-above values in seconds with one decimal', () => {
+    expect(formatDuration(1_000)).toBe('1.0s');
+    expect(formatDuration(2_345)).toBe('2.3s');
+    expect(formatDuration(12_000)).toBe('12.0s');
+  });
+});

--- a/web/test/thread.test.tsx
+++ b/web/test/thread.test.tsx
@@ -141,6 +141,54 @@ describe('AssistantMessage', () => {
       screen.queryByRole('button', { name: 'Обиди се повторно' }),
     ).not.toBeInTheDocument();
   });
+
+  it('renders a timing footnote when finished with timing metadata', () => {
+    const msg: MyUIMessage = {
+      id: 'a1',
+      metadata: { timing: { totalMs: 2_345, ttftMs: 1_200 } },
+      parts: [{ text: 'Готово', type: 'text' }],
+      role: 'assistant',
+    };
+    render(<AssistantMessage message={msg} />);
+
+    const footnote = screen.getByTestId('message-timing');
+
+    expect(footnote).toHaveTextContent('2.3s');
+    expect(footnote).toHaveTextContent('прв токен');
+    expect(footnote).toHaveTextContent('1.2s');
+  });
+
+  it('omits the first-token part when ttft is unknown', () => {
+    const msg: MyUIMessage = {
+      id: 'a1',
+      metadata: { timing: { totalMs: 500, ttftMs: null } },
+      parts: [{ text: 'Готово', type: 'text' }],
+      role: 'assistant',
+    };
+    render(<AssistantMessage message={msg} />);
+
+    const footnote = screen.getByTestId('message-timing');
+
+    expect(footnote).toHaveTextContent('500ms');
+    expect(footnote).not.toHaveTextContent('прв токен');
+  });
+
+  it('hides the timing footnote while pending', () => {
+    const msg: MyUIMessage = {
+      id: 'a1',
+      metadata: { timing: { totalMs: 2_345, ttftMs: 1_200 } },
+      parts: [{ text: 'Делумен', type: 'text' }],
+      role: 'assistant',
+    };
+    render(
+      <AssistantMessage
+        message={msg}
+        pending
+      />,
+    );
+
+    expect(screen.queryByTestId('message-timing')).not.toBeInTheDocument();
+  });
 });
 
 describe('Thread', () => {
@@ -188,6 +236,18 @@ describe('Thread', () => {
     );
 
     expect(screen.getByTestId('typing-indicator')).toBeInTheDocument();
+  });
+
+  it('shows a live elapsed timer while awaiting the reply', () => {
+    render(
+      <Thread
+        messages={[userMessage('прашање')]}
+        status="submitted"
+        streamStartedAt={Date.now()}
+      />,
+    );
+
+    expect(screen.getByTestId('elapsed-timer')).toBeInTheDocument();
   });
 
   it('passes the active status only to the LAST assistant message while streaming', () => {


### PR DESCRIPTION
Draft umbrella PR for incremental web (`/web`) improvements. More will be added on top of this branch.

## Included so far

### Streaming indicator + response timing
Mirrors the timing readout the [`finki-hub-discord-bot`](https://github.com/finki-hub/finki-hub-discord-bot) shows after a streamed answer.

- **Live elapsed timer** while the assistant is thinking/streaming (before the first token arrives), shown next to the typing dots / search-status chip.
- **Timing footnote** under the finished answer: total time and time-to-first-token, e.g. `⏱ 2.3s · прв токен 1.6s`. Uses the same `formatDuration` rules as the bot (`>=1s → Xs`, else `Xms`) and the `прв токен` label.
- Measured client-side (true user-perceived latency) and persisted in message `metadata.timing`, so it survives reload via the existing Dexie store.

## Notes
- No server/BFF or stream-translation changes — timing is purely client-side, so the existing strict-equality stream tests are untouched.
- New `data-testid`s: `elapsed-timer`, `message-timing`.

## Verification
- `npm run check` (tsc) — clean
- `npm run lint` (eslint) — clean
- `npm run test` (vitest) — 107 passed (incl. new `duration` + timing-footnote tests)
- `npm run e2e` (real Chromium, mocked BFF) — passed, asserts the live timer mid-stream and the footnote after finish
- `npm run build` (Next 16) — succeeds
