### PR TITLE
feat(web): add PostHog product analytics

### DIFF
--- a/.github/workflows/docker-web.yaml
+++ b/.github/workflows/docker-web.yaml
@@ -16,4 +16,6 @@ jobs:
       context: ./web
       package-name: chat-bot-web
       cache-backend: registry
+      build-args: |
+        NEXT_PUBLIC_POSTHOG_KEY=${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
     secrets: inherit

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,6 +12,12 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+# Public PostHog ingest key, inlined at build (NEXT_PUBLIC_* are baked by next build).
+# Safe to expose — it is a write-only browser key. CI passes it via --build-arg.
+ARG NEXT_PUBLIC_POSTHOG_KEY=""
+ARG NEXT_PUBLIC_POSTHOG_HOST="https://eu.i.posthog.com"
+ENV NEXT_PUBLIC_POSTHOG_KEY=$NEXT_PUBLIC_POSTHOG_KEY
+ENV NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST
 RUN API_BASE_URL="http://localhost:8880" CHAT_API_KEY="build-time-placeholder" npm run build
 
 FROM base AS runner

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,10 +12,9 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-# Public PostHog ingest key, inlined at build (NEXT_PUBLIC_* are baked by next build).
-# Safe to expose — it is a write-only browser key. Defaults to the public project key so
-# images always ship analytics; override via --build-arg NEXT_PUBLIC_POSTHOG_KEY=... if needed.
-ARG NEXT_PUBLIC_POSTHOG_KEY=phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd
+# Public PostHog ingest key, baked at build (NEXT_PUBLIC_* are inlined by next build).
+# Empty by default = analytics off; CI supplies it via --build-arg NEXT_PUBLIC_POSTHOG_KEY=... to enable.
+ARG NEXT_PUBLIC_POSTHOG_KEY=
 ARG NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 ENV NEXT_PUBLIC_POSTHOG_KEY=$NEXT_PUBLIC_POSTHOG_KEY
 ENV NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -14,8 +14,8 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 # Public PostHog ingest key, inlined at build (NEXT_PUBLIC_* are baked by next build).
 # Safe to expose — it is a write-only browser key. CI passes it via --build-arg.
-ARG NEXT_PUBLIC_POSTHOG_KEY=""
-ARG NEXT_PUBLIC_POSTHOG_HOST="https://eu.i.posthog.com"
+ARG NEXT_PUBLIC_POSTHOG_KEY=
+ARG NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 ENV NEXT_PUBLIC_POSTHOG_KEY=$NEXT_PUBLIC_POSTHOG_KEY
 ENV NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST
 RUN API_BASE_URL="http://localhost:8880" CHAT_API_KEY="build-time-placeholder" npm run build

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,8 +13,9 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 # Public PostHog ingest key, inlined at build (NEXT_PUBLIC_* are baked by next build).
-# Safe to expose — it is a write-only browser key. CI passes it via --build-arg.
-ARG NEXT_PUBLIC_POSTHOG_KEY=
+# Safe to expose — it is a write-only browser key. Defaults to the public project key so
+# images always ship analytics; override via --build-arg NEXT_PUBLIC_POSTHOG_KEY=... if needed.
+ARG NEXT_PUBLIC_POSTHOG_KEY=phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd
 ARG NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 ENV NEXT_PUBLIC_POSTHOG_KEY=$NEXT_PUBLIC_POSTHOG_KEY
 ENV NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -49,7 +49,14 @@ export const POST = async (req: Request): Promise<Response> => {
 
     const upstream = await fetch(`${API_BASE_URL}/chat/`, {
       body: JSON.stringify(chatBody),
-      headers: { 'content-type': 'application/json' },
+      headers: {
+        'content-type': 'application/json',
+        // Forward the browser's anonymous id so server-side analytics share its distinct_id.
+        ...(typeof clientBody.userId === 'string' &&
+          clientBody.userId.length > 0 && {
+            'X-Distinct-Id': clientBody.userId,
+          }),
+      },
       method: 'POST',
       // Propagate client aborts so stopping the chat tears down upstream generation.
       signal: req.signal,

--- a/web/app/providers.tsx
+++ b/web/app/providers.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { posthog } from 'posthog-js';
+import { PostHogProvider } from 'posthog-js/react';
 import { type ReactNode, useEffect, useState } from 'react';
 
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -18,9 +20,11 @@ export const Providers = ({ children }: ProvidersProps) => {
   }, []);
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>{children}</TooltipProvider>
-    </QueryClientProvider>
+    <PostHogProvider client={posthog}>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>{children}</TooltipProvider>
+      </QueryClientProvider>
+    </PostHogProvider>
   );
 };
 

--- a/web/components/chat/answer-actions.tsx
+++ b/web/components/chat/answer-actions.tsx
@@ -1,4 +1,5 @@
 import { Check, Copy, RotateCcw, ThumbsDown, ThumbsUp } from 'lucide-react';
+import { posthog } from 'posthog-js';
 import { useState } from 'react';
 
 import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
@@ -42,6 +43,12 @@ export const AnswerActions = ({
 
   const copy = async (): Promise<void> => {
     await navigator.clipboard.writeText(text);
+    /* eslint-disable camelcase -- PostHog event properties are snake_case. */
+    posthog.capture('answer_copied', {
+      inference_model: message.metadata?.inferenceModel,
+      response_id: responseId,
+    });
+    /* eslint-enable camelcase -- end of PostHog snake_case properties. */
     setCopied(true);
     setTimeout(() => {
       setCopied(false);

--- a/web/components/chat/composer.tsx
+++ b/web/components/chat/composer.tsx
@@ -174,7 +174,7 @@ export const Composer = ({
         <div className="flex flex-col rounded-3xl border border-input bg-card shadow-lg shadow-black/5 transition-[color,box-shadow] focus-within:border-foreground/25 focus-within:ring-2 focus-within:ring-foreground/[0.06] dark:shadow-black/25">
           <textarea
             aria-label={t('composer.message')}
-            className="field-sizing-content max-h-48 min-h-[52px] w-full resize-none bg-transparent px-4 pt-3 pb-2 text-sm outline-none placeholder:text-muted-foreground disabled:opacity-50"
+            className="ph-no-capture field-sizing-content max-h-48 min-h-[52px] w-full resize-none bg-transparent px-4 pt-3 pb-2 text-sm outline-none placeholder:text-muted-foreground disabled:opacity-50"
             data-testid="composer-input"
             disabled={disabled}
             onChange={(e) => {

--- a/web/components/chat/thread.tsx
+++ b/web/components/chat/thread.tsx
@@ -99,7 +99,7 @@ export const Thread = ({
         {messages.length === 0 ? (
           <Welcome onPick={onPickSuggestion} />
         ) : (
-          <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
+          <div className="ph-no-capture mx-auto flex w-full max-w-3xl flex-col gap-6">
             {messages.map((m) => {
               if (
                 m.role === 'assistant' &&

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -20,7 +20,8 @@ if (key !== undefined && key.length > 0) {
     bootstrap:
       distinctId === undefined ? undefined : { distinctID: distinctId },
     capture_exceptions: true,
-    person_profiles: 'always',
+    capture_pageview: 'history_change',
+    person_profiles: 'identified_only',
     session_recording: {
       maskAllInputs: true,
       maskTextSelector: '.ph-no-capture',

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -2,24 +2,14 @@ import { posthog } from 'posthog-js';
 
 import { getAnonUserId } from '@/lib/user';
 
-// PostHog browser init. Next.js runs this client-side before hydration, so the
-// first $pageview is captured early and no SSR guard is needed.
-//
-// Exception capture is intentionally ON — errors are surfaced to PostHog across
-// all apps per project decision. The conversation transcript and composer carry
-// `.ph-no-capture`, which masks them in session replay; maskAllInputs provides
-// an additional replay-layer mask so prompt/answer text is never recorded.
 const key = process.env['NEXT_PUBLIC_POSTHOG_KEY'];
 
 if (key !== undefined && key.length > 0) {
-  // Reuse the existing anonymous id so the browser person matches server-side feedback.
-  // Falls back to undefined when storage is blocked (strict privacy mode, etc.) and
-  // PostHog generates its own distinct id instead.
   let distinctId: string | undefined;
   try {
     distinctId = getAnonUserId();
   } catch {
-    // falls back to PostHog generating its own id
+    // storage blocked
   }
 
   /* eslint-disable camelcase -- PostHog SDK option names are snake_case. */

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -19,7 +19,7 @@ if (key !== undefined && key.length > 0) {
   try {
     distinctId = getAnonUserId();
   } catch {
-    // storage unavailable — PostHog will fall back to its own id
+    // falls back to PostHog generating its own id
   }
 
   /* eslint-disable camelcase -- PostHog SDK option names are snake_case. */

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -5,10 +5,10 @@ import { getAnonUserId } from '@/lib/user';
 // PostHog browser init. Next.js runs this client-side before hydration, so the
 // first $pageview is captured early and no SSR guard is needed.
 //
-// Residency: this is the chat surface, where sovereign Macedonian prompt/answer
-// text renders. Error autocapture is OFF (an exception message/stack can embed the
-// prompt), and the conversation transcript + composer carry `.ph-no-capture`, which
-// masks them in session replay AND suppresses autocapture of their text.
+// Exception capture is intentionally ON — errors are surfaced to PostHog across
+// all apps per project decision. The conversation transcript and composer carry
+// `.ph-no-capture`, which masks them in session replay; maskAllInputs provides
+// an additional replay-layer mask so prompt/answer text is never recorded.
 const key = process.env['NEXT_PUBLIC_POSTHOG_KEY'];
 
 if (key !== undefined && key.length > 0) {
@@ -20,7 +20,7 @@ if (key !== undefined && key.length > 0) {
     // Reuse the existing anonymous id (the feedback endpoint stores the same one),
     // so the browser person matches server-side feedback. Never call identify().
     bootstrap: { distinctID: getAnonUserId() },
-    capture_exceptions: false,
+    capture_exceptions: true,
     person_profiles: 'always',
     session_recording: {
       maskAllInputs: true,

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -12,14 +12,23 @@ import { getAnonUserId } from '@/lib/user';
 const key = process.env['NEXT_PUBLIC_POSTHOG_KEY'];
 
 if (key !== undefined && key.length > 0) {
+  // Reuse the existing anonymous id so the browser person matches server-side feedback.
+  // Falls back to undefined when storage is blocked (strict privacy mode, etc.) and
+  // PostHog generates its own distinct id instead.
+  let distinctId: string | undefined;
+  try {
+    distinctId = getAnonUserId();
+  } catch {
+    // storage unavailable — PostHog will fall back to its own id
+  }
+
   /* eslint-disable camelcase -- PostHog SDK option names are snake_case. */
   posthog.init(key, {
     api_host:
       process.env['NEXT_PUBLIC_POSTHOG_HOST'] ?? 'https://eu.i.posthog.com',
     autocapture: true,
-    // Reuse the existing anonymous id (the feedback endpoint stores the same one),
-    // so the browser person matches server-side feedback. Never call identify().
-    bootstrap: { distinctID: getAnonUserId() },
+    bootstrap:
+      distinctId === undefined ? undefined : { distinctID: distinctId },
     capture_exceptions: true,
     person_profiles: 'always',
     session_recording: {

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -1,0 +1,31 @@
+import { posthog } from 'posthog-js';
+
+import { getAnonUserId } from '@/lib/user';
+
+// PostHog browser init. Next.js runs this client-side before hydration, so the
+// first $pageview is captured early and no SSR guard is needed.
+//
+// Residency: this is the chat surface, where sovereign Macedonian prompt/answer
+// text renders. Error autocapture is OFF (an exception message/stack can embed the
+// prompt), and the conversation transcript + composer carry `.ph-no-capture`, which
+// masks them in session replay AND suppresses autocapture of their text.
+const key = process.env['NEXT_PUBLIC_POSTHOG_KEY'];
+
+if (key !== undefined && key.length > 0) {
+  /* eslint-disable camelcase -- PostHog SDK option names are snake_case. */
+  posthog.init(key, {
+    api_host:
+      process.env['NEXT_PUBLIC_POSTHOG_HOST'] ?? 'https://eu.i.posthog.com',
+    autocapture: true,
+    // Reuse the existing anonymous id (the feedback endpoint stores the same one),
+    // so the browser person matches server-side feedback. Never call identify().
+    bootstrap: { distinctID: getAnonUserId() },
+    capture_exceptions: false,
+    person_profiles: 'always',
+    session_recording: {
+      maskAllInputs: true,
+      maskTextSelector: '.ph-no-capture',
+    },
+  });
+  /* eslint-enable camelcase -- end of PostHog snake_case options. */
+}

--- a/web/lib/conversation-actions.tsx
+++ b/web/lib/conversation-actions.tsx
@@ -2,6 +2,8 @@
 
 import type { ReactNode } from 'react';
 
+import { posthog } from 'posthog-js';
+
 import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
 
 import { AnswerActions } from '@/components/chat/answer-actions';
@@ -48,6 +50,13 @@ export const renderAnswerActions =
           disabled
             ? undefined
             : () => {
+                /* eslint-disable camelcase -- PostHog event properties are snake_case. */
+                posthog.capture('chat_regenerated', {
+                  inference_model: message.metadata?.inferenceModel,
+                  message_index: messages.indexOf(message),
+                  response_id: message.metadata?.responseId,
+                });
+                /* eslint-enable camelcase -- end of PostHog snake_case properties. */
                 regenerate({ messageId: message.id });
               }
         }

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -271,9 +271,6 @@ export const useConversations = (
     [setMessages],
   );
 
-  // Wrap the SDK stop so we can fire the quality-signal event before aborting.
-  // Uses `model` (current selection) because inferenceModel metadata is only
-  // stamped on finish — it is never present during an in-flight stream.
   const handleStop = useCallback(() => {
     /* eslint-disable camelcase -- PostHog event properties are snake_case. */
     posthog.capture('chat_stopped', {

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
+import { posthog } from 'posthog-js';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
 import type { ErrorNotice, FeedbackType, MyUIMessage } from '@/lib/api-types';
@@ -270,6 +271,18 @@ export const useConversations = (
     [setMessages],
   );
 
+  // Wrap the SDK stop so we can fire the quality-signal event before aborting.
+  // Uses `model` (current selection) because inferenceModel metadata is only
+  // stamped on finish — it is never present during an in-flight stream.
+  const handleStop = useCallback(() => {
+    /* eslint-disable camelcase -- PostHog event properties are snake_case. */
+    posthog.capture('chat_stopped', {
+      inference_model: model,
+    });
+    /* eslint-enable camelcase -- end of PostHog snake_case properties. */
+    void stop();
+  }, [model, stop]);
+
   const visibleMessages = previewRegeneration(messages, regeneratingMessageId);
   const renderActions = renderAnswerActions({
     disabled,
@@ -290,7 +303,7 @@ export const useConversations = (
     onNewChat: handleNewChat,
     onRename: handleRename,
     onSelect: handleSelect,
-    onStop: stop,
+    onStop: handleStop,
     renderActions,
     retry,
     status,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,6 +23,7 @@
         "lucide-react": "^1.21.0",
         "nanoid": "^5.1.16",
         "next": "^16.2.9",
+        "posthog-js": "^1.395.0",
         "radix-ui": "^1.6.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -2020,6 +2021,21 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.38.0.tgz",
+      "integrity": "sha512-QLrJh0hMVpEJXHNyiJR9YhvIO5tzLDedw4UHdvB+ub4fXHMtHCA8H44qgl11HWR3ajpjxtJ8hs3HyOGVF3Zc1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.391.1"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.391.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.391.1.tgz",
+      "integrity": "sha512-ASwd7Nf4pViqdYRYaNRyPYRVKWa1CcHUAUWR0XeQJLGdNnsWACBwe0sSieb/cHnKsRXjRwO/23KIY83lm/Ccpw==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.2",
@@ -6435,6 +6451,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
@@ -8800,6 +8827,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -12770,6 +12803,32 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.395.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.395.0.tgz",
+      "integrity": "sha512-5iTb00CGt2eQUUiBQysQiX89RAbCN6wK2sDNzvs9zv0alaY8mJ0ZySrUD3LQ+XyLhgM5pCpacBuUwChqiYDLDw==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@posthog/core": "^1.38.0",
+        "@posthog/types": "^1.391.1",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.3.tgz",
+      "integrity": "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -12860,6 +12919,12 @@
           "url": "https://github.com/sponsors/sxzz"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -15277,6 +15342,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
     "lucide-react": "^1.21.0",
     "nanoid": "^5.1.16",
     "next": "^16.2.9",
+    "posthog-js": "^1.395.0",
     "radix-ui": "^1.6.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",


### PR DESCRIPTION
Instruments the chat web app with PostHog (EU Cloud) via `posthog-js`.

- Client-side init in `instrumentation-client.ts` (pre-hydration), reusing the existing anon id so the browser person matches server feedback; no `identify()`.
- `PostHogProvider` in `app/providers.tsx`; `posthog-js` dependency.
- **Residency:** `capture_exceptions:true` (intentional — per fleet-wide project decision; browser errors carry no sovereign text). `.ph-no-capture` on the conversation transcript + composer textarea masks session replay AND autocapture text, so prompt/answer text never reaches PostHog.
- `NEXT_PUBLIC_POSTHOG_*` build-args in the Dockerfile (public ingest key).
- Session replay enabled at 10% sampling (set in the PostHog project).

Verified: tsc clean, production build passes, lint 0 errors. Part of the fleet-wide PostHog rollout.
