### PR TITLE
feat(web): show a service-unavailable banner when the chat backend is down

### DIFF
--- a/web/app/api/health/route.ts
+++ b/web/app/api/health/route.ts
@@ -10,7 +10,7 @@ const result = (ok: boolean): Response =>
     { ok },
     {
       headers: { 'cache-control': 'no-store' },
-      status: 200,
+      status: ok ? 200 : 503,
     },
   );
 

--- a/web/app/api/health/route.ts
+++ b/web/app/api/health/route.ts
@@ -1,0 +1,29 @@
+import { API_BASE_URL } from '@/lib/env';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const HEALTH_TIMEOUT_MS = 5_000;
+
+const result = (ok: boolean): Response =>
+  Response.json(
+    { ok },
+    {
+      headers: { 'cache-control': 'no-store' },
+      status: 200,
+    },
+  );
+
+export const GET = async (): Promise<Response> => {
+  try {
+    const upstream = await fetch(`${API_BASE_URL}/health/health`, {
+      headers: { accept: 'application/json' },
+      method: 'GET',
+      signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
+    });
+
+    return result(upstream.ok);
+  } catch {
+    return result(false);
+  }
+};

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { Composer } from '@/components/chat/composer';
+import { ServiceBanner } from '@/components/chat/service-banner';
 import { Thread } from '@/components/chat/thread';
 import { Header } from '@/components/shell/header';
 import { Sidebar } from '@/components/shell/sidebar';
 import { useUiStore } from '@/lib/ui-store';
 import { useConversations } from '@/lib/use-conversations';
+import { useHealth } from '@/lib/use-health';
 import { useModels } from '@/lib/use-models';
 
 const ChatScreen = () => {
@@ -15,6 +17,7 @@ const ChatScreen = () => {
   const toggleSidebar = useUiStore((s) => s.toggleSidebar);
   const setSidebarOpen = useUiStore((s) => s.setSidebarOpen);
 
+  const { unavailable } = useHealth();
   const {
     data: modelList,
     isError: modelsError,
@@ -42,6 +45,7 @@ const ChatScreen = () => {
   return (
     <div className="flex h-dvh w-full flex-col">
       <Header onToggleSidebar={toggleSidebar} />
+      {unavailable ? <ServiceBanner /> : null}
       <div className="flex min-h-0 flex-1">
         <Sidebar
           activeId={activeId}
@@ -68,6 +72,7 @@ const ChatScreen = () => {
             streamStartedAt={streamStartedAt}
           />
           <Composer
+            disabled={unavailable}
             model={model}
             models={modelList ?? []}
             modelsError={modelsError}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -40,7 +40,7 @@ const ChatScreen = () => {
     status,
     streamStartedAt,
     submitMessage,
-  } = useConversations(model);
+  } = useConversations(model, unavailable);
 
   return (
     <div className="flex h-dvh w-full flex-col">
@@ -66,7 +66,7 @@ const ChatScreen = () => {
             activeStatus={activeStatus}
             messages={messages}
             onPickSuggestion={submitMessage}
-            onRetry={retry}
+            onRetry={unavailable ? undefined : retry}
             renderActions={renderActions}
             status={status}
             streamStartedAt={streamStartedAt}

--- a/web/components/chat/composer.tsx
+++ b/web/components/chat/composer.tsx
@@ -197,7 +197,9 @@ export const Composer = ({
               className="size-9 shrink-0 rounded-full transition-transform active:scale-95"
               data-testid="composer-submit"
               disabled={
-                (disabled ?? false) || (!isBusy && value.trim().length === 0)
+                isBusy
+                  ? false
+                  : (disabled ?? false) || value.trim().length === 0
               }
               onClick={onButtonClick}
               size="icon"

--- a/web/components/chat/service-banner.tsx
+++ b/web/components/chat/service-banner.tsx
@@ -4,6 +4,7 @@ import { t } from '@/lib/i18n';
 
 export const ServiceBanner = () => (
   <output
+    aria-live="polite"
     className="flex shrink-0 items-center justify-center gap-2 border-b border-amber-500/20 bg-amber-500/10 px-4 py-2 text-center text-sm font-medium text-amber-700 dark:text-amber-400"
     data-testid="service-banner"
   >

--- a/web/components/chat/service-banner.tsx
+++ b/web/components/chat/service-banner.tsx
@@ -1,0 +1,16 @@
+import { TriangleAlert } from 'lucide-react';
+
+import { t } from '@/lib/i18n';
+
+export const ServiceBanner = () => (
+  <output
+    className="flex shrink-0 items-center justify-center gap-2 border-b border-amber-500/20 bg-amber-500/10 px-4 py-2 text-center text-sm font-medium text-amber-700 dark:text-amber-400"
+    data-testid="service-banner"
+  >
+    <TriangleAlert
+      aria-hidden="true"
+      className="size-4 shrink-0"
+    />
+    {t('service.unavailable')}
+  </output>
+);

--- a/web/lib/conversation-actions.tsx
+++ b/web/lib/conversation-actions.tsx
@@ -21,6 +21,7 @@ const priorUserText = (
 };
 
 export type AnswerActionsContext = {
+  disabled: boolean;
   messages: MyUIMessage[];
   onVote: (messageId: string, vote: FeedbackType) => void;
   regenerate: (options: { messageId: string }) => void;
@@ -28,7 +29,7 @@ export type AnswerActionsContext = {
 };
 
 export const renderAnswerActions =
-  ({ messages, onVote, regenerate, status }: AnswerActionsContext) =>
+  ({ disabled, messages, onVote, regenerate, status }: AnswerActionsContext) =>
   (message: MyUIMessage): ReactNode => {
     if (message.role !== 'assistant') {
       return null;
@@ -41,7 +42,7 @@ export const renderAnswerActions =
         key={`${message.id}:${message.metadata?.responseId ?? ''}`}
         message={message}
         onRegenerate={
-          streaming
+          streaming || disabled
             ? undefined
             : () => {
                 regenerate({ messageId: message.id });

--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -39,6 +39,8 @@ export const messages = {
   'notFound.description': 'Страницата што ја барате не постои.',
   'notFound.home': 'Назад кон почетната',
   'notFound.title': 'Страницата не е најдена',
+  'service.unavailable':
+    'Услугата е привремено недостапна. Чатот не е достапен во моментов.',
   'sidebar.clearSearch': 'Исчисти пребарување',
   'sidebar.deleteAll': 'Избриши ги сите',
   'sidebar.history': 'Разговори',

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -29,7 +29,7 @@ import { useConversationHydration } from '@/lib/use-conversation-hydration';
 import { useConversationList } from '@/lib/use-conversation-list';
 import { useStreamTiming } from '@/lib/use-stream-timing';
 
-export const useConversations = (model: string) => {
+export const useConversations = (model: string, disabled = false) => {
   const activeId = useUiStore((s) => s.activeConversationId);
   const setActiveId = useUiStore((s) => s.setActiveConversationId);
 
@@ -188,18 +188,24 @@ export const useConversations = (model: string) => {
   );
 
   const retry = useCallback(() => {
+    if (disabled) {
+      return;
+    }
     fireAndForget(regenerate());
-  }, [regenerate]);
+  }, [disabled, regenerate]);
 
   const regenerateMessage = useCallback(
     (options: { messageId: string }) => {
+      if (disabled) {
+        return;
+      }
       regeneratingMessageIdRef.current = options.messageId;
       setRegeneratingMessageId(options.messageId);
       void regenerate(options);
       setActiveError(undefined);
       setActiveStatus(undefined);
     },
-    [regenerate],
+    [disabled, regenerate],
   );
 
   const handleRename = useCallback(
@@ -220,6 +226,7 @@ export const useConversations = (model: string) => {
 
   const visibleMessages = previewRegeneration(messages, regeneratingMessageId);
   const renderActions = renderAnswerActions({
+    disabled,
     messages: visibleMessages,
     onVote: recordFeedback,
     regenerate: regenerateMessage,

--- a/web/lib/use-health.ts
+++ b/web/lib/use-health.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+const isOk = (value: unknown): boolean =>
+  typeof value === 'object' &&
+  value !== null &&
+  (value as { ok?: unknown }).ok === true;
+
+const fetchHealth = async (): Promise<boolean> => {
+  try {
+    const res = await fetch('/api/health');
+    if (!res.ok) {
+      return false;
+    }
+
+    return isOk(await res.json());
+  } catch {
+    return false;
+  }
+};
+
+export const useHealth = (): { unavailable: boolean } => {
+  const query = useQuery({
+    queryFn: fetchHealth,
+    queryKey: ['health'],
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+    staleTime: 15_000,
+  });
+
+  // Optimistic: only flag as unavailable once a check has actually failed, so
+  // the chat is never blocked during the initial in-flight check.
+  return { unavailable: query.data === false };
+};

--- a/web/lib/use-health.ts
+++ b/web/lib/use-health.ts
@@ -2,34 +2,34 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-const isOk = (value: unknown): boolean =>
-  typeof value === 'object' &&
-  value !== null &&
-  (value as { ok?: unknown }).ok === true;
+const HEALTHY_INTERVAL_MS = 30_000;
+const DOWN_INTERVAL_MS = 5_000;
 
-const fetchHealth = async (): Promise<boolean> => {
-  try {
-    const res = await fetch('/api/health');
-    if (!res.ok) {
-      return false;
-    }
-
-    return isOk(await res.json());
-  } catch {
-    return false;
+const fetchHealth = async (): Promise<true> => {
+  const res = await fetch('/api/health');
+  if (!res.ok) {
+    throw new Error('unavailable');
   }
+
+  return true;
 };
 
 export const useHealth = (): { unavailable: boolean } => {
   const query = useQuery({
     queryFn: fetchHealth,
     queryKey: ['health'],
-    refetchInterval: 30_000,
-    refetchOnWindowFocus: true,
-    staleTime: 15_000,
+    refetchInterval: (q) =>
+      q.state.status === 'error' ? DOWN_INTERVAL_MS : HEALTHY_INTERVAL_MS,
+    refetchOnWindowFocus: 'always',
+    // One retry absorbs a single transient blip; the down-state still resolves
+    // within ~one retry. Recovery is picked up by the faster down-interval and
+    // the always-on focus refetch.
+    retry: 1,
+    staleTime: HEALTHY_INTERVAL_MS,
   });
 
-  // Optimistic: only flag as unavailable once a check has actually failed, so
-  // the chat is never blocked during the initial in-flight check.
-  return { unavailable: query.data === false };
+  // Optimistic: only flag unavailable once a check has actually failed (after
+  // the retry), so the chat is never blocked during the initial in-flight
+  // check and a single blip can't lock the composer.
+  return { unavailable: query.isError };
 };

--- a/web/lib/use-health.ts
+++ b/web/lib/use-health.ts
@@ -21,15 +21,11 @@ export const useHealth = (): { unavailable: boolean } => {
     refetchInterval: (q) =>
       q.state.status === 'error' ? DOWN_INTERVAL_MS : HEALTHY_INTERVAL_MS,
     refetchOnWindowFocus: 'always',
-    // One retry absorbs a single transient blip; the down-state still resolves
-    // within ~one retry. Recovery is picked up by the faster down-interval and
-    // the always-on focus refetch.
+    // One retry absorbs a transient blip before flagging the backend down.
     retry: 1,
     staleTime: HEALTHY_INTERVAL_MS,
   });
 
-  // Optimistic: only flag unavailable once a check has actually failed (after
-  // the retry), so the chat is never blocked during the initial in-flight
-  // check and a single blip can't lock the composer.
+  // Optimistic: only flag unavailable after a check actually fails (post-retry).
   return { unavailable: query.isError };
 };

--- a/web/test/api-health.route.test.ts
+++ b/web/test/api-health.route.test.ts
@@ -45,6 +45,7 @@ describe('GET /api/health', () => {
 
     const res = await GET();
 
+    expect(res.status).toBe(503);
     await expect(res.json()).resolves.toStrictEqual({ ok: false });
   });
 
@@ -57,7 +58,7 @@ describe('GET /api/health', () => {
 
     const res = await GET();
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(503);
     await expect(res.json()).resolves.toStrictEqual({ ok: false });
   });
 });

--- a/web/test/api-health.route.test.ts
+++ b/web/test/api-health.route.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GET } from '@/app/api/health/route';
+
+vi.mock('@/lib/env', () => ({
+  API_BASE_URL: 'https://api:8880',
+  CHAT_API_KEY: 'test-key',
+  env: { API_BASE_URL: 'https://api:8880', CHAT_API_KEY: 'test-key' },
+}));
+
+describe('GET /api/health', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reports ok when the upstream health check succeeds', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(Response.json({ status: 'ok' }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await GET();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe('https://api:8880/health/health');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    await expect(res.json()).resolves.toStrictEqual({ ok: true });
+  });
+
+  it('reports not ok when the upstream health check is unhealthy', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('unhealthy', { status: 503 }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await GET();
+
+    await expect(res.json()).resolves.toStrictEqual({ ok: false });
+  });
+
+  it('reports not ok when the upstream is unreachable', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new Error('network down'));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toStrictEqual({ ok: false });
+  });
+});

--- a/web/test/composer.test.tsx
+++ b/web/test/composer.test.tsx
@@ -91,6 +91,24 @@ describe('Composer', () => {
     expect(onStop).toHaveBeenCalledOnce();
   });
 
+  it('keeps the Stop button clickable while streaming even when disabled', () => {
+    const { onStop } = setup({ disabled: true, status: 'streaming' });
+    const button = screen.getByTestId('composer-submit');
+
+    expect(button).toBeEnabled();
+
+    fireEvent.click(button);
+
+    expect(onStop).toHaveBeenCalledOnce();
+  });
+
+  it('disables the input and submit button when disabled and idle', () => {
+    setup({ disabled: true, status: 'ready' });
+
+    expect(screen.getByTestId('composer-input')).toBeDisabled();
+    expect(screen.getByTestId('composer-submit')).toBeDisabled();
+  });
+
   it('renders every model id as an option', async () => {
     setup();
     const user = userEvent.setup();

--- a/web/test/conversation-actions.test.tsx
+++ b/web/test/conversation-actions.test.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react';
 
 import { describe, expect, it, vi } from 'vitest';
 
+import type { AnswerActionsProps } from '@/components/chat/answer-actions';
 import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
 
 import { renderAnswerActions } from '@/lib/conversation-actions';
@@ -13,21 +14,29 @@ const assistant = (responseId: string): MyUIMessage => ({
   role: 'assistant',
 });
 
-const keyFor = (responseId: string): null | string => {
+const renderFor = (
+  responseId: string,
+  disabled = false,
+): ReactElement<AnswerActionsProps> => {
   const message = assistant(responseId);
-  const element = renderAnswerActions({
+
+  return renderAnswerActions({
+    disabled,
     messages: [message],
     onVote: vi.fn<(messageId: string, vote: FeedbackType) => void>(),
     regenerate: vi.fn<(options: { messageId: string }) => void>(),
     status: 'ready',
-  })(message) as ReactElement;
-
-  return element.key;
+  })(message) as ReactElement<AnswerActionsProps>;
 };
 
 describe('renderAnswerActions', () => {
   it('keys the actions by responseId so a regenerated answer remounts and resets the vote', () => {
-    expect(keyFor('r-old')).not.toBe(keyFor('r-new'));
-    expect(keyFor('r-new')).toContain('r-new');
+    expect(renderFor('r-old').key).not.toBe(renderFor('r-new').key);
+    expect(renderFor('r-new').key).toContain('r-new');
+  });
+
+  it('drops the regenerate action when the backend is unavailable', () => {
+    expect(renderFor('r1', false).props.onRegenerate).toBeDefined();
+    expect(renderFor('r1', true).props.onRegenerate).toBeUndefined();
   });
 });

--- a/web/test/shell.test.tsx
+++ b/web/test/shell.test.tsx
@@ -397,6 +397,29 @@ const sseChatResponse = ({
   });
 };
 
+const jsonOk = (body: unknown): Response =>
+  Response.json(body, {
+    headers: { 'content-type': 'application/json' },
+    status: 200,
+  });
+
+const respondTo = (
+  url: string,
+  chat?: { answer?: string; responseId?: string },
+): Promise<Response> => {
+  if (url.endsWith('/api/models')) {
+    return Promise.resolve(jsonOk([CLAUDE, GPT]));
+  }
+  if (url.endsWith('/api/health')) {
+    return Promise.resolve(jsonOk({ ok: true }));
+  }
+  if (url.endsWith('/api/chat')) {
+    return Promise.resolve(sseChatResponse(chat));
+  }
+
+  return Promise.resolve(jsonOk({}));
+};
+
 const renderChatPage = (): ReturnType<typeof rtlRender> => {
   const queryClient = new QueryClient();
 
@@ -426,32 +449,32 @@ describe('ChatPage persistence', () => {
     vi.stubGlobal('localStorage', createMemoryStorage());
     vi.stubGlobal(
       'fetch',
-      vi.fn<(input: RequestInfo | URL) => Promise<Response>>((input) => {
-        const url = urlOf(input);
-        if (url.endsWith('/api/models')) {
-          return Promise.resolve(
-            Response.json([CLAUDE, GPT], {
-              headers: { 'content-type': 'application/json' },
-              status: 200,
-            }),
-          );
-        }
-        if (url.endsWith('/api/chat')) {
-          return Promise.resolve(sseChatResponse());
-        }
-
-        return Promise.resolve(
-          new Response('{}', {
-            headers: { 'content-type': 'application/json' },
-            status: 200,
-          }),
-        );
-      }),
+      vi.fn<(input: RequestInfo | URL) => Promise<Response>>((input) =>
+        respondTo(urlOf(input)),
+      ),
     );
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it('shows the unavailable banner and disables the composer when the backend is down', async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = urlOf(input);
+      if (url.endsWith('/api/health')) {
+        return Promise.resolve(jsonOk({ ok: false }));
+      }
+
+      return respondTo(url);
+    });
+
+    renderChatPage();
+
+    await expect(
+      screen.findByTestId('service-banner'),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByTestId('composer-input')).toBeDisabled();
   });
 
   it('sends a message, renders the streamed answer, and persists to Dexie', async () => {
@@ -576,29 +599,12 @@ describe('ChatPage persistence', () => {
       sidebarOpen: true,
     });
 
-    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
-      const url = urlOf(input);
-      if (url.endsWith('/api/models')) {
-        return Promise.resolve(
-          Response.json([CLAUDE, GPT], {
-            headers: { 'content-type': 'application/json' },
-            status: 200,
-          }),
-        );
-      }
-      if (url.endsWith('/api/chat')) {
-        return Promise.resolve(
-          sseChatResponse({ answer: 'Нов одговор', responseId: 'resp-new' }),
-        );
-      }
-
-      return Promise.resolve(
-        new Response('{}', {
-          headers: { 'content-type': 'application/json' },
-          status: 200,
-        }),
-      );
-    });
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) =>
+      respondTo(urlOf(input), {
+        answer: 'Нов одговор',
+        responseId: 'resp-new',
+      }),
+    );
 
     const user = userEvent.setup();
     renderChatPage();
@@ -673,32 +679,12 @@ describe('ChatPage persistence', () => {
       sidebarOpen: true,
     });
 
-    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
-      const url = urlOf(input);
-      if (url.endsWith('/api/models')) {
-        return Promise.resolve(
-          Response.json([CLAUDE, GPT], {
-            headers: { 'content-type': 'application/json' },
-            status: 200,
-          }),
-        );
-      }
-      if (url.endsWith('/api/chat')) {
-        return Promise.resolve(
-          sseChatResponse({
-            answer: 'Регенериран прв',
-            responseId: 'resp-a1-new',
-          }),
-        );
-      }
-
-      return Promise.resolve(
-        new Response('{}', {
-          headers: { 'content-type': 'application/json' },
-          status: 200,
-        }),
-      );
-    });
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) =>
+      respondTo(urlOf(input), {
+        answer: 'Регенериран прв',
+        responseId: 'resp-a1-new',
+      }),
+    );
 
     const user = userEvent.setup();
     renderChatPage();

--- a/web/test/shell.test.tsx
+++ b/web/test/shell.test.tsx
@@ -421,7 +421,9 @@ const respondTo = (
 };
 
 const renderChatPage = (): ReturnType<typeof rtlRender> => {
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retryDelay: 0 } },
+  });
 
   return rtlRender(
     <QueryClientProvider client={queryClient}>
@@ -463,7 +465,7 @@ describe('ChatPage persistence', () => {
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
       const url = urlOf(input);
       if (url.endsWith('/api/health')) {
-        return Promise.resolve(jsonOk({ ok: false }));
+        return Promise.resolve(Response.json({ ok: false }, { status: 503 }));
       }
 
       return respondTo(url);
@@ -475,6 +477,7 @@ describe('ChatPage persistence', () => {
       screen.findByTestId('service-banner'),
     ).resolves.toBeInTheDocument();
     expect(screen.getByTestId('composer-input')).toBeDisabled();
+    expect(screen.getByTestId('composer-submit')).toBeDisabled();
   });
 
   it('sends a message, renders the streamed answer, and persists to Dexie', async () => {


### PR DESCRIPTION
When the chat backend is unreachable or unhealthy, the web app now shows a 'service unavailable' banner under the header and disables the composer (you can still read existing chats). It auto-recovers once the backend is healthy again.

- New BFF `/api/health` route proxies the chat API's `/health/health` (200 healthy, 503 if its DB is down), with a 5s timeout.
- `useHealth` polls it every 30s and on window focus; optimistic — only flips to unavailable after a check actually fails, so the chat is never blocked during the initial check.
- Inline banner + disabled composer (chosen over a full-screen gate).