### PR TITLE
fix(web): stabilize streaming indicator, keep message actions visible, and regenerate answers in place

### DIFF
--- a/web/components/chat/thread.tsx
+++ b/web/components/chat/thread.tsx
@@ -16,7 +16,7 @@ import { ElapsedTimer } from '@/components/chat/elapsed-timer';
 import { AssistantMessage } from '@/components/chat/message';
 import { TypingIndicator } from '@/components/chat/typing-indicator';
 import { t } from '@/lib/i18n';
-import { joinText } from '@/lib/message-parts';
+import { hasText, joinText } from '@/lib/message-parts';
 
 export type ThreadProps = {
   activeError?: { code: string; message: string };
@@ -85,7 +85,11 @@ export const Thread = ({
 }: ThreadProps) => {
   const lastAssistantId = messages.findLast((m) => m.role === 'assistant')?.id;
   const streaming = status === 'streaming' || status === 'submitted';
-  const awaitingReply = streaming && messages.at(-1)?.role !== 'assistant';
+  const lastMessage = messages.at(-1);
+  const awaitingReply =
+    streaming &&
+    (lastMessage?.role !== 'assistant' ||
+      (activeStatus === undefined && !hasText(lastMessage)));
 
   return (
     <Conversation className="flex-1">
@@ -95,6 +99,15 @@ export const Thread = ({
         ) : (
           <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
             {messages.map((m) => {
+              if (
+                m.role === 'assistant' &&
+                streaming &&
+                activeStatus === undefined &&
+                !hasText(m)
+              ) {
+                return null;
+              }
+
               if (m.role === 'user') {
                 return (
                   <Message

--- a/web/components/chat/thread.tsx
+++ b/web/components/chat/thread.tsx
@@ -101,6 +101,7 @@ export const Thread = ({
             {messages.map((m) => {
               if (
                 m.role === 'assistant' &&
+                m.id === lastAssistantId &&
                 streaming &&
                 activeStatus === undefined &&
                 !hasText(m)

--- a/web/lib/chat-translate.ts
+++ b/web/lib/chat-translate.ts
@@ -11,11 +11,13 @@ import { type ParsedEvent } from '@/lib/sse';
 export type ChatClientBody = {
   embeddingsModel?: string;
   maxTokens?: number;
+  messageId?: string;
   messages: MyUIMessage[];
   model?: string;
   queryTransformModel?: string;
   temperature?: number;
   topP?: number;
+  trigger?: string;
   userId?: string;
 };
 
@@ -41,8 +43,22 @@ export type UiStreamWriter = {
   write: (part: UiStreamPart) => void;
 };
 
+const messagesForRequest = (body: ChatClientBody): MyUIMessage[] => {
+  if (body.messageId === undefined || !body.trigger?.includes('regenerate')) {
+    return body.messages;
+  }
+
+  const messageIndex = body.messages.findIndex(
+    (message) => message.id === body.messageId,
+  );
+
+  return messageIndex === -1
+    ? body.messages
+    : body.messages.slice(0, messageIndex);
+};
+
 export const toChatRequestBody = (body: ChatClientBody): ChatRequestBody => {
-  const trimmed = body.messages.slice(-MAX_MESSAGES);
+  const trimmed = messagesForRequest(body).slice(-MAX_MESSAGES);
   const messages: ConversationTurn[] = trimmed.map((message) => ({
     content: joinText(message).slice(0, MAX_CHARS_PER_TURN),
     role: message.role === 'assistant' ? 'assistant' : 'user',

--- a/web/lib/conversation-actions.tsx
+++ b/web/lib/conversation-actions.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import type { MyUIMessage } from '@/lib/api-types';
+
+import { AnswerActions } from '@/components/chat/answer-actions';
+import { joinText } from '@/lib/message-parts';
+
+export type ChatStatus = 'error' | 'ready' | 'streaming' | 'submitted';
+
+const priorUserText = (
+  messages: MyUIMessage[],
+  message: MyUIMessage,
+): string | undefined => {
+  const prior = messages
+    .slice(0, messages.indexOf(message))
+    .findLast((m) => m.role === 'user');
+
+  return prior ? joinText(prior) : undefined;
+};
+
+export const renderAnswerActions =
+  (
+    messages: MyUIMessage[],
+    regenerate: (options: { messageId: string }) => void,
+    status: ChatStatus,
+  ) =>
+  (message: MyUIMessage): ReactNode =>
+    message.role === 'assistant' ? (
+      <AnswerActions
+        message={message}
+        onRegenerate={
+          status === 'streaming' || status === 'submitted'
+            ? undefined
+            : () => {
+                regenerate({ messageId: message.id });
+              }
+        }
+        questionText={priorUserText(messages, message)}
+      />
+    ) : null;

--- a/web/lib/conversation-message-state.ts
+++ b/web/lib/conversation-message-state.ts
@@ -1,0 +1,85 @@
+import type { MyUIMessage } from '@/lib/api-types';
+
+type FinishedReplacement = {
+  readonly pruneAfterReplacement: boolean;
+  readonly replacement: MyUIMessage;
+  readonly streamMessageId: string;
+};
+
+export const finalizeMessage = (
+  message: MyUIMessage,
+  startedAt: null | number,
+  firstTokenAt: null | number,
+): MyUIMessage =>
+  startedAt === null
+    ? message
+    : {
+        ...message,
+        metadata: {
+          ...message.metadata,
+          timing: {
+            totalMs: Date.now() - startedAt,
+            ttftMs: firstTokenAt === null ? null : firstTokenAt - startedAt,
+          },
+        },
+      };
+
+export const replaceFinishedMessage =
+  ({
+    pruneAfterReplacement,
+    replacement,
+    streamMessageId,
+  }: FinishedReplacement): ((messages: MyUIMessage[]) => MyUIMessage[]) =>
+  (messages) => {
+    const replacementIndex = messages.findIndex(
+      (message) => message.id === replacement.id,
+    );
+
+    if (replacementIndex === -1) {
+      return [
+        ...messages.filter((message) => message.id !== streamMessageId),
+        replacement,
+      ];
+    }
+
+    return messages.flatMap((message, messageIndex): MyUIMessage[] => {
+      if (messageIndex > replacementIndex && pruneAfterReplacement) {
+        return [];
+      }
+
+      if (message.id === replacement.id) {
+        return [replacement];
+      }
+
+      if (message.id === streamMessageId) {
+        return [];
+      }
+
+      return [message];
+    });
+  };
+
+export const previewRegeneration = (
+  messages: MyUIMessage[],
+  messageId: null | string,
+): MyUIMessage[] => {
+  if (messageId === null) {
+    return messages;
+  }
+
+  const targetIndex = messages.findIndex((message) => message.id === messageId);
+  if (targetIndex === -1) {
+    return messages;
+  }
+
+  const target = messages.at(targetIndex);
+
+  if (target === undefined) {
+    return messages;
+  }
+
+  return [
+    ...messages.slice(0, targetIndex),
+    { ...target, metadata: {}, parts: [] },
+  ];
+};

--- a/web/lib/db.ts
+++ b/web/lib/db.ts
@@ -119,3 +119,41 @@ export const saveMessages = async (
     await db.conversations.update(conversationId, { updatedAt: nextNow() });
   });
 };
+
+export const replaceConversationMessages = async (
+  conversationId: string,
+  messages: MyUIMessage[],
+): Promise<void> => {
+  await db.transaction('rw', db.conversations, db.messages, async () => {
+    const existingRows = await db.messages
+      .where('conversationId')
+      .equals(conversationId)
+      .toArray();
+    const existing = new Map(
+      existingRows.map((row) => [row.id, row.createdAt] as const),
+    );
+    const base = nextNow();
+    const rows: MessageRow[] = messages.map((message, index) => ({
+      conversationId,
+      createdAt: existing.get(message.id) ?? base + index,
+      id: message.id,
+      metadata: message.metadata,
+      parts: message.parts,
+      role: message.role,
+    }));
+    const keptIds = new Set(rows.map((row) => row.id));
+    const staleIds: string[] = [];
+    for (const id of existing.keys()) {
+      if (!keptIds.has(id)) {
+        staleIds.push(id);
+      }
+    }
+
+    if (staleIds.length > 0) {
+      await db.messages.bulkDelete(staleIds);
+    }
+
+    await db.messages.bulkPut(rows);
+    await db.conversations.update(conversationId, { updatedAt: nextNow() });
+  });
+};

--- a/web/lib/db.ts
+++ b/web/lib/db.ts
@@ -132,7 +132,11 @@ export const replaceConversationMessages = async (
     const existing = new Map(
       existingRows.map((row) => [row.id, row.createdAt] as const),
     );
-    const base = nextNow();
+    let maxExisting = 0;
+    for (const row of existingRows) {
+      maxExisting = Math.max(maxExisting, row.createdAt);
+    }
+    const base = Math.max(nextNow(), maxExisting + 1);
     const rows: MessageRow[] = messages.map((message, index) => ({
       conversationId,
       createdAt: existing.get(message.id) ?? base + index,

--- a/web/lib/use-conversation-hydration.ts
+++ b/web/lib/use-conversation-hydration.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import { type RefObject, useEffect } from 'react';
+
+import type { MyUIMessage } from '@/lib/api-types';
+
+import { fireAndForget } from '@/lib/async';
+import { getConversation, loadMessages, type MessageRow } from '@/lib/db';
+
+type UseConversationHydrationOptions = {
+  readonly activeId: null | string;
+  readonly convoIdRef: RefObject<null | string>;
+  readonly setActiveError: (
+    value: undefined | { code: string; message: string },
+  ) => void;
+  readonly setActiveId: (id: null | string) => void;
+  readonly setActiveStatus: (
+    value: undefined | { label: string; tool?: string },
+  ) => void;
+  readonly setMessages: (messages: MyUIMessage[]) => void;
+};
+
+const fromRow = (row: MessageRow): MyUIMessage => ({
+  id: row.id,
+  metadata: row.metadata,
+  parts: row.parts,
+  role: row.role,
+});
+
+export const useConversationHydration = ({
+  activeId,
+  convoIdRef,
+  setActiveError,
+  setActiveId,
+  setActiveStatus,
+  setMessages,
+}: UseConversationHydrationOptions): void => {
+  useEffect(() => {
+    convoIdRef.current = activeId;
+    setActiveError(undefined);
+    setActiveStatus(undefined);
+    let cancelled = false;
+    const isCancelled = (): boolean => cancelled;
+
+    const hydrate = async (id: string): Promise<void> => {
+      const convo = await getConversation(id);
+
+      if (!isCancelled() && convo === undefined) {
+        setActiveId(null);
+        setMessages([]);
+        return;
+      }
+
+      if (convo === undefined || isCancelled()) {
+        return;
+      }
+
+      const loaded = await loadMessages(id);
+      if (!isCancelled()) {
+        setMessages(loaded.map(fromRow));
+      }
+    };
+
+    if (activeId) {
+      fireAndForget(hydrate(activeId));
+    } else {
+      setMessages([]);
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeId,
+    convoIdRef,
+    setActiveError,
+    setActiveId,
+    setActiveStatus,
+    setMessages,
+  ]);
+};

--- a/web/lib/use-conversation-list.ts
+++ b/web/lib/use-conversation-list.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { fireAndForget } from '@/lib/async';
+import { type ConversationRow, listConversations } from '@/lib/db';
+
+export const useConversationList = () => {
+  const [conversations, setConversations] = useState<ConversationRow[]>([]);
+
+  const refreshConversations = useCallback(async () => {
+    setConversations(await listConversations());
+  }, []);
+
+  useEffect(() => {
+    fireAndForget(refreshConversations());
+  }, [refreshConversations]);
+
+  return { conversations, refreshConversations };
+};

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -1,131 +1,37 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import {
-  type ReactNode,
-  type RefObject,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import type { MyUIMessage } from '@/lib/api-types';
 
-import { AnswerActions } from '@/components/chat/answer-actions';
 import { fireAndForget } from '@/lib/async';
+import { renderAnswerActions } from '@/lib/conversation-actions';
+import {
+  finalizeMessage,
+  previewRegeneration,
+  replaceFinishedMessage,
+} from '@/lib/conversation-message-state';
 import {
   clearAllConversations,
-  type ConversationRow,
   createConversation,
   deleteConversation,
-  getConversation,
-  listConversations,
-  loadMessages,
-  type MessageRow,
   renameConversation,
+  replaceConversationMessages,
   saveMessages,
 } from '@/lib/db';
-import { hasText, joinText } from '@/lib/message-parts';
 import { deriveTitle } from '@/lib/messages';
 import { buildChatTransport } from '@/lib/transport';
 import { useUiStore } from '@/lib/ui-store';
-
-const fromRow = (row: MessageRow): MyUIMessage => ({
-  id: row.id,
-  metadata: row.metadata,
-  parts: row.parts,
-  role: row.role,
-});
-
-const priorUserText = (
-  messages: MyUIMessage[],
-  message: MyUIMessage,
-): string | undefined => {
-  const prior = messages
-    .slice(0, messages.indexOf(message))
-    .findLast((m) => m.role === 'user');
-  return prior ? joinText(prior) : undefined;
-};
-
-const hasAssistantText = (message: MyUIMessage): boolean =>
-  message.role === 'assistant' && hasText(message);
-
-const finalizeMessage = (
-  message: MyUIMessage,
-  startedAt: null | number,
-  firstTokenAt: null | number,
-): MyUIMessage =>
-  startedAt === null
-    ? message
-    : {
-        ...message,
-        metadata: {
-          ...message.metadata,
-          timing: {
-            totalMs: Date.now() - startedAt,
-            ttftMs: firstTokenAt === null ? null : firstTokenAt - startedAt,
-          },
-        },
-      };
-
-const renderAnswerActions =
-  (
-    messages: MyUIMessage[],
-    status: 'error' | 'ready' | 'streaming' | 'submitted',
-    regenerate: (options: { messageId: string }) => void,
-  ) =>
-  (message: MyUIMessage): ReactNode =>
-    message.role === 'assistant' && status !== 'streaming' ? (
-      <AnswerActions
-        message={message}
-        onRegenerate={() => {
-          regenerate({ messageId: message.id });
-        }}
-        questionText={priorUserText(messages, message)}
-      />
-    ) : null;
-
-const useStreamTiming = ({
-  firstTokenAtRef,
-  messages,
-  setStreamStartedAt,
-  startedAtRef,
-  status,
-}: {
-  firstTokenAtRef: RefObject<null | number>;
-  messages: MyUIMessage[];
-  setStreamStartedAt: (value: null | number) => void;
-  startedAtRef: RefObject<null | number>;
-  status: 'error' | 'ready' | 'streaming' | 'submitted';
-}): void => {
-  useEffect(() => {
-    if (status === 'submitted') {
-      const now = Date.now();
-      startedAtRef.current = now;
-      firstTokenAtRef.current = null;
-      setStreamStartedAt(now);
-    } else if (status === 'ready' || status === 'error') {
-      setStreamStartedAt(null);
-    }
-  }, [status, firstTokenAtRef, setStreamStartedAt, startedAtRef]);
-
-  useEffect(() => {
-    if (firstTokenAtRef.current !== null || startedAtRef.current === null) {
-      return;
-    }
-    const last = messages.at(-1);
-    if (last !== undefined && hasAssistantText(last)) {
-      firstTokenAtRef.current = Date.now();
-    }
-  }, [messages, firstTokenAtRef, startedAtRef]);
-};
+import { useConversationHydration } from '@/lib/use-conversation-hydration';
+import { useConversationList } from '@/lib/use-conversation-list';
+import { useStreamTiming } from '@/lib/use-stream-timing';
 
 export const useConversations = (model: string) => {
   const activeId = useUiStore((s) => s.activeConversationId);
   const setActiveId = useUiStore((s) => s.setActiveConversationId);
 
-  const [conversations, setConversations] = useState<ConversationRow[]>([]);
+  const { conversations, refreshConversations } = useConversationList();
   const [activeStatus, setActiveStatus] = useState<
     undefined | { label: string; tool?: string }
   >();
@@ -135,19 +41,19 @@ export const useConversations = (model: string) => {
   const convoIdRef = useRef<null | string>(activeId);
   const startedAtRef = useRef<null | number>(null);
   const firstTokenAtRef = useRef<null | number>(null);
+  const regeneratingMessageIdRef = useRef<null | string>(null);
+  const [regeneratingMessageId, setRegeneratingMessageId] = useState<
+    null | string
+  >(null);
   const [streamStartedAt, setStreamStartedAt] = useState<null | number>(null);
 
-  const refreshConversations = useCallback(async () => {
-    setConversations(await listConversations());
-  }, []);
-
   const persistFinished = useCallback(
-    async (message: MyUIMessage): Promise<void> => {
+    async (allMessages: readonly MyUIMessage[]): Promise<void> => {
       const cid = convoIdRef.current;
       if (!cid) {
         return;
       }
-      await saveMessages(cid, [message]);
+      await replaceConversationMessages(cid, [...allMessages]);
       await refreshConversations();
     },
     [refreshConversations],
@@ -162,24 +68,36 @@ export const useConversations = (model: string) => {
           setActiveError(part.data);
         }
       },
+      onError: () => {
+        regeneratingMessageIdRef.current = null;
+        setRegeneratingMessageId(null);
+      },
       onFinish: ({ message }) => {
         setActiveStatus(undefined);
-        const finalized = finalizeMessage(
+        const replacementId = regeneratingMessageIdRef.current;
+        regeneratingMessageIdRef.current = null;
+        setRegeneratingMessageId(null);
+        const finalizedBase = finalizeMessage(
           message,
           startedAtRef.current,
           firstTokenAtRef.current,
         );
-        setMessages((prev) =>
-          prev.map((m) => (m.id === finalized.id ? finalized : m)),
-        );
-        fireAndForget(persistFinished(finalized));
+        const finalized =
+          replacementId === null
+            ? finalizedBase
+            : { ...finalizedBase, id: replacementId };
+        setMessages((prev) => {
+          const next = replaceFinishedMessage({
+            pruneAfterReplacement: replacementId !== null,
+            replacement: finalized,
+            streamMessageId: message.id,
+          })(prev);
+          fireAndForget(persistFinished(next));
+          return next;
+        });
       },
       transport: buildChatTransport(() => ({ model })),
     });
-
-  useEffect(() => {
-    fireAndForget(refreshConversations());
-  }, [refreshConversations]);
 
   useStreamTiming({
     firstTokenAtRef,
@@ -189,36 +107,14 @@ export const useConversations = (model: string) => {
     status,
   });
 
-  useEffect(() => {
-    convoIdRef.current = activeId;
-    setActiveError(undefined);
-    setActiveStatus(undefined);
-    let cancelled = false;
-    const isCancelled = (): boolean => cancelled;
-    if (activeId) {
-      const hydrate = async (): Promise<void> => {
-        const convo = await getConversation(activeId);
-        if (!isCancelled()) {
-          if (convo === undefined) {
-            setActiveId(null);
-            setMessages([]);
-          } else {
-            const loaded = await loadMessages(activeId);
-            if (!isCancelled()) {
-              setMessages(loaded.map(fromRow));
-            }
-          }
-        }
-      };
-      fireAndForget(hydrate());
-    } else {
-      setMessages([]);
-    }
-
-    return () => {
-      cancelled = true;
-    };
-  }, [activeId, setActiveId, setMessages]);
+  useConversationHydration({
+    activeId,
+    convoIdRef,
+    setActiveError,
+    setActiveId,
+    setActiveStatus,
+    setMessages,
+  });
 
   const handleNewChat = useCallback(() => {
     setActiveId(null);
@@ -293,6 +189,17 @@ export const useConversations = (model: string) => {
     fireAndForget(regenerate());
   }, [regenerate]);
 
+  const regenerateMessage = useCallback(
+    (options: { messageId: string }) => {
+      regeneratingMessageIdRef.current = options.messageId;
+      setRegeneratingMessageId(options.messageId);
+      void regenerate(options);
+      setActiveError(undefined);
+      setActiveStatus(undefined);
+    },
+    [regenerate],
+  );
+
   const handleRename = useCallback(
     async (id: string, title: string) => {
       await renameConversation(id, title);
@@ -301,19 +208,26 @@ export const useConversations = (model: string) => {
     [refreshConversations],
   );
 
+  const visibleMessages = previewRegeneration(messages, regeneratingMessageId);
+  const renderActions = renderAnswerActions(
+    visibleMessages,
+    regenerateMessage,
+    status,
+  );
+
   return {
     activeError,
     activeId,
     activeStatus,
     conversations,
-    messages,
+    messages: visibleMessages,
     onClearAll: handleClearAll,
     onDelete: handleDelete,
     onNewChat: handleNewChat,
     onRename: handleRename,
     onSelect: handleSelect,
     onStop: stop,
-    renderActions: renderAnswerActions(messages, status, regenerate),
+    renderActions,
     retry,
     status,
     streamStartedAt,

--- a/web/lib/use-stream-timing.ts
+++ b/web/lib/use-stream-timing.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { type RefObject, useEffect } from 'react';
+
+import type { MyUIMessage } from '@/lib/api-types';
+
+import { hasText } from '@/lib/message-parts';
+
+const hasAssistantText = (message: MyUIMessage): boolean =>
+  message.role === 'assistant' && hasText(message);
+
+export const useStreamTiming = ({
+  firstTokenAtRef,
+  messages,
+  setStreamStartedAt,
+  startedAtRef,
+  status,
+}: {
+  firstTokenAtRef: RefObject<null | number>;
+  messages: MyUIMessage[];
+  setStreamStartedAt: (value: null | number) => void;
+  startedAtRef: RefObject<null | number>;
+  status: 'error' | 'ready' | 'streaming' | 'submitted';
+}): void => {
+  useEffect(() => {
+    if (status === 'submitted') {
+      const now = Date.now();
+      startedAtRef.current = now;
+      firstTokenAtRef.current = null;
+      setStreamStartedAt(now);
+    } else if (status === 'ready' || status === 'error') {
+      setStreamStartedAt(null);
+    }
+  }, [status, firstTokenAtRef, setStreamStartedAt, startedAtRef]);
+
+  useEffect(() => {
+    if (firstTokenAtRef.current !== null || startedAtRef.current === null) {
+      return;
+    }
+
+    const last = messages.at(-1);
+
+    if (last !== undefined && hasAssistantText(last)) {
+      firstTokenAtRef.current = Date.now();
+    }
+  }, [messages, firstTokenAtRef, startedAtRef]);
+};

--- a/web/test/chat-translate.test.ts
+++ b/web/test/chat-translate.test.ts
@@ -77,6 +77,20 @@ describe('toChatRequestBody', () => {
 
     expect(out).toStrictEqual({ messages: [{ content: 'hi', role: 'user' }] });
   });
+
+  it('removes the regenerated assistant answer from the forwarded context', () => {
+    const question = msg('user', 'Прашање?');
+    const firstAnswer = { ...msg('assistant', 'Стар одговор'), id: 'a1' };
+    const followUp = msg('user', 'Следно?');
+
+    const out = toChatRequestBody({
+      messageId: 'a1',
+      messages: [question, firstAnswer, followUp],
+      trigger: 'regenerate-message',
+    });
+
+    expect(out.messages).toStrictEqual([{ content: 'Прашање?', role: 'user' }]);
+  });
 });
 
 class FakeWriter {

--- a/web/test/shell.test.tsx
+++ b/web/test/shell.test.tsx
@@ -23,6 +23,7 @@ import ChatPage from '@/app/page';
 import { ConversationList } from '@/components/shell/conversation-list';
 import { Sidebar } from '@/components/shell/sidebar';
 import { type ConversationRow, db } from '@/lib/db';
+import { lastText } from '@/lib/message-parts';
 import { useUiStore } from '@/lib/ui-store';
 import {
   createMemoryStorage,
@@ -37,6 +38,7 @@ const CLAUDE = 'claude-sonnet-4-6';
 const GPT = 'gpt-5.4-mini';
 const RESPONSE_ID = 'resp-123';
 const FIRST_TITLE = 'Прв разговор';
+const REGENERATE_CONVERSATION_ID = 'c-regenerate';
 
 const rows: ConversationRow[] = [
   {
@@ -299,17 +301,23 @@ describe('Sidebar', () => {
   });
 });
 
-const sseChatResponse = (): Response => {
+const sseChatResponse = ({
+  answer = 'Здраво!',
+  responseId = RESPONSE_ID,
+}: {
+  answer?: string;
+  responseId?: string;
+} = {}): Response => {
   const chunks = [
     {
       messageMetadata: {
         inferenceModel: CLAUDE,
-        responseId: RESPONSE_ID,
+        responseId,
       },
       type: 'start',
     },
     { id: 'txt-1', type: 'text-start' },
-    { delta: 'Здраво!', id: 'txt-1', type: 'text-delta' },
+    { delta: answer, id: 'txt-1', type: 'text-delta' },
     { id: 'txt-1', type: 'text-end' },
     { type: 'finish' },
   ];
@@ -320,7 +328,7 @@ const sseChatResponse = (): Response => {
   return new Response(body, {
     headers: {
       'content-type': 'text/event-stream',
-      'X-Response-Id': RESPONSE_ID,
+      'X-Response-Id': responseId,
       'x-vercel-ai-ui-message-stream': 'v1',
     },
     status: 200,
@@ -413,6 +421,203 @@ describe('ChatPage persistence', () => {
     expect(msgs.find((m) => m.role === 'assistant')?.metadata?.responseId).toBe(
       RESPONSE_ID,
     );
+  });
+
+  it('regenerates an assistant answer in place and persists only the replacement', async () => {
+    const now = Date.now();
+    await db.conversations.put({
+      createdAt: now,
+      id: REGENERATE_CONVERSATION_ID,
+      model: CLAUDE,
+      title: 'Прашање?',
+      updatedAt: now,
+    });
+    await db.messages.bulkPut([
+      {
+        conversationId: REGENERATE_CONVERSATION_ID,
+        createdAt: now,
+        id: 'u-regenerate',
+        parts: [{ text: 'Прашање?', type: 'text' }],
+        role: 'user',
+      },
+      {
+        conversationId: REGENERATE_CONVERSATION_ID,
+        createdAt: now + 1,
+        id: 'a-regenerate',
+        metadata: { responseId: 'resp-old' },
+        parts: [{ text: 'Стар одговор', type: 'text' }],
+        role: 'assistant',
+      },
+    ]);
+    useUiStore.setState({
+      activeConversationId: REGENERATE_CONVERSATION_ID,
+      model: CLAUDE,
+      sidebarOpen: true,
+    });
+
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = urlOf(input);
+      if (url.endsWith('/api/models')) {
+        return Promise.resolve(
+          Response.json([CLAUDE, GPT], {
+            headers: { 'content-type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+      if (url.endsWith('/api/chat')) {
+        return Promise.resolve(
+          sseChatResponse({ answer: 'Нов одговор', responseId: 'resp-new' }),
+        );
+      }
+
+      return Promise.resolve(
+        new Response('{}', {
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        }),
+      );
+    });
+
+    const user = userEvent.setup();
+    renderChatPage();
+
+    await expect(
+      screen.findByText('Стар одговор'),
+    ).resolves.toBeInTheDocument();
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Регенерирај' }),
+    );
+
+    await expect(screen.findByText('Нов одговор')).resolves.toBeInTheDocument();
+
+    const regenerated = await db.messages
+      .where('conversationId')
+      .equals(REGENERATE_CONVERSATION_ID)
+      .sortBy('createdAt');
+    const assistants = regenerated.filter((m) => m.role === 'assistant');
+
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]?.id).toBe('a-regenerate');
+    expect(assistants[0] ? lastText(assistants[0]) : null).toBe('Нов одговор');
+    expect(assistants[0]?.metadata?.responseId).toBe('resp-new');
+  });
+
+  it('prunes trailing messages when regenerating a middle answer and persists only the survivors', async () => {
+    const now = Date.now();
+    const convId = 'c-multi-regenerate';
+    await db.conversations.put({
+      createdAt: now,
+      id: convId,
+      model: CLAUDE,
+      title: 'Повеќе пораки',
+      updatedAt: now,
+    });
+    await db.messages.bulkPut([
+      {
+        conversationId: convId,
+        createdAt: now,
+        id: 'u1',
+        parts: [{ text: 'Прво прашање', type: 'text' }],
+        role: 'user',
+      },
+      {
+        conversationId: convId,
+        createdAt: now + 1,
+        id: 'a1',
+        metadata: { responseId: 'resp-a1' },
+        parts: [{ text: 'Прв стар одговор', type: 'text' }],
+        role: 'assistant',
+      },
+      {
+        conversationId: convId,
+        createdAt: now + 2,
+        id: 'u2',
+        parts: [{ text: 'Второ прашање', type: 'text' }],
+        role: 'user',
+      },
+      {
+        conversationId: convId,
+        createdAt: now + 3,
+        id: 'a2',
+        metadata: { responseId: 'resp-a2' },
+        parts: [{ text: 'Втор стар одговор', type: 'text' }],
+        role: 'assistant',
+      },
+    ]);
+    useUiStore.setState({
+      activeConversationId: convId,
+      model: CLAUDE,
+      sidebarOpen: true,
+    });
+
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = urlOf(input);
+      if (url.endsWith('/api/models')) {
+        return Promise.resolve(
+          Response.json([CLAUDE, GPT], {
+            headers: { 'content-type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+      if (url.endsWith('/api/chat')) {
+        return Promise.resolve(
+          sseChatResponse({
+            answer: 'Регенериран прв',
+            responseId: 'resp-a1-new',
+          }),
+        );
+      }
+
+      return Promise.resolve(
+        new Response('{}', {
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        }),
+      );
+    });
+
+    const user = userEvent.setup();
+    renderChatPage();
+
+    await expect(
+      screen.findByText('Втор стар одговор'),
+    ).resolves.toBeInTheDocument();
+
+    const regenerateButtons = await screen.findAllByRole('button', {
+      name: 'Регенерирај',
+    });
+    const firstRegenerate = regenerateButtons[0];
+    if (!firstRegenerate) {
+      throw new Error('expected a regenerate button for the first answer');
+    }
+    await user.click(firstRegenerate);
+
+    await expect(
+      screen.findByText('Регенериран прв'),
+    ).resolves.toBeInTheDocument();
+
+    await waitFor(async () => {
+      const count = await db.messages
+        .where('conversationId')
+        .equals(convId)
+        .count();
+
+      expect(count).toBe(2);
+    });
+
+    const persisted = await db.messages
+      .where('conversationId')
+      .equals(convId)
+      .sortBy('createdAt');
+    const ids = persisted.map((row) => row.id);
+    const a1 = persisted.find((m) => m.id === 'a1');
+
+    expect(ids).toStrictEqual(['u1', 'a1']);
+    expect(a1 ? lastText(a1) : null).toBe('Регенериран прв');
+    expect(a1?.metadata?.responseId).toBe('resp-a1-new');
   });
 
   it('hydrates an existing conversation on mount', async () => {

--- a/web/test/thread.test.tsx
+++ b/web/test/thread.test.tsx
@@ -271,6 +271,23 @@ describe('Thread', () => {
     expect(screen.getByTestId('typing-indicator')).toBeInTheDocument();
   });
 
+  it('keeps the typing indicator mounted when an empty assistant stream shell appears', () => {
+    const messages: MyUIMessage[] = [
+      userMessage('прашање'),
+      assistantWithParts([]),
+    ];
+
+    render(
+      <Thread
+        messages={messages}
+        status="streaming"
+      />,
+    );
+
+    expect(screen.getAllByTestId('typing-indicator')).toHaveLength(1);
+    expect(screen.queryByTestId('answer-text')).not.toBeInTheDocument();
+  });
+
   it('shows a live elapsed timer while awaiting the reply', () => {
     render(
       <Thread
@@ -312,5 +329,24 @@ describe('Thread', () => {
     );
 
     expect(screen.getByTestId('acts')).toHaveTextContent('a1');
+  });
+
+  it('keeps completed message actions visible while a later answer streams', () => {
+    const messages: MyUIMessage[] = [
+      assistantWithParts([{ text: 'готово', type: 'text' }]),
+      userMessage('уште едно'),
+      { ...assistantWithParts([]), id: 'a2' },
+    ];
+
+    render(
+      <Thread
+        messages={messages}
+        renderActions={(m) => <span data-testid="acts">{m.id}</span>}
+        status="streaming"
+      />,
+    );
+
+    expect(screen.getByTestId('acts')).toHaveTextContent('a1');
+    expect(screen.getAllByTestId('typing-indicator')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Fixes three chat UX defects reported during streaming and regeneration, and hardens IndexedDB persistence so the on-screen conversation always matches what is stored.

### Bugs fixed
1. **Typing indicator flicker** — the three-dots indicator briefly disappeared and reappeared when the SDK appended an empty assistant shell at the start of a response. The thread now skips rendering the empty assistant placeholder during streaming and keeps a single stable indicator until the first token arrives.
2. **Message actions vanishing mid-stream** — Copy/feedback actions were gated on `status !== 'streaming'`, so they disappeared for every answer while a new response streamed. Actions now stay visible during streaming; only the **Regenerate** action is suppressed while a stream is active (prevents corrupting the single in-flight regenerate ref).
3. **Duplicate / stale answers after refresh** — regenerating an answer (especially a mid-conversation one) left the old answer and all trailing messages stranded in Dexie, so they reappeared on refresh and leaked into the next chat request. Regeneration now replaces the answer **in place** and the full visible message list is persisted transactionally, pruning any trailing rows.

### Key changes
- `lib/db.ts`: new `replaceConversationMessages` — a single `rw` transaction that prunes stale rows and preserves `createdAt` for reused message ids (no reordering on refresh).
- `lib/use-conversations.tsx`: regenerate tracking via a ref + state, in-place replacement on finish, `onError` resets the regenerate state so a failed transport never strands it. Extracted hydration, list, stream-timing, action-render, and message-state logic into focused modules.
- `lib/chat-translate.ts`: requests carry `messageId`/`trigger`; on regenerate, messages after the target are trimmed before hitting the API.
- `components/chat/thread.tsx`: stable typing indicator + empty-shell skip during streaming.

## Verification
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (2 pre-existing soft `max-lines-per-function` warnings)
- `npm test` — 113 passed (incl. a new multi-turn regenerate persistence regression that seeds `u1/a1/u2/a2`, regenerates the middle answer, and asserts only `u1` + the in-place-regenerated `a1` survive in Dexie)
- `npm run build` — succeeds
