### PR TITLE
fix(web): retain the chat error notice after a refresh

### DIFF
--- a/web/components/chat/message.tsx
+++ b/web/components/chat/message.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 import { Clock3 } from 'lucide-react';
 
-import type { MyUIMessage } from '@/lib/api-types';
+import type { ErrorNotice, MyUIMessage } from '@/lib/api-types';
 
 import {
   Message,
@@ -25,7 +25,7 @@ import { reasoningParts, textParts } from '@/lib/message-parts';
 
 export type AssistantMessageProps = {
   actions?: ReactNode;
-  errorPart?: { code: string; message: string };
+  errorPart?: ErrorNotice;
   message: MyUIMessage;
   onRetry?: () => void;
   pending?: boolean;
@@ -232,7 +232,7 @@ const MessageError = ({
   errorPart,
   onRetry,
 }: {
-  errorPart: { code: string; message: string };
+  errorPart: ErrorNotice;
   onRetry?: () => void;
 }) => (
   <div

--- a/web/components/chat/thread.tsx
+++ b/web/components/chat/thread.tsx
@@ -129,10 +129,14 @@ export const Thread = ({
               return (
                 <AssistantMessage
                   actions={renderActions ? renderActions(m) : undefined}
-                  errorPart={isLastAssistant ? activeError : undefined}
+                  errorPart={
+                    isLastAssistant
+                      ? (activeError ?? m.metadata?.error)
+                      : m.metadata?.error
+                  }
                   key={m.id}
                   message={m}
-                  onRetry={onRetry}
+                  onRetry={isLastAssistant ? onRetry : undefined}
                   pending={isLastAssistant && streaming}
                   statusPart={
                     isLastAssistant && streaming ? activeStatus : undefined

--- a/web/components/chat/thread.tsx
+++ b/web/components/chat/thread.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import type { MyUIMessage } from '@/lib/api-types';
+import type { ErrorNotice, MyUIMessage } from '@/lib/api-types';
 
 import {
   Conversation,
@@ -19,7 +19,7 @@ import { t } from '@/lib/i18n';
 import { hasReasoning, hasText, joinText } from '@/lib/message-parts';
 
 export type ThreadProps = {
-  activeError?: { code: string; message: string };
+  activeError?: ErrorNotice;
   activeStatus?: { label: string; tool?: string };
   messages: MyUIMessage[];
   onPickSuggestion?: (text: string) => void;

--- a/web/lib/api-types.ts
+++ b/web/lib/api-types.ts
@@ -79,6 +79,8 @@ export type MyDataParts = {
 
 export type MyMetadata = {
   diagnostics?: MessageDiagnostics;
+  // Persisted so the notice survives a refresh; the live `error` part is transient.
+  error?: { code: string; message: string };
   feedback?: FeedbackType;
   inferenceModel?: string;
   responseId?: string;

--- a/web/lib/api-types.ts
+++ b/web/lib/api-types.ts
@@ -27,6 +27,11 @@ export const MAX_CHARS_PER_TURN = 8_000;
 
 export type ChatErrorCode = 'agent_error' | 'interrupted' | 'no_answer';
 
+// A user-facing error: the live transient `error` part, the persisted metadata, and
+// the in-memory active error all share this shape (`code` is looser than ChatErrorCode
+// because it also carries transport codes like 'network'/'pre_stream').
+export type ErrorNotice = { code: string; message: string };
+
 export type FeedbackAck = {
   feedback_type: FeedbackType;
   id: string;
@@ -73,14 +78,14 @@ export type MessageDiagnostics = {
 };
 
 export type MyDataParts = {
-  error: { code: string; message: string };
+  error: ErrorNotice;
   status: { label: string; tool?: string };
 };
 
 export type MyMetadata = {
   diagnostics?: MessageDiagnostics;
   // Persisted so the notice survives a refresh; the live `error` part is transient.
-  error?: { code: string; message: string };
+  error?: ErrorNotice;
   feedback?: FeedbackType;
   inferenceModel?: string;
   responseId?: string;

--- a/web/lib/chat-translate.ts
+++ b/web/lib/chat-translate.ts
@@ -1,6 +1,7 @@
 import {
   type ChatRequestBody,
   type ConversationTurn,
+  type ErrorNotice,
   MAX_CHARS_PER_TURN,
   MAX_MESSAGES,
   type MessageDiagnostics,
@@ -27,7 +28,7 @@ export type UiStreamMeta = { inferenceModel?: string; responseId?: string };
 
 export type UiStreamPart =
   | {
-      data: { code: string; message: string };
+      data: ErrorNotice;
       transient: true;
       type: 'data-error';
     }

--- a/web/lib/conversation-actions.tsx
+++ b/web/lib/conversation-actions.tsx
@@ -31,8 +31,7 @@ export type AnswerActionsContext = {
 export const renderAnswerActions =
   ({ disabled, messages, onVote, regenerate, status }: AnswerActionsContext) =>
   (message: MyUIMessage): ReactNode => {
-    // A text-less turn (errored or still empty) has no answer to copy, vote on,
-    // or regenerate meaningfully — skip the action bar so an error can't be voted on.
+    // No answer text means an errored/empty turn — skip the bar so it can't be voted on.
     if (message.role !== 'assistant' || !hasText(message)) {
       return null;
     }

--- a/web/lib/conversation-actions.tsx
+++ b/web/lib/conversation-actions.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from 'react';
 import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
 
 import { AnswerActions } from '@/components/chat/answer-actions';
-import { joinText } from '@/lib/message-parts';
+import { hasText, joinText } from '@/lib/message-parts';
 
 export type ChatStatus = 'error' | 'ready' | 'streaming' | 'submitted';
 
@@ -31,7 +31,9 @@ export type AnswerActionsContext = {
 export const renderAnswerActions =
   ({ disabled, messages, onVote, regenerate, status }: AnswerActionsContext) =>
   (message: MyUIMessage): ReactNode => {
-    if (message.role !== 'assistant') {
+    // A text-less turn (errored or still empty) has no answer to copy, vote on,
+    // or regenerate meaningfully — skip the action bar so an error can't be voted on.
+    if (message.role !== 'assistant' || !hasText(message)) {
       return null;
     }
 

--- a/web/lib/use-conversation-hydration.ts
+++ b/web/lib/use-conversation-hydration.ts
@@ -2,7 +2,7 @@
 
 import { type RefObject, useEffect } from 'react';
 
-import type { MyUIMessage } from '@/lib/api-types';
+import type { ErrorNotice, MyUIMessage } from '@/lib/api-types';
 
 import { fireAndForget } from '@/lib/async';
 import { getConversation, loadMessages, type MessageRow } from '@/lib/db';
@@ -10,9 +10,7 @@ import { getConversation, loadMessages, type MessageRow } from '@/lib/db';
 type UseConversationHydrationOptions = {
   readonly activeId: null | string;
   readonly convoIdRef: RefObject<null | string>;
-  readonly setActiveError: (
-    value: undefined | { code: string; message: string },
-  ) => void;
+  readonly setActiveError: (value: ErrorNotice | undefined) => void;
   readonly setActiveId: (id: null | string) => void;
   readonly setActiveStatus: (
     value: undefined | { label: string; tool?: string },

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -48,6 +48,9 @@ export const useConversations = (
   const convoIdRef = useRef<null | string>(activeId);
   const startedAtRef = useRef<null | number>(null);
   const firstTokenAtRef = useRef<null | number>(null);
+  const activeErrorRef = useRef<undefined | { code: string; message: string }>(
+    undefined,
+  );
   const regeneratingMessageIdRef = useRef<null | string>(null);
   const [regeneratingMessageId, setRegeneratingMessageId] = useState<
     null | string
@@ -87,6 +90,8 @@ export const useConversations = (
           setActiveStatus(part.data);
         } else {
           setActiveError(part.data);
+          // Stamp it onto the message in onFinish so the notice persists past refresh.
+          activeErrorRef.current = part.data;
         }
       },
       onError: () => {
@@ -102,6 +107,9 @@ export const useConversations = (
         const replacementId = regeneratingMessageIdRef.current;
         regeneratingMessageIdRef.current = null;
         setRegeneratingMessageId(null);
+        // Consume on every finish so a prior turn's error can't leak onto the next.
+        const error = activeErrorRef.current;
+        activeErrorRef.current = undefined;
         // ai v7 also calls onFinish on abort/error; never finalize or persist a
         // partial answer (it would ghost into a switched-away conversation).
         if (isAbort || isError) {
@@ -112,10 +120,17 @@ export const useConversations = (
           startedAtRef.current,
           firstTokenAtRef.current,
         );
+        const withError =
+          error === undefined
+            ? finalizedBase
+            : {
+                ...finalizedBase,
+                metadata: { ...finalizedBase.metadata, error },
+              };
         const finalized =
           replacementId === null
-            ? finalizedBase
-            : { ...finalizedBase, id: replacementId };
+            ? withError
+            : { ...withError, id: replacementId };
         setMessages((prev) => {
           const next = replaceFinishedMessage({
             pruneAfterReplacement: replacementId !== null,

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -3,7 +3,7 @@
 import { useChat } from '@ai-sdk/react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
-import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
+import type { ErrorNotice, FeedbackType, MyUIMessage } from '@/lib/api-types';
 
 import { fireAndForget } from '@/lib/async';
 import { renderAnswerActions } from '@/lib/conversation-actions';
@@ -42,15 +42,11 @@ export const useConversations = (
   const [activeStatus, setActiveStatus] = useState<
     undefined | { label: string; tool?: string }
   >();
-  const [activeError, setActiveError] = useState<
-    undefined | { code: string; message: string }
-  >();
+  const [activeError, setActiveError] = useState<ErrorNotice | undefined>();
   const convoIdRef = useRef<null | string>(activeId);
   const startedAtRef = useRef<null | number>(null);
   const firstTokenAtRef = useRef<null | number>(null);
-  const activeErrorRef = useRef<undefined | { code: string; message: string }>(
-    undefined,
-  );
+  const activeErrorRef = useRef<ErrorNotice | undefined>(undefined);
   const regeneratingMessageIdRef = useRef<null | string>(null);
   const [regeneratingMessageId, setRegeneratingMessageId] = useState<
     null | string

--- a/web/test/conversation-actions.test.tsx
+++ b/web/test/conversation-actions.test.tsx
@@ -58,4 +58,25 @@ describe('renderAnswerActions', () => {
 
     expect(screen.getByRole('button', { name: REGENERATE })).toBeEnabled();
   });
+
+  it('drops the action bar for a text-less (errored) turn', () => {
+    const message: MyUIMessage = {
+      id: 'a1',
+      metadata: {
+        error: { code: 'agent_error', message: 'грешка' },
+        responseId: 'r1',
+      },
+      parts: [],
+      role: 'assistant',
+    };
+    const node = renderAnswerActions({
+      disabled: false,
+      messages: [message],
+      onVote: vi.fn<(messageId: string, vote: FeedbackType) => void>(),
+      regenerate: vi.fn<(options: { messageId: string }) => void>(),
+      status: 'ready',
+    })(message);
+
+    expect(node).toBeNull();
+  });
 });

--- a/web/test/thread.test.tsx
+++ b/web/test/thread.test.tsx
@@ -341,6 +341,51 @@ describe('Thread', () => {
     expect(screen.queryByText(hasText('преамбула'))).not.toBeInTheDocument();
   });
 
+  it('renders a persisted error notice after refresh (from message metadata)', () => {
+    // After a refresh there is no live activeError; the errored turn is hydrated
+    // with metadata.error and must still show the notice, not an empty bubble.
+    const messages: MyUIMessage[] = [
+      userMessage('прашање'),
+      {
+        id: 'a1',
+        metadata: {
+          error: { code: 'agent_error', message: 'Се случи грешка.' },
+        },
+        parts: [],
+        role: 'assistant',
+      },
+    ];
+    render(
+      <Thread
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Се случи грешка.');
+  });
+
+  it('prefers the live error over a stale persisted one on the last message', () => {
+    const messages: MyUIMessage[] = [
+      userMessage('прашање'),
+      {
+        id: 'a1',
+        metadata: { error: { code: 'agent_error', message: 'Стара грешка.' } },
+        parts: [],
+        role: 'assistant',
+      },
+    ];
+    render(
+      <Thread
+        activeError={{ code: 'agent_error', message: 'Грешка во живо.' }}
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Грешка во живо.');
+  });
+
   it('shows a typing indicator while awaiting the assistant reply', () => {
     render(
       <Thread


### PR DESCRIPTION
An agent_error arrives as a transient data-error part, so the stream finishes normally and onFinish persists a text-less assistant message — the notice (in-memory only) was lost on refresh, leaving an invisible bubble. Now the error is stored in message metadata and rendered after refresh. Also hides the answer action bar on text-less errored turns (it would otherwise copy an empty string / let you vote on a non-answer).