### PR TITLE
feat(web): persist like/dislike feedback across refreshes

### DIFF
--- a/web/components/chat/answer-actions.tsx
+++ b/web/components/chat/answer-actions.tsx
@@ -11,20 +11,26 @@ import { cn } from '@/lib/utils';
 export type AnswerActionsProps = {
   message: MyUIMessage;
   onRegenerate?: () => void;
+  onVote?: (vote: FeedbackType) => void;
+  pending?: boolean;
   questionText?: string;
 };
 
 const BTN =
-  'inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none';
+  'inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-40';
 
 export const AnswerActions = ({
   message,
   onRegenerate,
+  onVote,
+  pending = false,
   questionText,
 }: AnswerActionsProps) => {
   const responseId = message.metadata?.responseId;
   const [copied, setCopied] = useState(false);
-  const [vote, setVote] = useState<FeedbackType | null>(null);
+  const [vote, setVote] = useState<FeedbackType | null>(
+    message.metadata?.feedback ?? null,
+  );
 
   if (!responseId) {
     return null;
@@ -41,6 +47,9 @@ export const AnswerActions = ({
   };
 
   const sendFeedback = async (feedbackType: FeedbackType): Promise<void> => {
+    if (pending) {
+      return;
+    }
     const previous = vote;
     setVote(feedbackType);
     try {
@@ -58,7 +67,9 @@ export const AnswerActions = ({
       });
       if (!res.ok) {
         setVote(previous);
+        return;
       }
+      onVote?.(feedbackType);
     } catch {
       setVote(previous);
     }
@@ -111,6 +122,7 @@ export const AnswerActions = ({
             'bg-green-600/10 text-green-600 hover:bg-green-600/15 hover:text-green-600',
         )}
         data-testid="like-button"
+        disabled={pending}
         onClick={() => {
           void sendFeedback('like');
         }}
@@ -130,6 +142,7 @@ export const AnswerActions = ({
             'bg-red-600/10 text-red-600 hover:bg-red-600/15 hover:text-red-600',
         )}
         data-testid="dislike-button"
+        disabled={pending}
         onClick={() => {
           void sendFeedback('dislike');
         }}

--- a/web/lib/api-types.ts
+++ b/web/lib/api-types.ts
@@ -64,6 +64,7 @@ export type MyDataParts = {
 };
 
 export type MyMetadata = {
+  feedback?: FeedbackType;
   inferenceModel?: string;
   responseId?: string;
   timing?: { totalMs: number; ttftMs: null | number };

--- a/web/lib/conversation-actions.tsx
+++ b/web/lib/conversation-actions.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from 'react';
 
-import type { MyUIMessage } from '@/lib/api-types';
+import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
 
 import { AnswerActions } from '@/components/chat/answer-actions';
 import { joinText } from '@/lib/message-parts';
@@ -20,23 +20,37 @@ const priorUserText = (
   return prior ? joinText(prior) : undefined;
 };
 
+export type AnswerActionsContext = {
+  messages: MyUIMessage[];
+  onVote: (messageId: string, vote: FeedbackType) => void;
+  regenerate: (options: { messageId: string }) => void;
+  status: ChatStatus;
+};
+
 export const renderAnswerActions =
-  (
-    messages: MyUIMessage[],
-    regenerate: (options: { messageId: string }) => void,
-    status: ChatStatus,
-  ) =>
-  (message: MyUIMessage): ReactNode =>
-    message.role === 'assistant' ? (
+  ({ messages, onVote, regenerate, status }: AnswerActionsContext) =>
+  (message: MyUIMessage): ReactNode => {
+    if (message.role !== 'assistant') {
+      return null;
+    }
+
+    const streaming = status === 'streaming' || status === 'submitted';
+
+    return (
       <AnswerActions
         message={message}
         onRegenerate={
-          status === 'streaming' || status === 'submitted'
+          streaming
             ? undefined
             : () => {
                 regenerate({ messageId: message.id });
               }
         }
+        onVote={(vote) => {
+          onVote(message.id, vote);
+        }}
+        pending={streaming && messages.at(-1)?.id === message.id}
         questionText={priorUserText(messages, message)}
       />
-    ) : null;
+    );
+  };

--- a/web/lib/conversation-actions.tsx
+++ b/web/lib/conversation-actions.tsx
@@ -38,6 +38,7 @@ export const renderAnswerActions =
 
     return (
       <AnswerActions
+        key={`${message.id}:${message.metadata?.responseId ?? ''}`}
         message={message}
         onRegenerate={
           streaming

--- a/web/lib/conversation-message-state.ts
+++ b/web/lib/conversation-message-state.ts
@@ -1,4 +1,4 @@
-import type { MyUIMessage } from '@/lib/api-types';
+import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
 
 type FinishedReplacement = {
   readonly pruneAfterReplacement: boolean;
@@ -58,6 +58,15 @@ export const replaceFinishedMessage =
       return [message];
     });
   };
+
+export const applyFeedback =
+  (messageId: string, feedback: FeedbackType) =>
+  (messages: MyUIMessage[]): MyUIMessage[] =>
+    messages.map((message) =>
+      message.id === messageId
+        ? { ...message, metadata: { ...message.metadata, feedback } }
+        : message,
+    );
 
 export const previewRegeneration = (
   messages: MyUIMessage[],

--- a/web/lib/db.ts
+++ b/web/lib/db.ts
@@ -1,6 +1,6 @@
 import { Dexie, type EntityTable } from 'dexie';
 
-import type { MyUIMessage } from '@/lib/api-types';
+import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
 
 export type ConversationRow = {
   createdAt: number;
@@ -117,6 +117,19 @@ export const saveMessages = async (
   await db.transaction('rw', db.conversations, db.messages, async () => {
     await db.messages.bulkPut(rows);
     await db.conversations.update(conversationId, { updatedAt: nextNow() });
+  });
+};
+
+export const setMessageFeedback = async (
+  messageId: string,
+  feedback: FeedbackType,
+): Promise<void> => {
+  await db.transaction('rw', db.messages, async () => {
+    const row = await db.messages.get(messageId);
+    if (!row) {
+      return;
+    }
+    await db.messages.put({ ...row, metadata: { ...row.metadata, feedback } });
   });
 };
 

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -3,11 +3,12 @@
 import { useChat } from '@ai-sdk/react';
 import { useCallback, useRef, useState } from 'react';
 
-import type { MyUIMessage } from '@/lib/api-types';
+import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
 
 import { fireAndForget } from '@/lib/async';
 import { renderAnswerActions } from '@/lib/conversation-actions';
 import {
+  applyFeedback,
   finalizeMessage,
   previewRegeneration,
   replaceFinishedMessage,
@@ -19,6 +20,7 @@ import {
   renameConversation,
   replaceConversationMessages,
   saveMessages,
+  setMessageFeedback,
 } from '@/lib/db';
 import { deriveTitle } from '@/lib/messages';
 import { buildChatTransport } from '@/lib/transport';
@@ -208,12 +210,21 @@ export const useConversations = (model: string) => {
     [refreshConversations],
   );
 
-  const visibleMessages = previewRegeneration(messages, regeneratingMessageId);
-  const renderActions = renderAnswerActions(
-    visibleMessages,
-    regenerateMessage,
-    status,
+  const recordFeedback = useCallback(
+    (messageId: string, vote: FeedbackType) => {
+      setMessages(applyFeedback(messageId, vote));
+      fireAndForget(setMessageFeedback(messageId, vote));
+    },
+    [setMessages],
   );
+
+  const visibleMessages = previewRegeneration(messages, regeneratingMessageId);
+  const renderActions = renderAnswerActions({
+    messages: visibleMessages,
+    onVote: recordFeedback,
+    regenerate: regenerateMessage,
+    status,
+  });
 
   return {
     activeError,

--- a/web/test/answer-actions.test.tsx
+++ b/web/test/answer-actions.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { MyUIMessage } from '@/lib/api-types';
+import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
 
 import { AnswerActions } from '@/components/chat/answer-actions';
 import { createMemoryStorage } from '@/test/helpers/dom-stubs';
@@ -25,6 +25,8 @@ const ack = Response.json(
   },
   { headers: { 'content-type': 'application/json' }, status: 200 },
 );
+
+const PRESSED = 'aria-pressed';
 
 const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue();
 
@@ -95,7 +97,7 @@ describe('AnswerActions feedback', () => {
     fireEvent.click(dislike);
 
     await waitFor(() => {
-      expect(dislike).toHaveAttribute('aria-pressed', 'true');
+      expect(dislike).toHaveAttribute(PRESSED, 'true');
     });
   });
 
@@ -105,27 +107,80 @@ describe('AnswerActions feedback', () => {
     fireEvent.click(like);
 
     await waitFor(() => {
-      expect(like).toHaveAttribute('aria-pressed', 'true');
+      expect(like).toHaveAttribute(PRESSED, 'true');
     });
 
     expect(like.className).toContain('text-green-600');
     expect(like.className).not.toContain('text-muted-foreground');
   });
 
-  it('reverts the optimistic vote when the request fails', async () => {
+  it('restores the persisted vote from message metadata on mount', () => {
+    const message: MyUIMessage = {
+      ...assistant('resp-9'),
+      metadata: { feedback: 'like', responseId: 'resp-9' },
+    };
+    render(<AnswerActions message={message} />);
+
+    expect(screen.getByRole('button', { name: 'Допаѓа' })).toHaveAttribute(
+      PRESSED,
+      'true',
+    );
+  });
+
+  it('reports the vote to onVote once the request succeeds', async () => {
+    const onVote = vi.fn<(vote: FeedbackType) => void>();
+    render(
+      <AnswerActions
+        message={assistant('resp-9')}
+        onVote={onVote}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Допаѓа' }));
+
+    await waitFor(() => {
+      expect(onVote).toHaveBeenCalledWith('like');
+    });
+  });
+
+  it('reverts the vote and skips onVote when the request fails', async () => {
     vi.stubGlobal(
       'fetch',
       vi
         .fn<typeof fetch>()
         .mockResolvedValue(new Response('{}', { status: 500 })),
     );
-    render(<AnswerActions message={assistant('resp-9')} />);
+    const onVote = vi.fn<(vote: FeedbackType) => void>();
+    render(
+      <AnswerActions
+        message={assistant('resp-9')}
+        onVote={onVote}
+      />,
+    );
     const like = screen.getByRole('button', { name: 'Допаѓа' });
     fireEvent.click(like);
 
     await waitFor(() => {
-      expect(like).toHaveAttribute('aria-pressed', 'false');
+      expect(like).toHaveAttribute(PRESSED, 'false');
     });
+
+    expect(onVote).not.toHaveBeenCalled();
+  });
+
+  it('disables voting while the answer is still streaming', () => {
+    const onVote = vi.fn<(vote: FeedbackType) => void>();
+    render(
+      <AnswerActions
+        message={assistant('resp-9')}
+        onVote={onVote}
+        pending
+      />,
+    );
+    const like = screen.getByRole('button', { name: 'Допаѓа' });
+    fireEvent.click(like);
+
+    expect(like).toBeDisabled();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(onVote).not.toHaveBeenCalled();
   });
 
   it('invokes onRegenerate when Регенерирај is clicked', () => {

--- a/web/test/conversation-actions.test.tsx
+++ b/web/test/conversation-actions.test.tsx
@@ -1,0 +1,33 @@
+import type { ReactElement } from 'react';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
+
+import { renderAnswerActions } from '@/lib/conversation-actions';
+
+const assistant = (responseId: string): MyUIMessage => ({
+  id: 'a1',
+  metadata: { feedback: 'like', responseId },
+  parts: [{ text: 'Одговор', type: 'text' }],
+  role: 'assistant',
+});
+
+const keyFor = (responseId: string): null | string => {
+  const message = assistant(responseId);
+  const element = renderAnswerActions({
+    messages: [message],
+    onVote: vi.fn<(messageId: string, vote: FeedbackType) => void>(),
+    regenerate: vi.fn<(options: { messageId: string }) => void>(),
+    status: 'ready',
+  })(message) as ReactElement;
+
+  return element.key;
+};
+
+describe('renderAnswerActions', () => {
+  it('keys the actions by responseId so a regenerated answer remounts and resets the vote', () => {
+    expect(keyFor('r-old')).not.toBe(keyFor('r-new'));
+    expect(keyFor('r-new')).toContain('r-new');
+  });
+});

--- a/web/test/db.test.ts
+++ b/web/test/db.test.ts
@@ -10,6 +10,7 @@ import {
   loadMessages,
   renameConversation,
   saveMessages,
+  setMessageFeedback,
 } from '@/lib/db';
 
 const UUID_LIKE = /[0-9a-f-]{36}/u;
@@ -109,6 +110,26 @@ describe('messages', () => {
     const updated = list.find((c) => c.id === 'c2');
 
     expect(updated?.updatedAt).toBeGreaterThanOrEqual(conv.updatedAt);
+  });
+
+  it('persists feedback into the message metadata, preserving prior fields', async () => {
+    await createConversation({ id: 'c4', model: 'm', title: 'C4' });
+    await saveMessages('c4', [assistantMsg('m1', 'одговор', 'resp-123')]);
+
+    await setMessageFeedback('m1', 'like');
+
+    const rows = await loadMessages('c4');
+
+    expect(rows[0]?.metadata).toStrictEqual({
+      feedback: 'like',
+      responseId: 'resp-123',
+    });
+  });
+
+  it('ignores feedback for an unknown message id', async () => {
+    await expect(
+      setMessageFeedback('missing', 'dislike'),
+    ).resolves.toBeUndefined();
   });
 
   it('deletes a conversation and its messages', async () => {

--- a/web/test/shell.test.tsx
+++ b/web/test/shell.test.tsx
@@ -345,6 +345,12 @@ const renderChatPage = (): ReturnType<typeof rtlRender> => {
   );
 };
 
+const persistedAssistantFeedback = async (): Promise<string | undefined> => {
+  const stored = await db.messages.toArray();
+
+  return stored.find((m) => m.role === 'assistant')?.metadata?.feedback;
+};
+
 describe('ChatPage persistence', () => {
   beforeEach(async () => {
     await db.delete();
@@ -421,6 +427,59 @@ describe('ChatPage persistence', () => {
     expect(msgs.find((m) => m.role === 'assistant')?.metadata?.responseId).toBe(
       RESPONSE_ID,
     );
+  });
+
+  it('persists a like and restores it after a remount (refresh)', async () => {
+    const now = Date.now();
+    await db.conversations.put({
+      createdAt: now,
+      id: 'c-like',
+      model: CLAUDE,
+      title: 'Оценет разговор',
+      updatedAt: now,
+    });
+    await db.messages.bulkPut([
+      {
+        conversationId: 'c-like',
+        createdAt: now,
+        id: 'u-like',
+        parts: [{ text: 'Прашање за оцена', type: 'text' }],
+        role: 'user',
+      },
+      {
+        conversationId: 'c-like',
+        createdAt: now + 1,
+        id: 'a-like',
+        metadata: { responseId: 'resp-like' },
+        parts: [{ text: 'Одговор за оценување', type: 'text' }],
+        role: 'assistant',
+      },
+    ]);
+    useUiStore.setState({
+      activeConversationId: 'c-like',
+      model: CLAUDE,
+      sidebarOpen: true,
+    });
+
+    const user = userEvent.setup();
+    const view = renderChatPage();
+
+    await user.click(await screen.findByTestId('like-button'));
+
+    await waitFor(async () => {
+      await expect(persistedAssistantFeedback()).resolves.toBe('like');
+    });
+
+    // A refresh re-hydrates from Dexie; the vote must come back pressed.
+    view.unmount();
+    renderChatPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('like-button')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+    });
   });
 
   it('regenerates an assistant answer in place and persists only the replacement', async () => {


### PR DESCRIPTION
Thumbs up/down on an answer now survives a page refresh: the vote is stored in the message metadata (IndexedDB) and restored on load. Voting is gated until the answer finishes streaming so there's always a persisted row to write to.