### PR TITLE
feat(web): stream reasoning live and add thinking time to diagnostics

### DIFF
--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -58,11 +58,17 @@ def _history_for_retrieval(payload: ChatSchema) -> str | None:
 def _sse_event_name(chunk: bytes | str | memoryview) -> str:
     """The SSE event name of ``chunk``, or '' if it has none.
 
-    Each chunk is one ``_sse`` frame, so reading the ``event:`` prefix is enough.
+    Only the first line is inspected: the rest of the frame is the (possibly large)
+    data payload, and decoding bytes mid-character would risk a UnicodeDecodeError.
     """
-    text = bytes(chunk).decode() if not isinstance(chunk, str) else chunk
-    if text.startswith("event: "):
-        return text[len("event: ") :].split("\n", 1)[0].strip()
+    if isinstance(chunk, str):
+        first_line = chunk.split("\n", 1)[0]
+    else:
+        raw = bytes(chunk)
+        newline = raw.find(b"\n")
+        first_line = (raw if newline == -1 else raw[:newline]).decode(errors="ignore")
+    if first_line.startswith("event:"):
+        return first_line[len("event:") :].strip()
     return ""
 
 

--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -86,13 +86,16 @@ async def _instrument_stream(
     drop unknown events, so it stays backward compatible.
     """
     try:
+        marking = True
         async for chunk in body:
             timings.mark_ttft()
-            event_name = _sse_event_name(chunk)
-            if event_name == "thinking":
-                timings.mark_thinking()
-            elif event_name == "token":
-                timings.mark_answer()
+            if marking:
+                event_name = _sse_event_name(chunk)
+                if event_name == "thinking":
+                    timings.mark_thinking()
+                elif event_name == "token":
+                    timings.mark_answer()
+                    marking = False
             yield chunk
     finally:
         timings.mark_total()

--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -56,10 +56,9 @@ def _history_for_retrieval(payload: ChatSchema) -> str | None:
 
 
 def _sse_event_name(chunk: bytes | str | memoryview) -> str:
-    """The SSE event name of a single frame, or '' if it carries none.
+    """The SSE event name of ``chunk``, or '' if it has none.
 
-    The agent generator yields exactly one frame per chunk, so a cheap prefix read
-    suffices — no need to parse the whole frame.
+    Each chunk is one ``_sse`` frame, so reading the ``event:`` prefix is enough.
     """
     text = bytes(chunk).decode() if not isinstance(chunk, str) else chunk
     if text.startswith("event: "):
@@ -78,8 +77,8 @@ async def _instrument_stream(
     """Pass the SSE body through untouched, stamping TTFT, thinking and total, then
     log one chat.timing line and emit a trailing ``meta`` frame with the same breakdown.
 
-    Thinking time is the span from the first ``thinking`` frame to the first ``token``
-    frame, measured here so it rides the same ``meta``/diagnostics path as the rest.
+    Thinking time spans the first ``thinking`` frame to the first ``token`` frame, so it
+    lands in the same ``meta`` diagnostics as TTFT and total.
 
     The ``meta`` frame trails the body's ``done`` (``total_ms`` is known only once the
     body drains); consumers that stop at ``done`` ignore it and the protocol-v2 parsers

--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -55,6 +55,18 @@ def _history_for_retrieval(payload: ChatSchema) -> str | None:
     )
 
 
+def _sse_event_name(chunk: bytes | str | memoryview) -> str:
+    """The SSE event name of a single frame, or '' if it carries none.
+
+    The agent generator yields exactly one frame per chunk, so a cheap prefix read
+    suffices — no need to parse the whole frame.
+    """
+    text = bytes(chunk).decode() if not isinstance(chunk, str) else chunk
+    if text.startswith("event: "):
+        return text[len("event: ") :].split("\n", 1)[0].strip()
+    return ""
+
+
 async def _instrument_stream(
     body: AsyncIterable[bytes | str | memoryview],
     *,
@@ -63,8 +75,11 @@ async def _instrument_stream(
     timings: RequestTimings,
     retrieval_hit: bool,
 ) -> AsyncGenerator[bytes | str | memoryview]:
-    """Pass the SSE body through untouched, stamping TTFT and total, then log one
-    chat.timing line and emit a trailing ``meta`` frame with the same breakdown.
+    """Pass the SSE body through untouched, stamping TTFT, thinking and total, then
+    log one chat.timing line and emit a trailing ``meta`` frame with the same breakdown.
+
+    Thinking time is the span from the first ``thinking`` frame to the first ``token``
+    frame, measured here so it rides the same ``meta``/diagnostics path as the rest.
 
     The ``meta`` frame trails the body's ``done`` (``total_ms`` is known only once the
     body drains); consumers that stop at ``done`` ignore it and the protocol-v2 parsers
@@ -73,6 +88,11 @@ async def _instrument_stream(
     try:
         async for chunk in body:
             timings.mark_ttft()
+            event_name = _sse_event_name(chunk)
+            if event_name == "thinking":
+                timings.mark_thinking()
+            elif event_name == "token":
+                timings.mark_answer()
             yield chunk
     finally:
         timings.mark_total()

--- a/api/app/utils/timing.py
+++ b/api/app/utils/timing.py
@@ -17,9 +17,11 @@ class RequestTimings:
 
     def __init__(self) -> None:
         self._t0 = time.perf_counter()
+        self._thinking_t0: float | None = None
         self.spans: dict[str, float] = {}
         self.ttft_ms: float | None = None
         self.total_ms: float | None = None
+        self.thinking_ms: float | None = None
         self.candidate_count: int | None = None
         self.top_distance: float | None = None
 
@@ -30,6 +32,14 @@ class RequestTimings:
         if self.ttft_ms is None:
             self.ttft_ms = (time.perf_counter() - self._t0) * 1000.0
 
+    def mark_thinking(self) -> None:
+        if self._thinking_t0 is None:
+            self._thinking_t0 = time.perf_counter()
+
+    def mark_answer(self) -> None:
+        if self.thinking_ms is None and self._thinking_t0 is not None:
+            self.thinking_ms = (time.perf_counter() - self._thinking_t0) * 1000.0
+
     def mark_total(self) -> None:
         self.total_ms = (time.perf_counter() - self._t0) * 1000.0
 
@@ -37,6 +47,7 @@ class RequestTimings:
         return {
             "ttft_ms": _round(self.ttft_ms),
             "total_ms": _round(self.total_ms),
+            "thinking_ms": _round(self.thinking_ms),
             "candidate_count": self.candidate_count,
             "top_distance": _round(self.top_distance, 4),
             "spans": {name: round(ms, 1) for name, ms in self.spans.items()},

--- a/web/components/chat/message.tsx
+++ b/web/components/chat/message.tsx
@@ -69,6 +69,12 @@ const DiagnosticsCard = ({
     <div className="flex flex-col gap-2 text-xs">
       <p className="font-medium text-foreground">{t('diagnostics.title')}</p>
       <DiagnosticsGroup>
+        {typeof diagnostics.thinkingMs === 'number' ? (
+          <DiagnosticsRow
+            label={t('diagnostics.thinking')}
+            value={formatMs(diagnostics.thinkingMs)}
+          />
+        ) : null}
         <DiagnosticsRow
           label={t('diagnostics.serverTotal')}
           value={formatMs(diagnostics.serverTotalMs)}
@@ -249,8 +255,15 @@ export const AssistantMessage = ({
   const inPreamble =
     Boolean(pending) && Boolean(statusPart) && parts.length <= 1;
   const text = inPreamble ? null : (parts.at(-1)?.text ?? null);
+  const reasoningStreaming =
+    Boolean(pending) && reasoningText.length > 0 && text === null;
   const showChip = Boolean(statusPart) && !text;
-  const showDots = Boolean(pending) && !text && !statusPart && !errorPart;
+  const showDots =
+    Boolean(pending) &&
+    !text &&
+    !statusPart &&
+    !errorPart &&
+    reasoningText.length === 0;
   const timing = message.metadata?.timing;
   const diagnostics = message.metadata?.diagnostics;
   const liveTimer =
@@ -261,7 +274,12 @@ export const AssistantMessage = ({
   return (
     <Message from="assistant">
       <MessageContent>
-        {reasoningText ? <ReasoningDisclosure text={reasoningText} /> : null}
+        {reasoningText ? (
+          <ReasoningDisclosure
+            streaming={reasoningStreaming}
+            text={reasoningText}
+          />
+        ) : null}
         {text ? (
           <div data-testid="answer-text">
             <MessageResponse>{text}</MessageResponse>

--- a/web/components/chat/reasoning-disclosure.tsx
+++ b/web/components/chat/reasoning-disclosure.tsx
@@ -11,8 +11,7 @@ export const ReasoningDisclosure = ({
   streaming?: boolean;
   text: string;
 }) => {
-  // Until the user clicks, the panel follows the stream: open while thinking, collapse
-  // once the answer begins. A manual toggle then takes over.
+  // null = follow the stream (open while thinking); a click pins it open or closed.
   const [manualOpen, setManualOpen] = useState<boolean | null>(null);
   const panelId = useId();
 

--- a/web/components/chat/reasoning-disclosure.tsx
+++ b/web/components/chat/reasoning-disclosure.tsx
@@ -4,13 +4,23 @@ import { useId, useState } from 'react';
 import { MessageResponse } from '@/components/ai-elements/message';
 import { t } from '@/lib/i18n';
 
-export const ReasoningDisclosure = ({ text }: { text: string }) => {
-  const [open, setOpen] = useState(false);
+export const ReasoningDisclosure = ({
+  streaming = false,
+  text,
+}: {
+  streaming?: boolean;
+  text: string;
+}) => {
+  // Until the user clicks, the panel follows the stream: open while thinking, collapse
+  // once the answer begins. A manual toggle then takes over.
+  const [manualOpen, setManualOpen] = useState<boolean | null>(null);
   const panelId = useId();
 
   if (text.length === 0) {
     return null;
   }
+
+  const open = manualOpen ?? streaming;
 
   return (
     <div
@@ -22,7 +32,7 @@ export const ReasoningDisclosure = ({ text }: { text: string }) => {
         aria-expanded={open}
         className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
         onClick={() => {
-          setOpen((v) => !v);
+          setManualOpen(!open);
         }}
         type="button"
       >
@@ -30,11 +40,14 @@ export const ReasoningDisclosure = ({ text }: { text: string }) => {
           aria-hidden="true"
           className={`size-3 transition-transform ${open ? 'rotate-90' : ''}`}
         />
-        {t('thread.reasoning')}
+        <span className={streaming ? 'animate-pulse' : undefined}>
+          {streaming ? t('thread.thinking') : t('thread.reasoning')}
+        </span>
       </button>
       {open ? (
         <div
           className="mt-1 border-l-2 border-border pl-3 text-sm text-muted-foreground"
+          data-testid="reasoning-panel"
           id={panelId}
         >
           <MessageResponse>{text}</MessageResponse>

--- a/web/components/chat/thread.tsx
+++ b/web/components/chat/thread.tsx
@@ -16,7 +16,7 @@ import { ElapsedTimer } from '@/components/chat/elapsed-timer';
 import { AssistantMessage } from '@/components/chat/message';
 import { TypingIndicator } from '@/components/chat/typing-indicator';
 import { t } from '@/lib/i18n';
-import { hasText, joinText } from '@/lib/message-parts';
+import { hasReasoning, hasText, joinText } from '@/lib/message-parts';
 
 export type ThreadProps = {
   activeError?: { code: string; message: string };
@@ -89,7 +89,9 @@ export const Thread = ({
   const awaitingReply =
     streaming &&
     (lastMessage?.role !== 'assistant' ||
-      (activeStatus === undefined && !hasText(lastMessage)));
+      (activeStatus === undefined &&
+        !hasText(lastMessage) &&
+        !hasReasoning(lastMessage)));
 
   return (
     <Conversation className="flex-1">
@@ -104,7 +106,8 @@ export const Thread = ({
                 m.id === lastAssistantId &&
                 streaming &&
                 activeStatus === undefined &&
-                !hasText(m)
+                !hasText(m) &&
+                !hasReasoning(m)
               ) {
                 return null;
               }

--- a/web/e2e/helpers/sse.ts
+++ b/web/e2e/helpers/sse.ts
@@ -12,7 +12,10 @@ export type UiChunk =
       transient: true;
       type: 'data-status';
     }
+  | { delta: string; id: string; type: 'reasoning-delta' }
   | { delta: string; id: string; type: 'text-delta' }
+  | { id: string; type: 'reasoning-end' }
+  | { id: string; type: 'reasoning-start' }
   | { id: string; type: 'text-end' }
   | { id: string; type: 'text-start' }
   | {

--- a/web/e2e/reasoning.spec.ts
+++ b/web/e2e/reasoning.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { createServer } from 'node:http';
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http';
 import { type AddressInfo } from 'node:net';
 
 import { type UiChunk } from './helpers/sse';
@@ -10,6 +14,8 @@ const REASON_HEAD = 'Размислувам чекор еден…';
 const REASON_TAIL = ' и чекор два.';
 const ANSWER = 'Конечниот одговор е дека ФИНКИ е во Скопје.';
 
+type TimedEvent = { atMs: number; chunk?: UiChunk; done?: boolean };
+
 const frame = (chunk: UiChunk): string => `data: ${JSON.stringify(chunk)}\n\n`;
 
 const closeServer = (server: ReturnType<typeof createServer>): Promise<void> =>
@@ -19,40 +25,58 @@ const closeServer = (server: ReturnType<typeof createServer>): Promise<void> =>
     });
   });
 
+// A client that navigates away mid-stream ends the response, so a late timer must
+// not write to a finished socket (that throws ERR_STREAM_WRITE_AFTER_END).
+const writeEvent = (res: ServerResponse, event: TimedEvent): void => {
+  if (res.writableEnded || res.destroyed) {
+    return;
+  }
+  if (event.done) {
+    res.write('data: [DONE]\n\n');
+    res.end();
+  } else if (event.chunk) {
+    res.write(frame(event.chunk));
+  }
+};
+
+const handleStream =
+  (events: TimedEvent[]) =>
+  (req: IncomingMessage, res: ServerResponse): void => {
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, {
+        'access-control-allow-headers': '*',
+        'access-control-allow-methods': '*',
+        'access-control-allow-origin': '*',
+      });
+      res.end();
+      return;
+    }
+    res.writeHead(200, {
+      'access-control-allow-origin': '*',
+      'cache-control': 'no-cache, no-transform',
+      'content-type': 'text/event-stream',
+      'x-vercel-ai-ui-message-stream': 'v1',
+    });
+    res.flushHeaders();
+    const timers = events.map((event) =>
+      setTimeout(() => {
+        writeEvent(res, event);
+      }, event.atMs),
+    );
+    res.on('close', () => {
+      for (const timer of timers) {
+        clearTimeout(timer);
+      }
+    });
+  };
+
 // A streaming server that flushes each chunk on its own schedule, so reasoning deltas
 // genuinely arrive over time (the shared head/tail helper batches them).
 const startTimedStream = (
-  events: Array<{ atMs: number; chunk?: UiChunk; done?: boolean }>,
+  events: TimedEvent[],
 ): Promise<{ close: () => Promise<void>; url: string }> =>
   new Promise((resolve) => {
-    const server = createServer((req, res) => {
-      if (req.method === 'OPTIONS') {
-        res.writeHead(204, {
-          'access-control-allow-headers': '*',
-          'access-control-allow-methods': '*',
-          'access-control-allow-origin': '*',
-        });
-        res.end();
-        return;
-      }
-      res.writeHead(200, {
-        'access-control-allow-origin': '*',
-        'cache-control': 'no-cache, no-transform',
-        'content-type': 'text/event-stream',
-        'x-vercel-ai-ui-message-stream': 'v1',
-      });
-      res.flushHeaders();
-      for (const event of events) {
-        setTimeout(() => {
-          if (event.done) {
-            res.write('data: [DONE]\n\n');
-            res.end();
-          } else if (event.chunk) {
-            res.write(frame(event.chunk));
-          }
-        }, event.atMs);
-      }
-    });
+    const server = createServer(handleStream(events));
     server.listen(0, '127.0.0.1', () => {
       const { port } = server.address() as AddressInfo;
       resolve({
@@ -95,52 +119,54 @@ test.describe('reasoning streaming (mocked BFF)', () => {
       { atMs: 1_500, done: true },
     ]);
 
-    await page.route('**/api/health', async (route) => {
-      await route.fulfill({
-        body: '{}',
-        contentType: 'application/json',
-        status: 200,
+    try {
+      await page.route('**/api/health', async (route) => {
+        await route.fulfill({
+          body: '{}',
+          contentType: 'application/json',
+          status: 200,
+        });
       });
-    });
-    await page.route('**/api/models', async (route) => {
-      await route.fulfill({
-        body: JSON.stringify([INFERENCE_MODEL, 'gpt-5.4-mini']),
-        contentType: 'application/json',
-        status: 200,
+      await page.route('**/api/models', async (route) => {
+        await route.fulfill({
+          body: JSON.stringify([INFERENCE_MODEL, 'gpt-5.4-mini']),
+          contentType: 'application/json',
+          status: 200,
+        });
       });
-    });
-    await page.route('**/api/chat', async (route) => {
-      await route.fulfill({
-        headers: { location: chatServer.url },
-        status: 307,
+      await page.route('**/api/chat', async (route) => {
+        await route.fulfill({
+          headers: { location: chatServer.url },
+          status: 307,
+        });
       });
-    });
 
-    await page.goto('/');
-    await page.getByTestId('composer-input').fill('Каде е ФИНКИ?');
-    await page.getByTestId('composer-input').press('Enter');
+      await page.goto('/');
+      await page.getByTestId('composer-input').fill('Каде е ФИНКИ?');
+      await page.getByTestId('composer-input').press('Enter');
 
-    // Mid-stream: the panel is auto-expanded and the partial reasoning is visible
-    // BEFORE the answer text exists.
-    await expect(page.getByTestId('reasoning-panel')).toContainText(
-      'чекор еден',
-    );
-    await expect(page.getByTestId('answer-text')).toHaveCount(0);
+      // Mid-stream: the panel is auto-expanded and the partial reasoning is visible
+      // BEFORE the answer text exists.
+      await expect(page.getByTestId('reasoning-panel')).toContainText(
+        'чекор еден',
+      );
+      await expect(page.getByTestId('answer-text')).toHaveCount(0);
 
-    // After the stream completes: the answer renders and the panel auto-collapses
-    // (the toggle stays, so the reasoning is still reachable).
-    await expect(page.getByTestId('answer-text')).toContainText(
-      'ФИНКИ е во Скопје',
-    );
-    await expect(page.getByTestId('reasoning')).toBeVisible();
-    await expect(page.getByTestId('reasoning-panel')).toHaveCount(0);
+      // After the stream completes: the answer renders and the panel auto-collapses
+      // (the toggle stays, so the reasoning is still reachable).
+      await expect(page.getByTestId('answer-text')).toContainText(
+        'ФИНКИ е во Скопје',
+      );
+      await expect(page.getByTestId('reasoning')).toBeVisible();
+      await expect(page.getByTestId('reasoning-panel')).toHaveCount(0);
 
-    // Re-expanding shows the full reasoning trace.
-    await page.getByTestId('reasoning').getByRole('button').click();
-    await expect(page.getByTestId('reasoning-panel')).toContainText(
-      'чекор еден… и чекор два.',
-    );
-
-    await chatServer.close();
+      // Re-expanding shows the full reasoning trace.
+      await page.getByTestId('reasoning').getByRole('button').click();
+      await expect(page.getByTestId('reasoning-panel')).toContainText(
+        'чекор еден… и чекор два.',
+      );
+    } finally {
+      await chatServer.close();
+    }
   });
 });

--- a/web/e2e/reasoning.spec.ts
+++ b/web/e2e/reasoning.spec.ts
@@ -25,8 +25,7 @@ const closeServer = (server: ReturnType<typeof createServer>): Promise<void> =>
     });
   });
 
-// A client that navigates away mid-stream ends the response, so a late timer must
-// not write to a finished socket (that throws ERR_STREAM_WRITE_AFTER_END).
+// Skip a late timer once the client navigated away: writing to an ended socket throws.
 const writeEvent = (res: ServerResponse, event: TimedEvent): void => {
   if (res.writableEnded || res.destroyed) {
     return;
@@ -70,8 +69,7 @@ const handleStream =
     });
   };
 
-// A streaming server that flushes each chunk on its own schedule, so reasoning deltas
-// genuinely arrive over time (the shared head/tail helper batches them).
+// Flushes each chunk on its own timer so reasoning deltas arrive over time, not batched.
 const startTimedStream = (
   events: TimedEvent[],
 ): Promise<{ close: () => Promise<void>; url: string }> =>
@@ -106,7 +104,6 @@ test.describe('reasoning streaming (mocked BFF)', () => {
         atMs: 0,
         chunk: { delta: REASON_HEAD, id: 'r', type: 'reasoning-delta' },
       },
-      // reasoning keeps streaming for ~1.2s before any answer text exists
       {
         atMs: 700,
         chunk: { delta: REASON_TAIL, id: 'r', type: 'reasoning-delta' },
@@ -145,22 +142,19 @@ test.describe('reasoning streaming (mocked BFF)', () => {
       await page.getByTestId('composer-input').fill('Каде е ФИНКИ?');
       await page.getByTestId('composer-input').press('Enter');
 
-      // Mid-stream: the panel is auto-expanded and the partial reasoning is visible
-      // BEFORE the answer text exists.
+      // Reasoning is visible mid-stream, before any answer text exists.
       await expect(page.getByTestId('reasoning-panel')).toContainText(
         'чекор еден',
       );
       await expect(page.getByTestId('answer-text')).toHaveCount(0);
 
-      // After the stream completes: the answer renders and the panel auto-collapses
-      // (the toggle stays, so the reasoning is still reachable).
+      // Once the answer arrives the panel auto-collapses, but the toggle remains.
       await expect(page.getByTestId('answer-text')).toContainText(
         'ФИНКИ е во Скопје',
       );
       await expect(page.getByTestId('reasoning')).toBeVisible();
       await expect(page.getByTestId('reasoning-panel')).toHaveCount(0);
 
-      // Re-expanding shows the full reasoning trace.
       await page.getByTestId('reasoning').getByRole('button').click();
       await expect(page.getByTestId('reasoning-panel')).toContainText(
         'чекор еден… и чекор два.',

--- a/web/e2e/reasoning.spec.ts
+++ b/web/e2e/reasoning.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test } from '@playwright/test';
+import { createServer } from 'node:http';
+import { type AddressInfo } from 'node:net';
+
+import { type UiChunk } from './helpers/sse';
+
+const RESPONSE_ID = '99999999-8888-7777-6666-555555555555';
+const INFERENCE_MODEL = 'claude-sonnet-4-6';
+const REASON_HEAD = 'Размислувам чекор еден…';
+const REASON_TAIL = ' и чекор два.';
+const ANSWER = 'Конечниот одговор е дека ФИНКИ е во Скопје.';
+
+const frame = (chunk: UiChunk): string => `data: ${JSON.stringify(chunk)}\n\n`;
+
+const closeServer = (server: ReturnType<typeof createServer>): Promise<void> =>
+  new Promise((resolve) => {
+    server.close(() => {
+      resolve();
+    });
+  });
+
+// A streaming server that flushes each chunk on its own schedule, so reasoning deltas
+// genuinely arrive over time (the shared head/tail helper batches them).
+const startTimedStream = (
+  events: Array<{ atMs: number; chunk?: UiChunk; done?: boolean }>,
+): Promise<{ close: () => Promise<void>; url: string }> =>
+  new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      if (req.method === 'OPTIONS') {
+        res.writeHead(204, {
+          'access-control-allow-headers': '*',
+          'access-control-allow-methods': '*',
+          'access-control-allow-origin': '*',
+        });
+        res.end();
+        return;
+      }
+      res.writeHead(200, {
+        'access-control-allow-origin': '*',
+        'cache-control': 'no-cache, no-transform',
+        'content-type': 'text/event-stream',
+        'x-vercel-ai-ui-message-stream': 'v1',
+      });
+      res.flushHeaders();
+      for (const event of events) {
+        setTimeout(() => {
+          if (event.done) {
+            res.write('data: [DONE]\n\n');
+            res.end();
+          } else if (event.chunk) {
+            res.write(frame(event.chunk));
+          }
+        }, event.atMs);
+      }
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        close: () => closeServer(server),
+        url: `http://127.0.0.1:${port}/chat`,
+      });
+    });
+  });
+
+test.describe('reasoning streaming (mocked BFF)', () => {
+  test('streams reasoning live in an auto-expanded panel before the answer, then collapses', async ({
+    page,
+  }) => {
+    const chatServer = await startTimedStream([
+      {
+        atMs: 0,
+        chunk: {
+          messageMetadata: {
+            inferenceModel: INFERENCE_MODEL,
+            responseId: RESPONSE_ID,
+          },
+          type: 'start',
+        },
+      },
+      { atMs: 0, chunk: { id: 'r', type: 'reasoning-start' } },
+      {
+        atMs: 0,
+        chunk: { delta: REASON_HEAD, id: 'r', type: 'reasoning-delta' },
+      },
+      // reasoning keeps streaming for ~1.2s before any answer text exists
+      {
+        atMs: 700,
+        chunk: { delta: REASON_TAIL, id: 'r', type: 'reasoning-delta' },
+      },
+      { atMs: 1_200, chunk: { id: 'r', type: 'reasoning-end' } },
+      { atMs: 1_400, chunk: { id: 'a', type: 'text-start' } },
+      { atMs: 1_400, chunk: { delta: ANSWER, id: 'a', type: 'text-delta' } },
+      { atMs: 1_400, chunk: { id: 'a', type: 'text-end' } },
+      { atMs: 1_400, chunk: { type: 'finish' } },
+      { atMs: 1_500, done: true },
+    ]);
+
+    await page.route('**/api/health', async (route) => {
+      await route.fulfill({
+        body: '{}',
+        contentType: 'application/json',
+        status: 200,
+      });
+    });
+    await page.route('**/api/models', async (route) => {
+      await route.fulfill({
+        body: JSON.stringify([INFERENCE_MODEL, 'gpt-5.4-mini']),
+        contentType: 'application/json',
+        status: 200,
+      });
+    });
+    await page.route('**/api/chat', async (route) => {
+      await route.fulfill({
+        headers: { location: chatServer.url },
+        status: 307,
+      });
+    });
+
+    await page.goto('/');
+    await page.getByTestId('composer-input').fill('Каде е ФИНКИ?');
+    await page.getByTestId('composer-input').press('Enter');
+
+    // Mid-stream: the panel is auto-expanded and the partial reasoning is visible
+    // BEFORE the answer text exists.
+    await expect(page.getByTestId('reasoning-panel')).toContainText(
+      'чекор еден',
+    );
+    await expect(page.getByTestId('answer-text')).toHaveCount(0);
+
+    // After the stream completes: the answer renders and the panel auto-collapses
+    // (the toggle stays, so the reasoning is still reachable).
+    await expect(page.getByTestId('answer-text')).toContainText(
+      'ФИНКИ е во Скопје',
+    );
+    await expect(page.getByTestId('reasoning')).toBeVisible();
+    await expect(page.getByTestId('reasoning-panel')).toHaveCount(0);
+
+    // Re-expanding shows the full reasoning trace.
+    await page.getByTestId('reasoning').getByRole('button').click();
+    await expect(page.getByTestId('reasoning-panel')).toContainText(
+      'чекор еден… и чекор два.',
+    );
+
+    await chatServer.close();
+  });
+});

--- a/web/lib/api-types.ts
+++ b/web/lib/api-types.ts
@@ -105,7 +105,8 @@ export type ProtocolV2Event =
         timing?: {
           candidate_count: null | number;
           spans: Record<string, number>;
-          thinking_ms: null | number;
+          // Optional: an older server (pre-rollout) won't emit it.
+          thinking_ms?: null | number;
           top_distance: null | number;
           total_ms: null | number;
           ttft_ms: null | number;

--- a/web/lib/api-types.ts
+++ b/web/lib/api-types.ts
@@ -105,8 +105,7 @@ export type ProtocolV2Event =
         timing?: {
           candidate_count: null | number;
           spans: Record<string, number>;
-          // Optional: an older server (pre-rollout) won't emit it.
-          thinking_ms?: null | number;
+          thinking_ms: null | number;
           top_distance: null | number;
           total_ms: null | number;
           ttft_ms: null | number;

--- a/web/lib/api-types.ts
+++ b/web/lib/api-types.ts
@@ -66,7 +66,7 @@ export type MessageDiagnostics = {
   serverTotalMs?: null | number;
   serverTtftMs?: null | number;
   spans?: Record<string, number>;
-  // Wall-clock the model spent thinking before the answer (first thinking → first token).
+  // Wall-clock before the answer: first thinking frame → first token.
   thinkingMs?: null | number;
   tokens?: { input: number; output: number; total: number };
   topDistance?: null | number;

--- a/web/lib/api-types.ts
+++ b/web/lib/api-types.ts
@@ -66,6 +66,8 @@ export type MessageDiagnostics = {
   serverTotalMs?: null | number;
   serverTtftMs?: null | number;
   spans?: Record<string, number>;
+  // Wall-clock the model spent thinking before the answer (first thinking → first token).
+  thinkingMs?: null | number;
   tokens?: { input: number; output: number; total: number };
   topDistance?: null | number;
 };
@@ -103,6 +105,7 @@ export type ProtocolV2Event =
         timing?: {
           candidate_count: null | number;
           spans: Record<string, number>;
+          thinking_ms: null | number;
           top_distance: null | number;
           total_ms: null | number;
           ttft_ms: null | number;

--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -30,6 +30,7 @@ export const messages = {
   'diagnostics.serverFirstByte': 'прв бајт (сервер)',
   'diagnostics.serverTotal': 'вкупно (сервер)',
   'diagnostics.stages': 'фази',
+  'diagnostics.thinking': 'Размислување',
   'diagnostics.title': 'Дијагностика',
   'diagnostics.tokensInput': 'токени (влез)',
   'diagnostics.tokensOutput': 'токени (излез)',

--- a/web/lib/message-parts.ts
+++ b/web/lib/message-parts.ts
@@ -30,3 +30,6 @@ export const lastText = (message: MyUIMessage): null | string =>
 
 export const hasText = (message: MyUIMessage): boolean =>
   textParts(message).some((part) => part.text.length > 0);
+
+export const hasReasoning = (message: MyUIMessage): boolean =>
+  reasoningParts(message).some((part) => part.text.length > 0);

--- a/web/lib/sse.ts
+++ b/web/lib/sse.ts
@@ -64,6 +64,7 @@ const toDiagnostics = (obj: Record<string, unknown>): MessageDiagnostics => {
   if (isRecord(timing)) {
     diagnostics.serverTtftMs = asNumberOrNull(timing['ttft_ms']);
     diagnostics.serverTotalMs = asNumberOrNull(timing['total_ms']);
+    diagnostics.thinkingMs = asNumberOrNull(timing['thinking_ms']);
     diagnostics.candidateCount = asNumberOrNull(timing['candidate_count']);
     diagnostics.topDistance = asNumberOrNull(timing['top_distance']);
     diagnostics.spans = toSpans(timing['spans']);

--- a/web/test/reasoning-disclosure.test.tsx
+++ b/web/test/reasoning-disclosure.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ReasoningDisclosure } from '@/components/chat/reasoning-disclosure';
+
+const REASONING = 'thinking out loud';
+
+describe('ReasoningDisclosure', () => {
+  it('auto-expands so reasoning is visible live while streaming', () => {
+    render(
+      <ReasoningDisclosure
+        streaming
+        text={REASONING}
+      />,
+    );
+
+    expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('reasoning-panel')).toBeInTheDocument();
+  });
+
+  it('collapses once not streaming (answer started or done)', () => {
+    render(
+      <ReasoningDisclosure
+        streaming={false}
+        text={REASONING}
+      />,
+    );
+
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.queryByTestId('reasoning-panel')).toBeNull();
+  });
+
+  it('lets a manual toggle override the streaming default', () => {
+    render(
+      <ReasoningDisclosure
+        streaming
+        text={REASONING}
+      />,
+    );
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(button);
+
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('reasoning-panel')).toBeNull();
+  });
+
+  it('renders nothing when there is no reasoning text', () => {
+    const { container } = render(
+      <ReasoningDisclosure
+        streaming
+        text=""
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/test/sse.test.ts
+++ b/web/test/sse.test.ts
@@ -116,7 +116,7 @@ describe('parseProtocolV2', () => {
     const events = await collect(
       'event: meta\ndata: {"tokens":{"input":12,"output":34,"total":46}}\n\n',
       DONE_FRAME,
-      'event: meta\ndata: {"timing":{"ttft_ms":120.5,"total_ms":980.2,"candidate_count":8,"top_distance":0.1234,"spans":{"retrieval.embed":42.1}}}\n\n',
+      'event: meta\ndata: {"timing":{"ttft_ms":120.5,"total_ms":980.2,"thinking_ms":340,"candidate_count":8,"top_distance":0.1234,"spans":{"retrieval.embed":42.1}}}\n\n',
     );
 
     expect(events).toStrictEqual([
@@ -131,6 +131,7 @@ describe('parseProtocolV2', () => {
           serverTotalMs: 980.2,
           serverTtftMs: 120.5,
           spans: { 'retrieval.embed': 42.1 },
+          thinkingMs: 340,
           topDistance: 0.1234,
         },
         type: 'meta',


### PR DESCRIPTION
Streams reasoning incrementally in an auto-expanding panel, then collapses when the answer starts. Adds server-measured thinking time to the diagnostics popup.