### PR TITLE
chore: enable Dependabot for web frontend

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,8 @@ updates:
     directory: '/gpu-api'
     schedule:
       interval: 'daily'
+
+  - package-ecosystem: 'npm'
+    directory: '/web'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
Adds an `npm` Dependabot entry for `/web` so frontend dependencies get the same daily update checks as `/api` and `/gpu-api`.