### PR TITLE
fix(api): repair reasoning/thinking-mode failures for OpenAI & Anthropic models

### DIFF
--- a/api/app/llms/anthropic.py
+++ b/api/app/llms/anthropic.py
@@ -45,8 +45,10 @@ def _thinking_config(
 
     budget, effective_max = thinking_budget(max_tokens)
     budget = max(budget, _MIN_ANTHROPIC_THINKING_BUDGET)
-    if effective_max <= budget:
-        effective_max = budget + _MIN_ANTHROPIC_THINKING_BUDGET
+    # max_tokens must exceed budget_tokens; always keep at least a budget's worth of room
+    # for the answer so a small max_tokens isn't swallowed whole by the thinking budget
+    # (without this, max_tokens just above 1024 leaves a near-empty answer).
+    effective_max = max(effective_max, budget + _MIN_ANTHROPIC_THINKING_BUDGET)
     return {"type": "enabled", "budget_tokens": budget}, effective_max
 
 

--- a/api/app/llms/anthropic.py
+++ b/api/app/llms/anthropic.py
@@ -28,17 +28,25 @@ anthropic_llm_clients: dict[tuple[str, float, float, int, bool], ChatAnthropic] 
 # Opus 4.7/4.8 reject `budget_tokens`; they use summarized adaptive thinking instead.
 _ADAPTIVE_THINKING_MODELS: frozenset[Model] = ANTHROPIC_NO_SAMPLING_MODELS
 
+# Anthropic rejects an enabled-thinking `budget_tokens` below 1024 and requires
+# `max_tokens` to exceed it. `thinking_budget` can fall below 1024 for small `max_tokens`
+# (e.g. max_tokens=2000 -> 1000), which 400s sonnet-4-6 / haiku-4-5, so clamp to the floor.
+_MIN_ANTHROPIC_THINKING_BUDGET = 1024
+
 
 def _thinking_config(
     model: Model,
     max_tokens: int,
 ) -> tuple[dict[str, object], int]:
     """The Anthropic ``thinking`` payload and effective ``max_tokens`` (adaptive for Opus
-    4.7/4.8, else an explicit budget)."""
+    4.7/4.8, else an explicit budget clamped to Anthropic's 1024-token floor)."""
     if model in _ADAPTIVE_THINKING_MODELS:
         return {"type": "adaptive", "display": "summarized"}, max_tokens
 
     budget, effective_max = thinking_budget(max_tokens)
+    budget = max(budget, _MIN_ANTHROPIC_THINKING_BUDGET)
+    if effective_max <= budget:
+        effective_max = budget + _MIN_ANTHROPIC_THINKING_BUDGET
     return {"type": "enabled", "budget_tokens": budget}, effective_max
 
 

--- a/api/app/llms/models.py
+++ b/api/app/llms/models.py
@@ -118,6 +118,18 @@ REASONING_CAPABLE_MODELS: frozenset[Model] = frozenset(
     },
 )
 
+# OpenAI reasoning models that default to "medium" effort and, in a non-reasoning chat,
+# can spend the whole max_output_tokens budget on hidden reasoning and return an empty
+# answer (observed for gpt-5-mini / gpt-5-nano). They accept reasoning effort "minimal",
+# which keeps them answering. The newer GPT-5.2 / 5.4 models reject "minimal" and do not
+# over-reason at the default, so they are deliberately excluded.
+OPENAI_MINIMAL_EFFORT_MODELS: frozenset[Model] = frozenset(
+    {
+        Model.GPT_5_MINI,
+        Model.GPT_5_NANO,
+    },
+)
+
 # Anthropic models that reject sampling parameters (temperature / top_p / top_k).
 # Claude Opus 4.7 and 4.8 return HTTP 400 if any of these are sent, so no sampling
 # parameters are forwarded for them. Every Claude 4+ model additionally rejects

--- a/api/app/llms/openai.py
+++ b/api/app/llms/openai.py
@@ -15,7 +15,11 @@ from app.llms.agents import (
     stream_sync_gen_as_sse,
 )
 from app.llms.mcp import get_mcp_tools
-from app.llms.models import OPENAI_MINIMAL_EFFORT_MODELS, Model
+from app.llms.models import (
+    OPENAI_MINIMAL_EFFORT_MODELS,
+    REASONING_CAPABLE_MODELS,
+    Model,
+)
 from app.llms.prompts import build_agent_messages
 from app.utils.settings import Settings
 
@@ -62,6 +66,10 @@ def get_openai_llm(
     wrapper strips automatically). When `reasoning` is off, models in
     `OPENAI_MINIMAL_EFFORT_MODELS` are pinned to `effort: "minimal"` so they don't burn the
     whole token budget on hidden reasoning and return an empty answer.
+
+    GPT-5 reasoning models reject `top_p` on the Responses API (HTTP 400 once a reasoning
+    request is made); the wrapper strips `temperature` for them but not `top_p`, so `top_p`
+    is forwarded only for the non-reasoning chat models. This mirrors the Anthropic client.
     """
     key = (model.value, temperature, top_p, max_tokens, reasoning)
 
@@ -71,12 +79,13 @@ def get_openai_llm(
             client_kwargs["reasoning"] = {"effort": "medium", "summary": "auto"}
         elif model in OPENAI_MINIMAL_EFFORT_MODELS:
             client_kwargs["reasoning"] = {"effort": "minimal"}
+        if model not in REASONING_CAPABLE_MODELS:
+            client_kwargs["top_p"] = top_p
         openai_llm_clients[key] = ChatOpenAI(
             model=model.value,
             api_key=SecretStr(settings.OPENAI_API_KEY),
             base_url=settings.OPENAI_BASE_URL or None,
             temperature=temperature,
-            top_p=top_p,
             streaming=True,
             stream_usage=True,
             max_tokens=max_tokens,  # type: ignore[call-arg]

--- a/api/app/llms/openai.py
+++ b/api/app/llms/openai.py
@@ -15,7 +15,7 @@ from app.llms.agents import (
     stream_sync_gen_as_sse,
 )
 from app.llms.mcp import get_mcp_tools
-from app.llms.models import Model
+from app.llms.models import OPENAI_MINIMAL_EFFORT_MODELS, Model
 from app.llms.prompts import build_agent_messages
 from app.utils.settings import Settings
 
@@ -59,7 +59,9 @@ def get_openai_llm(
     All OpenAI requests use the Responses API (`use_responses_api=True`); reasoning content
     is only surfaced there. When `reasoning` is on, a `reasoning` config requests a
     summarized reasoning trace (GPT-5 reasoning models ignore `temperature`, which the
-    wrapper strips automatically).
+    wrapper strips automatically). When `reasoning` is off, models in
+    `OPENAI_MINIMAL_EFFORT_MODELS` are pinned to `effort: "minimal"` so they don't burn the
+    whole token budget on hidden reasoning and return an empty answer.
     """
     key = (model.value, temperature, top_p, max_tokens, reasoning)
 
@@ -67,6 +69,8 @@ def get_openai_llm(
         client_kwargs: dict[str, object] = {"use_responses_api": True}
         if reasoning:
             client_kwargs["reasoning"] = {"effort": "medium", "summary": "auto"}
+        elif model in OPENAI_MINIMAL_EFFORT_MODELS:
+            client_kwargs["reasoning"] = {"effort": "minimal"}
         openai_llm_clients[key] = ChatOpenAI(
             model=model.value,
             api_key=SecretStr(settings.OPENAI_API_KEY),

--- a/api/app/llms/openai.py
+++ b/api/app/llms/openai.py
@@ -27,8 +27,8 @@ logger = logging.getLogger(__name__)
 
 settings = Settings()
 
-# Model, temperature, top_p, max_tokens, reasoning -> LLM
-openai_llm_clients: dict[tuple[str, float, float, int, bool], ChatOpenAI] = {}
+# Model, temperature, top_p (None when not forwarded), max_tokens, reasoning -> LLM
+openai_llm_clients: dict[tuple[str, float, float | None, int, bool], ChatOpenAI] = {}
 openai_embedders: dict[str, OpenAIEmbeddings] = {}
 
 
@@ -71,7 +71,16 @@ def get_openai_llm(
     request is made); the wrapper strips `temperature` for them but not `top_p`, so `top_p`
     is forwarded only for the non-reasoning chat models. This mirrors the Anthropic client.
     """
-    key = (model.value, temperature, top_p, max_tokens, reasoning)
+    # top_p is dropped for reasoning-capable (GPT-5) models, so it must not split the cache
+    # for them — fold it out of the key when it isn't forwarded.
+    forwards_top_p = model not in REASONING_CAPABLE_MODELS
+    key = (
+        model.value,
+        temperature,
+        top_p if forwards_top_p else None,
+        max_tokens,
+        reasoning,
+    )
 
     if key not in openai_llm_clients:
         client_kwargs: dict[str, object] = {"use_responses_api": True}
@@ -79,7 +88,7 @@ def get_openai_llm(
             client_kwargs["reasoning"] = {"effort": "medium", "summary": "auto"}
         elif model in OPENAI_MINIMAL_EFFORT_MODELS:
             client_kwargs["reasoning"] = {"effort": "minimal"}
-        if model not in REASONING_CAPABLE_MODELS:
+        if forwards_top_p:
             client_kwargs["top_p"] = top_p
         openai_llm_clients[key] = ChatOpenAI(
             model=model.value,


### PR DESCRIPTION
Three reasoning-mode defects surfaced by a live audit of the deployment. All pre-existing (not caused by the unified-endpoint switch), all verified live, all fixed and re-verified through the real agent path.

**1. `gpt-5-mini` / `gpt-5-nano` — empty answer (non-reasoning).** At their default `medium` effort they spend the whole `max_output_tokens` budget on hidden reasoning (128/128 tokens reasoning, 0 answer). Pin them to `effort: "minimal"`. `gpt-5.2`/`5.4` reject `minimal` and don't over-reason, so they're excluded.

**2. `gpt-5.2` / `gpt-5.4` / `gpt-5.4-mini` — thinking mode broken.** The Responses API rejects `top_p` once a reasoning request is made (`Unsupported parameter: 'top_p'`). The wrapper strips `temperature` for GPT-5 but not `top_p`; forward `top_p` only for non-reasoning chat models, mirroring the Anthropic client.

**3. `claude-sonnet-4-6` / `claude-haiku-4-5` — thinking mode broken below max_tokens 2048.** `thinking_budget` returns `min(2048, max_tokens//2)`, which falls under Anthropic's 1024 `budget_tokens` floor when `max_tokens < 2048` → HTTP 400. Clamp to 1024. (Worked at the 4096 default; broke for smaller limits. Opus 4.7/4.8 use adaptive thinking and were unaffected.)

After the fixes, every OpenAI/Anthropic/Google model answers in both reasoning on/off. `ruff format` / `ruff check` / `mypy` clean.