### PR TITLE
feat(web): type-to-focus composer, soften focus border

### DIFF
--- a/web/components/chat/composer.tsx
+++ b/web/components/chat/composer.tsx
@@ -83,6 +83,33 @@ export const Composer = ({
     }
   }, [status, focusInput]);
 
+  // Start typing anywhere on the page to focus the composer, so the first
+  // keystroke lands in the input even when it was never focused. Skip shortcuts
+  // and non-character keys, and stay out of the way of other editable fields.
+  useEffect(() => {
+    const onTypeAhead = (e: globalThis.KeyboardEvent) => {
+      if (e.ctrlKey || e.metaKey || e.altKey || e.key.length !== 1) {
+        return;
+      }
+      const active = document.activeElement;
+      const isEditable =
+        active instanceof HTMLElement &&
+        (active.isContentEditable ||
+          active.tagName === 'INPUT' ||
+          active.tagName === 'TEXTAREA' ||
+          active.tagName === 'SELECT');
+      if (isEditable || document.querySelector('[role="dialog"]') !== null) {
+        return;
+      }
+      textareaRef.current?.focus();
+    };
+
+    document.addEventListener('keydown', onTypeAhead);
+    return () => {
+      document.removeEventListener('keydown', onTypeAhead);
+    };
+  }, []);
+
   const submit = () => {
     const trimmed = value.trim();
     if (!trimmed || isBusy || disabled) {
@@ -138,7 +165,7 @@ export const Composer = ({
   return (
     <div className="bg-background px-3 pb-3 pt-2 sm:px-4">
       <div className="mx-auto w-full max-w-3xl">
-        <div className="flex flex-col rounded-3xl border border-input bg-card shadow-lg shadow-black/5 transition-[color,box-shadow] focus-within:border-ring/70 focus-within:ring-4 focus-within:ring-ring/15 dark:shadow-black/25">
+        <div className="flex flex-col rounded-3xl border border-input bg-card shadow-lg shadow-black/5 transition-[color,box-shadow] focus-within:border-foreground/25 focus-within:ring-2 focus-within:ring-foreground/[0.06] dark:shadow-black/25">
           <textarea
             aria-label={t('composer.message')}
             className="field-sizing-content max-h-48 min-h-[52px] w-full resize-none bg-transparent px-4 pt-3 pb-2 text-sm outline-none placeholder:text-muted-foreground disabled:opacity-50"

--- a/web/components/chat/composer.tsx
+++ b/web/components/chat/composer.tsx
@@ -88,7 +88,13 @@ export const Composer = ({
   // and non-character keys, and stay out of the way of other editable fields.
   useEffect(() => {
     const onTypeAhead = (e: globalThis.KeyboardEvent) => {
-      if (e.ctrlKey || e.metaKey || e.altKey || e.key.length !== 1) {
+      if (
+        e.defaultPrevented ||
+        e.ctrlKey ||
+        e.metaKey ||
+        e.altKey ||
+        e.key.length !== 1
+      ) {
         return;
       }
       const active = document.activeElement;

--- a/web/test/composer.test.tsx
+++ b/web/test/composer.test.tsx
@@ -124,7 +124,7 @@ describe('Composer', () => {
   });
 
   it('focuses the input when typing starts elsewhere on the page', () => {
-    setup();
+    setup({ status: 'error' });
     const textarea = screen.getByTestId('composer-input');
 
     expect(textarea).not.toHaveFocus();
@@ -135,7 +135,7 @@ describe('Composer', () => {
   });
 
   it('ignores shortcuts and non-character keys for type-to-focus', () => {
-    setup();
+    setup({ status: 'error' });
     const textarea = screen.getByTestId('composer-input');
 
     fireEvent.keyDown(document.body, { ctrlKey: true, key: 'a' });

--- a/web/test/composer.test.tsx
+++ b/web/test/composer.test.tsx
@@ -123,6 +123,27 @@ describe('Composer', () => {
     expect(screen.getByRole('option', { name: GPT })).toBeInTheDocument();
   });
 
+  it('focuses the input when typing starts elsewhere on the page', () => {
+    setup();
+    const textarea = screen.getByTestId('composer-input');
+
+    expect(textarea).not.toHaveFocus();
+
+    fireEvent.keyDown(document.body, { key: 'к' });
+
+    expect(textarea).toHaveFocus();
+  });
+
+  it('ignores shortcuts and non-character keys for type-to-focus', () => {
+    setup();
+    const textarea = screen.getByTestId('composer-input');
+
+    fireEvent.keyDown(document.body, { ctrlKey: true, key: 'a' });
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+
+    expect(textarea).not.toHaveFocus();
+  });
+
   it('reports model changes', async () => {
     const { onModelChange } = setup();
     const user = userEvent.setup();


### PR DESCRIPTION
Two small composer (chat input) tweaks for the web client.

## Changes
- **Type-to-focus**: start typing anywhere on the page (chat or new-chat) and the input focuses so the first keystroke lands in it. Skips shortcuts/modifier combos, non-character keys, other editable fields, and open dialogs.
- **Softer focus border**: replace the saturated green focus ring with a neutral, subtler one — the previous state read as too green when typing into an unfocused input.

## Tests
- New unit tests for type-to-focus (focuses on a character key; ignores shortcuts/arrow keys). `vitest` + `tsc` + `eslint` pass.
