### PR TITLE
feat(api): add PostHog analytics (api + gpu-api)

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -4,3 +4,5 @@ sonar.projectKey=finki-hub-chat-bot
 sonar.sources=.
 sonar.python.version=3.14
 sonar.exclusions=web/components/ui/**,web/components/ai-elements/**
+# Parallel telemetry boilerplate for two independently-deployed services (separate Docker build contexts preclude sharing).
+sonar.cpd.exclusions=api/app/utils/posthog_client.py,gpu-api/app/utils/analytics.py

--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -102,15 +102,26 @@ def _is_answer_chunk(event_name: str, chunk: bytes | str | memoryview) -> bool:
     return event_name == "" and bool(chunk)
 
 
+_META_PREFIX = "event: meta"
+_META_PREFIX_BYTES = _META_PREFIX.encode()
+
+
 def _sniff_tokens(chunk: bytes | str | memoryview) -> dict[str, int] | None:
     """Token counts from a trailing ``meta`` frame's ``{"tokens": ...}`` data line, or None.
 
-    Only the token-count meta frame ``agents.py`` emits is parsed; ``token``/``thinking``
-    frames carry the answer text and are never inspected, so no answer text is read.
+    A cheap leading-prefix check runs first, so the per-chunk hot path (``token`` frames,
+    and the GPU-API's bare ``data:`` frames) returns without copying the whole chunk. Only
+    the token-count meta frame ``agents.py`` emits is then parsed; the answer text in
+    ``token``/``thinking`` frames is never inspected.
     """
-    if _sse_event_name(chunk) != "meta":
-        return None
-    text = chunk if isinstance(chunk, str) else bytes(chunk).decode(errors="ignore")
+    if isinstance(chunk, str):
+        if not chunk.startswith(_META_PREFIX):
+            return None
+        text = chunk
+    else:
+        if bytes(chunk[: len(_META_PREFIX_BYTES)]) != _META_PREFIX_BYTES:
+            return None
+        text = bytes(chunk).decode(errors="ignore")
     for line in text.split("\n"):
         if not line.startswith("data:"):
             continue

--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Request, status
 from fastapi.responses import StreamingResponse
 
 from app.data.connection import Database
@@ -16,6 +16,7 @@ from app.llms.chat import handle_chat
 from app.llms.context import get_links_context, get_retrieved_context
 from app.llms.models import CHAT_MODELS
 from app.schemas.chat import ChatSchema
+from app.utils.posthog_client import capture
 from app.utils.settings import Settings
 from app.utils.timing import (
     RequestTimings,
@@ -72,6 +73,60 @@ def _sse_event_name(chunk: bytes | str | memoryview) -> str:
     return ""
 
 
+def _sniff_tokens(chunk: bytes | str | memoryview) -> dict[str, int] | None:
+    """Token counts from a trailing ``meta`` frame's ``{"tokens": ...}`` data line, or None.
+
+    Only the token-count meta frame ``agents.py`` emits is parsed; ``token``/``thinking``
+    frames carry the answer text and are never inspected, so no answer text is read.
+    """
+    if _sse_event_name(chunk) != "meta":
+        return None
+    text = chunk if isinstance(chunk, str) else bytes(chunk).decode(errors="ignore")
+    for line in text.split("\n"):
+        if not line.startswith("data:"):
+            continue
+        try:
+            data = json.loads(line[len("data:") :].strip())
+        except json.JSONDecodeError:
+            return None
+        tokens = data.get("tokens") if isinstance(data, dict) else None
+        if isinstance(tokens, dict):
+            return {
+                "input": int(tokens.get("input", 0) or 0),
+                "output": int(tokens.get("output", 0) or 0),
+            }
+    return None
+
+
+def _capture_chat_response(
+    *,
+    distinct_id: str,
+    payload: ChatSchema,
+    response_id: UUID,
+    timings: RequestTimings,
+    retrieval_hit: bool,
+    usage: dict[str, int] | None,
+    outcome: str,
+) -> None:
+    """Emit the PostHog AI-observability event for a finished stream (metadata only)."""
+    props: dict[str, object] = {
+        "$ai_model": payload.inference_model.value,
+        "$ai_latency": (
+            timings.total_ms / 1000.0 if timings.total_ms is not None else None
+        ),
+        "response_id": str(response_id),
+        "retrieval_hit": retrieval_hit,
+        "ttft_ms": timings.ttft_ms,
+        "candidate_count": timings.candidate_count,
+        "top_distance": timings.top_distance,
+        "outcome": outcome,
+    }
+    if usage is not None:
+        props["$ai_input_tokens"] = usage["input"]
+        props["$ai_output_tokens"] = usage["output"]
+    capture(distinct_id, "$ai_generation", props)
+
+
 async def _instrument_stream(
     body: AsyncIterable[bytes | str | memoryview],
     *,
@@ -79,6 +134,7 @@ async def _instrument_stream(
     response_id: UUID,
     timings: RequestTimings,
     retrieval_hit: bool,
+    distinct_id: str,
 ) -> AsyncGenerator[bytes | str | memoryview]:
     """Pass the SSE body through untouched, stamping TTFT, thinking and total, then
     log one chat.timing line and emit a trailing ``meta`` frame with the same breakdown.
@@ -90,6 +146,8 @@ async def _instrument_stream(
     body drains); consumers that stop at ``done`` ignore it and the protocol-v2 parsers
     drop unknown events, so it stays backward compatible.
     """
+    outcome = "completed"
+    usage: dict[str, int] | None = None
     try:
         marking = True
         async for chunk in body:
@@ -101,7 +159,17 @@ async def _instrument_stream(
                 elif event_name == "token":
                     timings.mark_answer()
                     marking = False
+            sniffed = _sniff_tokens(chunk)
+            if sniffed is not None:
+                usage = sniffed
             yield chunk
+    except GeneratorExit:
+        # The client hung up mid-stream; record the partial run before unwinding.
+        outcome = "client_disconnect"
+        raise
+    except asyncio.CancelledError:
+        outcome = "client_disconnect"
+        raise
     finally:
         timings.mark_total()
         record = timings.as_record()
@@ -117,6 +185,15 @@ async def _instrument_stream(
                     **record,
                 },
             ),
+        )
+        _capture_chat_response(
+            distinct_id=distinct_id,
+            payload=payload,
+            response_id=response_id,
+            timings=timings,
+            retrieval_hit=retrieval_hit,
+            usage=usage,
+            outcome=outcome,
         )
     yield meta_event({"timing": record})
 
@@ -157,6 +234,7 @@ router = APIRouter(
 )
 async def chat(
     payload: ChatSchema,
+    request: Request,
     db: Database = db_dep,
 ) -> StreamingResponse:
     logger.info(
@@ -168,6 +246,27 @@ async def chat(
 
     timings, token = start_request_timings()
     try:
+        # Minted before retrieval so it can tag chat_request + retrieval_miss and still
+        # back the X-Response-Id header below.
+        response_id = uuid4()
+        # Prefer the caller's anonymous id (browser) so events stitch into one person;
+        # fall back to the response id for un-identified callers (e.g. Discord).
+        distinct_id = request.headers.get("X-Distinct-Id") or str(response_id)
+        capture(
+            distinct_id,
+            "chat_request",
+            {
+                "inference_model": payload.inference_model.value,
+                "embeddings_model": payload.embeddings_model.value,
+                "query_transform_model": payload.query_transform_model.value,
+                "reasoning": payload.reasoning,
+                "temperature": payload.temperature,
+                "max_tokens": payload.max_tokens,
+                "query_len": len(payload.query),
+                "history_turns": len(payload.history),
+            },
+        )
+
         retrieved, links_context = await asyncio.gather(
             get_retrieved_context(
                 db=db,
@@ -180,6 +279,18 @@ async def chat(
         )
 
         if not retrieved:
+            capture(
+                distinct_id,
+                "retrieval_miss",
+                {
+                    "response_id": str(response_id),
+                    "embeddings_model": payload.embeddings_model.value,
+                    "query_transform_model": payload.query_transform_model.value,
+                    "candidate_count": timings.candidate_count,
+                    "top_distance": timings.top_distance,
+                    "query_len": len(payload.query),
+                },
+            )
             # On a miss, leave the bare "nothing found" context alone so the prompt's
             # tool-search directive isn't diluted by the links catalog.
             context = (
@@ -193,7 +304,6 @@ async def chat(
         today = datetime.now(tz=_TZ).strftime("%d.%m.%Y")
         context = f"Денешен датум: {today}.\n\n{context}"
 
-        response_id = uuid4()
         with timed("agent.setup"):
             response = await handle_chat(payload, context)
 
@@ -203,6 +313,7 @@ async def chat(
             response_id=response_id,
             timings=timings,
             retrieval_hit=bool(retrieved),
+            distinct_id=distinct_id,
         )
 
         # Set the header on the StreamingResponse returned by handle_chat: Starlette

--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -58,14 +58,10 @@ def _history_for_retrieval(payload: ChatSchema) -> str | None:
     )
 
 
-# X-Distinct-Id is an untrusted client header used verbatim as the PostHog person id.
-# Bound it to a short, opaque token (UUIDs, Discord snowflakes and PostHog anon ids all
-# fit) so a caller can't inject PII, smuggle free text, or explode person cardinality.
 _DISTINCT_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
 
 
 def _safe_distinct_id(raw: str | None, fallback: str) -> str:
-    """The caller-supplied analytics id if it's a short opaque token, else ``fallback``."""
     if raw is None:
         return fallback
     candidate = raw.strip()
@@ -92,11 +88,6 @@ def _sse_event_name(chunk: bytes | str | memoryview) -> str:
 
 
 def _is_answer_chunk(event_name: str, chunk: bytes | str | memoryview) -> bool:
-    """Whether ``chunk`` carries answer text: a protocol ``token`` frame, or the bare
-    ``data:`` frame the GPU-API path streams (which has no ``event:`` line). Control frames
-    (thinking/status/reset/error/done/meta all name their event) never count, so a run that
-    only ever reasons or errors out is correctly seen as having produced no answer.
-    """
     if event_name == "token":
         return True
     return event_name == "" and bool(chunk)
@@ -107,13 +98,6 @@ _META_PREFIX_BYTES = _META_PREFIX.encode()
 
 
 def _sniff_tokens(chunk: bytes | str | memoryview) -> dict[str, int] | None:
-    """Token counts from a trailing ``meta`` frame's ``{"tokens": ...}`` data line, or None.
-
-    A cheap leading-prefix check runs first, so the per-chunk hot path (``token`` frames,
-    and the GPU-API's bare ``data:`` frames) returns without copying the whole chunk. Only
-    the token-count meta frame ``agents.py`` emits is then parsed; the answer text in
-    ``token``/``thinking`` frames is never inspected.
-    """
     if isinstance(chunk, str):
         if not chunk.startswith(_META_PREFIX):
             return None
@@ -148,7 +132,6 @@ def _capture_chat_response(
     usage: dict[str, int] | None,
     outcome: str,
 ) -> None:
-    """Emit the PostHog AI-observability event for a finished stream (metadata only)."""
     props: dict[str, object] = {
         "$ai_model": payload.inference_model.value,
         "$ai_latency": (
@@ -186,11 +169,6 @@ async def _instrument_stream(
     The ``meta`` frame trails the body's ``done`` (``total_ms`` is known only once the
     body drains); consumers that stop at ``done`` ignore it and the protocol-v2 parsers
     drop unknown events, so it stays backward compatible.
-
-    The outcome is ``completed`` on a normal run, ``client_disconnect`` if the client hung
-    up, or ``empty_answer`` when the stream drained without ever producing an answer frame
-    (the gpt-5-mini/nano failure class). Token usage prefers the real provider counts the
-    agent generator folds into ``observation.usage`` and falls back to the meta-frame sniff.
     """
     outcome = "completed"
     usage: dict[str, int] | None = None
@@ -214,7 +192,6 @@ async def _instrument_stream(
                 usage = sniffed
             yield chunk
     except GeneratorExit:
-        # The client hung up mid-stream; record the partial run before unwinding.
         outcome = "client_disconnect"
         raise
     except asyncio.CancelledError:
@@ -299,17 +276,11 @@ async def chat(
 
     timings, token = start_request_timings()
     try:
-        # Minted before retrieval so it can tag chat_request + retrieval_miss and still
-        # back the X-Response-Id header below.
         response_id = uuid4()
-        # Prefer the caller's anonymous id (browser) so events stitch into one person;
-        # fall back to the response id for un-identified or malformed callers (e.g. Discord).
         distinct_id = _safe_distinct_id(
             request.headers.get("X-Distinct-Id"),
             str(response_id),
         )
-        # Threaded into the generator so token usage, tool calls, provider errors and
-        # fallbacks are reported against this request (metadata only).
         observation = StreamObservation(
             distinct_id=distinct_id,
             response_id=str(response_id),
@@ -328,8 +299,6 @@ async def chat(
                 "history_turns": len(payload.history),
             },
         )
-        # Server-side, residency-safe classification: only the topic label leaves, never
-        # the raw query text.
         capture(
             distinct_id,
             "query_classified",
@@ -372,7 +341,6 @@ async def chat(
             context = retrieved
             if links_context:
                 context = f"{retrieved}\n\n{links_context}"
-            # Which corpus entries actually backed the answer (ids only, never text).
             if timings.retrieval_ids:
                 capture(
                     distinct_id,
@@ -403,7 +371,6 @@ async def chat(
 
         # Set the header on the StreamingResponse returned by handle_chat: Starlette
         # serializes headers only when the body starts streaming, so this lands first.
-        # Done at the one chokepoint because the default agent path skips the SSE wrapper.
         response.headers["X-Response-Id"] = str(response_id)
         return response
     finally:

--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -11,7 +11,7 @@ from fastapi.responses import StreamingResponse
 
 from app.data.connection import Database
 from app.data.db import get_db
-from app.llms.agents import meta_event
+from app.llms.agents import StreamObservation, meta_event
 from app.llms.chat import handle_chat
 from app.llms.context import get_links_context, get_retrieved_context
 from app.llms.models import CHAT_MODELS
@@ -24,6 +24,7 @@ from app.utils.timing import (
     start_request_timings,
     timed,
 )
+from app.utils.topic import classify_topic
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +72,17 @@ def _sse_event_name(chunk: bytes | str | memoryview) -> str:
     if first_line.startswith("event:"):
         return first_line[len("event:") :].strip()
     return ""
+
+
+def _is_answer_chunk(event_name: str, chunk: bytes | str | memoryview) -> bool:
+    """Whether ``chunk`` carries answer text: a protocol ``token`` frame, or the bare
+    ``data:`` frame the GPU-API path streams (which has no ``event:`` line). Control frames
+    (thinking/status/reset/error/done/meta all name their event) never count, so a run that
+    only ever reasons or errors out is correctly seen as having produced no answer.
+    """
+    if event_name == "token":
+        return True
+    return event_name == "" and bool(chunk)
 
 
 def _sniff_tokens(chunk: bytes | str | memoryview) -> dict[str, int] | None:
@@ -135,6 +147,7 @@ async def _instrument_stream(
     timings: RequestTimings,
     retrieval_hit: bool,
     distinct_id: str,
+    observation: StreamObservation,
 ) -> AsyncGenerator[bytes | str | memoryview]:
     """Pass the SSE body through untouched, stamping TTFT, thinking and total, then
     log one chat.timing line and emit a trailing ``meta`` frame with the same breakdown.
@@ -145,20 +158,29 @@ async def _instrument_stream(
     The ``meta`` frame trails the body's ``done`` (``total_ms`` is known only once the
     body drains); consumers that stop at ``done`` ignore it and the protocol-v2 parsers
     drop unknown events, so it stays backward compatible.
+
+    The outcome is ``completed`` on a normal run, ``client_disconnect`` if the client hung
+    up, or ``empty_answer`` when the stream drained without ever producing an answer frame
+    (the gpt-5-mini/nano failure class). Token usage prefers the real provider counts the
+    agent generator folds into ``observation.usage`` and falls back to the meta-frame sniff.
     """
     outcome = "completed"
     usage: dict[str, int] | None = None
+    marking = True
+    answered = False
     try:
-        marking = True
         async for chunk in body:
             timings.mark_ttft()
-            if marking:
+            if marking or not answered:
                 event_name = _sse_event_name(chunk)
-                if event_name == "thinking":
-                    timings.mark_thinking()
-                elif event_name == "token":
-                    timings.mark_answer()
-                    marking = False
+                if marking:
+                    if event_name == "thinking":
+                        timings.mark_thinking()
+                    elif event_name == "token":
+                        timings.mark_answer()
+                        marking = False
+                if not answered and _is_answer_chunk(event_name, chunk):
+                    answered = True
             sniffed = _sniff_tokens(chunk)
             if sniffed is not None:
                 usage = sniffed
@@ -173,6 +195,8 @@ async def _instrument_stream(
     finally:
         timings.mark_total()
         record = timings.as_record()
+        if outcome == "completed" and not answered:
+            outcome = "empty_answer"
         logger.info(
             "chat.timing %s",
             json.dumps(
@@ -182,6 +206,7 @@ async def _instrument_stream(
                     "embeddings_model": payload.embeddings_model.value,
                     "query_transform_model": payload.query_transform_model.value,
                     "retrieval_hit": retrieval_hit,
+                    "outcome": outcome,
                     **record,
                 },
             ),
@@ -192,7 +217,7 @@ async def _instrument_stream(
             response_id=response_id,
             timings=timings,
             retrieval_hit=retrieval_hit,
-            usage=usage,
+            usage=observation.usage if any(observation.usage.values()) else usage,
             outcome=outcome,
         )
     yield meta_event({"timing": record})
@@ -252,6 +277,12 @@ async def chat(
         # Prefer the caller's anonymous id (browser) so events stitch into one person;
         # fall back to the response id for un-identified callers (e.g. Discord).
         distinct_id = request.headers.get("X-Distinct-Id") or str(response_id)
+        # Threaded into the generator so token usage, tool calls, provider errors and
+        # fallbacks are reported against this request (metadata only).
+        observation = StreamObservation(
+            distinct_id=distinct_id,
+            response_id=str(response_id),
+        )
         capture(
             distinct_id,
             "chat_request",
@@ -264,6 +295,16 @@ async def chat(
                 "max_tokens": payload.max_tokens,
                 "query_len": len(payload.query),
                 "history_turns": len(payload.history),
+            },
+        )
+        # Server-side, residency-safe classification: only the topic label leaves, never
+        # the raw query text.
+        capture(
+            distinct_id,
+            "query_classified",
+            {
+                "response_id": str(response_id),
+                "topic": classify_topic(payload.query),
             },
         )
 
@@ -300,12 +341,24 @@ async def chat(
             context = retrieved
             if links_context:
                 context = f"{retrieved}\n\n{links_context}"
+            # Which corpus entries actually backed the answer (ids only, never text).
+            if timings.retrieval_ids:
+                capture(
+                    distinct_id,
+                    "retrieval_used",
+                    {
+                        "response_id": str(response_id),
+                        "embeddings_model": payload.embeddings_model.value,
+                        "retrieval_ids": timings.retrieval_ids,
+                        "retrieval_count": len(timings.retrieval_ids),
+                    },
+                )
 
         today = datetime.now(tz=_TZ).strftime("%d.%m.%Y")
         context = f"Денешен датум: {today}.\n\n{context}"
 
         with timed("agent.setup"):
-            response = await handle_chat(payload, context)
+            response = await handle_chat(payload, context, observation)
 
         response.body_iterator = _instrument_stream(
             response.body_iterator,
@@ -314,6 +367,7 @@ async def chat(
             timings=timings,
             retrieval_hit=bool(retrieved),
             distinct_id=distinct_id,
+            observation=observation,
         )
 
         # Set the header on the StreamingResponse returned by handle_chat: Starlette

--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import re
 from collections.abc import AsyncGenerator, AsyncIterable
 from datetime import datetime
 from uuid import UUID, uuid4
@@ -18,7 +17,7 @@ from app.llms.context import get_links_context, get_retrieved_context
 from app.llms.models import CHAT_MODELS
 from app.llms.pricing import cost_usd, is_self_hosted
 from app.schemas.chat import ChatSchema
-from app.utils.posthog_client import capture
+from app.utils.posthog_client import capture, safe_distinct_id
 from app.utils.settings import Settings
 from app.utils.timing import (
     RequestTimings,
@@ -57,18 +56,6 @@ def _history_for_retrieval(payload: ChatSchema) -> str | None:
         f"{'Корисник' if t.role == 'user' else 'Асистент'}: {_clip(t.content)}"
         for t in turns
     )
-
-
-_DISTINCT_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
-
-
-def _safe_distinct_id(raw: str | None, fallback: str) -> str:
-    if raw is None:
-        return fallback
-    candidate = raw.strip()
-    if _DISTINCT_ID_RE.fullmatch(candidate):
-        return candidate
-    return fallback
 
 
 def _sse_event_name(chunk: bytes | str | memoryview) -> str:
@@ -345,7 +332,7 @@ async def chat(
     timings, token = start_request_timings()
     try:
         response_id = uuid4()
-        distinct_id = _safe_distinct_id(
+        distinct_id = safe_distinct_id(
             request.headers.get("X-Distinct-Id"),
             str(response_id),
         )

--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -16,6 +16,7 @@ from app.llms.agents import StreamObservation, meta_event
 from app.llms.chat import handle_chat
 from app.llms.context import get_links_context, get_retrieved_context
 from app.llms.models import CHAT_MODELS
+from app.llms.pricing import cost_usd, is_self_hosted
 from app.schemas.chat import ChatSchema
 from app.utils.posthog_client import capture
 from app.utils.settings import Settings
@@ -25,7 +26,7 @@ from app.utils.timing import (
     start_request_timings,
     timed,
 )
-from app.utils.topic import classify_topic
+from app.utils.topic import classify_language, classify_topic
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +123,19 @@ def _sniff_tokens(chunk: bytes | str | memoryview) -> dict[str, int] | None:
     return None
 
 
+def _ms(value: float | None) -> float | None:
+    return round(value, 1) if value is not None else None
+
+
+_WEB_SEARCH_HINTS = ("web_search", "web-search", "websearch", "search_web", "tavily")
+
+
+def _used_web_search(tool_names: set[str]) -> bool:
+    return any(
+        hint in name.lower() for name in tool_names for hint in _WEB_SEARCH_HINTS
+    )
+
+
 def _capture_chat_response(
     *,
     distinct_id: str,
@@ -131,22 +145,75 @@ def _capture_chat_response(
     retrieval_hit: bool,
     usage: dict[str, int] | None,
     outcome: str,
+    observation: StreamObservation,
 ) -> None:
+    model = payload.inference_model
+    generation_ms: float | None = None
+    if timings.total_ms is not None and timings.ttft_ms is not None:
+        generation_ms = max(timings.total_ms - timings.ttft_ms, 0.0)
+
     props: dict[str, object] = {
-        "$ai_model": payload.inference_model.value,
+        "$ai_model": model.value,
+        "$ai_provider": observation.provider or None,
+        "provider": observation.provider or None,
+        "is_self_hosted": is_self_hosted(model),
         "$ai_latency": (
             timings.total_ms / 1000.0 if timings.total_ms is not None else None
         ),
         "response_id": str(response_id),
         "retrieval_hit": retrieval_hit,
-        "ttft_ms": timings.ttft_ms,
+        "outcome": outcome,
+        "language": classify_language(payload.query),
+        "ttft_ms": _ms(timings.ttft_ms),
+        "thinking_ms": _ms(timings.thinking_ms),
+        "llm_generation_ms": _ms(generation_ms),
+        "embedding_ms": _ms(timings.spans.get("retrieval.embed")),
+        "retrieval_ms": _ms(timings.spans.get("retrieval.vector_search")),
+        "rerank_ms": _ms(timings.spans.get("retrieval.rerank")),
+        "query_transform_ms": _ms(timings.spans.get("retrieval.rewrite_hyde")),
         "candidate_count": timings.candidate_count,
         "top_distance": timings.top_distance,
-        "outcome": outcome,
+        "context_char_len": observation.context_chars,
+        "context_chunk_count": len(timings.retrieval_ids),
+        "answer_char_len": observation.answer_chars,
+        "tool_call_count": observation.tool_call_count,
+        "used_web_search": _used_web_search(observation.tool_names),
     }
+
+    if observation.finish_reason:
+        props["finish_reason"] = observation.finish_reason
+        props["truncated"] = observation.finish_reason == "length"
+
+    if timings.reranker_score_max is not None:
+        props["reranker_score_max"] = round(timings.reranker_score_max, 4)
+        props["reranker_score_min"] = round(timings.reranker_score_min or 0.0, 4)
+        props["chunks_above_threshold"] = timings.reranker_above_threshold
+
     if usage is not None:
-        props["$ai_input_tokens"] = usage["input"]
-        props["$ai_output_tokens"] = usage["output"]
+        input_tokens = usage["input"]
+        output_tokens = usage["output"]
+        props["$ai_input_tokens"] = input_tokens
+        props["$ai_output_tokens"] = output_tokens
+        if usage.get("cache_read"):
+            props["$ai_cache_read_input_tokens"] = usage["cache_read"]
+        if usage.get("reasoning"):
+            props["$ai_reasoning_tokens"] = usage["reasoning"]
+        if generation_ms and output_tokens:
+            props["output_tokens_per_sec"] = round(
+                output_tokens / (generation_ms / 1000.0),
+                1,
+            )
+        costs = cost_usd(model, input_tokens, output_tokens)
+        if costs is not None:
+            props["$ai_input_cost_usd"] = round(costs[0], 6)
+            props["$ai_output_cost_usd"] = round(costs[1], 6)
+            props["$ai_total_cost_usd"] = round(costs[2], 6)
+            props["cost_known"] = True
+        else:
+            props["cost_known"] = False
+    else:
+        props["cost_known"] = False
+
     capture(distinct_id, "$ai_generation", props)
 
 
@@ -224,6 +291,7 @@ async def _instrument_stream(
             retrieval_hit=retrieval_hit,
             usage=observation.usage if any(observation.usage.values()) else usage,
             outcome=outcome,
+            observation=observation,
         )
     yield meta_event({"timing": record})
 
@@ -339,6 +407,7 @@ async def chat(
             )
         else:
             context = retrieved
+            observation.context_chars = len(retrieved)
             if links_context:
                 context = f"{retrieved}\n\n{links_context}"
             if timings.retrieval_ids:

--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -21,6 +21,7 @@ from app.utils.posthog_client import capture, safe_distinct_id
 from app.utils.settings import Settings
 from app.utils.timing import (
     RequestTimings,
+    record_distinct_id,
     record_response_id,
     reset_request_timings,
     start_request_timings,
@@ -339,6 +340,7 @@ async def chat(
             request.headers.get("X-Distinct-Id"),
             str(response_id),
         )
+        record_distinct_id(distinct_id)
         observation = StreamObservation(
             distinct_id=distinct_id,
             response_id=str(response_id),

--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import re
 from collections.abc import AsyncGenerator, AsyncIterable
 from datetime import datetime
 from uuid import UUID, uuid4
@@ -55,6 +56,22 @@ def _history_for_retrieval(payload: ChatSchema) -> str | None:
         f"{'Корисник' if t.role == 'user' else 'Асистент'}: {_clip(t.content)}"
         for t in turns
     )
+
+
+# X-Distinct-Id is an untrusted client header used verbatim as the PostHog person id.
+# Bound it to a short, opaque token (UUIDs, Discord snowflakes and PostHog anon ids all
+# fit) so a caller can't inject PII, smuggle free text, or explode person cardinality.
+_DISTINCT_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
+
+
+def _safe_distinct_id(raw: str | None, fallback: str) -> str:
+    """The caller-supplied analytics id if it's a short opaque token, else ``fallback``."""
+    if raw is None:
+        return fallback
+    candidate = raw.strip()
+    if _DISTINCT_ID_RE.fullmatch(candidate):
+        return candidate
+    return fallback
 
 
 def _sse_event_name(chunk: bytes | str | memoryview) -> str:
@@ -275,8 +292,11 @@ async def chat(
         # back the X-Response-Id header below.
         response_id = uuid4()
         # Prefer the caller's anonymous id (browser) so events stitch into one person;
-        # fall back to the response id for un-identified callers (e.g. Discord).
-        distinct_id = request.headers.get("X-Distinct-Id") or str(response_id)
+        # fall back to the response id for un-identified or malformed callers (e.g. Discord).
+        distinct_id = _safe_distinct_id(
+            request.headers.get("X-Distinct-Id"),
+            str(response_id),
+        )
         # Threaded into the generator so token usage, tool calls, provider errors and
         # fallbacks are reported against this request (metadata only).
         observation = StreamObservation(

--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -21,6 +21,7 @@ from app.utils.posthog_client import capture, safe_distinct_id
 from app.utils.settings import Settings
 from app.utils.timing import (
     RequestTimings,
+    record_response_id,
     reset_request_timings,
     start_request_timings,
     timed,
@@ -140,6 +141,7 @@ def _capture_chat_response(
         generation_ms = max(timings.total_ms - timings.ttft_ms, 0.0)
 
     props: dict[str, object] = {
+        "$ai_trace_id": str(response_id),
         "$ai_model": model.value,
         "$ai_provider": observation.provider or None,
         "provider": observation.provider or None,
@@ -332,6 +334,7 @@ async def chat(
     timings, token = start_request_timings()
     try:
         response_id = uuid4()
+        record_response_id(str(response_id))
         distinct_id = safe_distinct_id(
             request.headers.get("X-Distinct-Id"),
             str(response_id),

--- a/api/app/api/feedback.py
+++ b/api/app/api/feedback.py
@@ -50,7 +50,6 @@ async def submit_feedback(
             detail="Failed to record feedback",
         )
 
-    # Metadata only: question_text / answer_text are deliberately excluded (residency).
     capture(
         str(payload.user_id),
         "chat_feedback",

--- a/api/app/api/feedback.py
+++ b/api/app/api/feedback.py
@@ -7,6 +7,7 @@ from app.data.db import get_db
 from app.data.feedback import upsert_feedback
 from app.schemas.feedback import FeedbackAckSchema, FeedbackSchema
 from app.utils.auth import verify_api_key
+from app.utils.posthog_client import capture
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,20 @@ async def submit_feedback(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to record feedback",
         )
+
+    # Metadata only: question_text / answer_text are deliberately excluded (residency).
+    capture(
+        str(payload.user_id),
+        "chat_feedback",
+        {
+            "response_id": str(payload.response_id),
+            "client": payload.client,
+            "feedback_type": payload.feedback_type,
+            "inference_model": payload.inference_model,
+            "embeddings_model": payload.embeddings_model,
+            "query_transform_model": payload.query_transform_model,
+        },
+    )
 
     logger.info(
         "Recorded %s feedback from %s for response %s",

--- a/api/app/llms/agents.py
+++ b/api/app/llms/agents.py
@@ -1,11 +1,15 @@
 import asyncio
 import json
 import logging
+import time
 from collections.abc import AsyncGenerator, Generator
+from dataclasses import dataclass, field
 
 from fastapi.responses import StreamingResponse
 from langchain_core.messages import AIMessageChunk, BaseMessage
 from langgraph.graph.state import CompiledStateGraph
+
+from app.utils.posthog_client import capture
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +50,124 @@ def meta_event(payload: dict[str, object]) -> str:
 
 RESET_EVENT = _sse("reset", {})
 DONE_EVENT = _sse("done", {})
+
+
+@dataclass
+class StreamObservation:
+    """Per-request, mutable analytics holder threaded into the agent generator.
+
+    Carries the request ids so per-invocation events (``tool_called``, ``model_error``,
+    ``model_fallback``) group with the rest of the request, and exposes the live token
+    ``usage`` dict by reference so the SSE wrapper reads real provider counts directly
+    instead of sniffing a trailing meta frame. Residency: every field is metadata only.
+    """
+
+    distinct_id: str
+    response_id: str
+    model: str = ""
+    provider: str = ""
+    usage: dict[str, int] = field(
+        default_factory=lambda: {"input": 0, "output": 0, "total": 0},
+    )
+
+
+def _error_status_code(exc: BaseException) -> int | None:
+    """An HTTP status code carried by a provider exception (e.g. 429), if any."""
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status
+    response = getattr(exc, "response", None)
+    code = getattr(response, "status_code", None)
+    return code if isinstance(code, int) else None
+
+
+def _content_len(value: object) -> int:
+    """Character length of a value's text form (a length only — never the text)."""
+    if value is None:
+        return 0
+    if isinstance(value, str):
+        return len(value)
+    content = getattr(value, "content", None)
+    if isinstance(content, str):
+        return len(content)
+    return len(str(value))
+
+
+def _tool_succeeded(output: object) -> bool:
+    """Whether a tool's output indicates success; an error ToolMessage flips it to False."""
+    return getattr(output, "status", None) != "error"
+
+
+def capture_tool_called(
+    observation: StreamObservation | None,
+    *,
+    tool: str,
+    latency_ms: float,
+    success: bool,
+    arg_len: int,
+    result_len: int,
+) -> None:
+    """Record one tool invocation (lengths/timings only — never the tool args/result)."""
+    if observation is None:
+        return
+    capture(
+        observation.distinct_id,
+        "tool_called",
+        {
+            "response_id": observation.response_id,
+            "model": observation.model,
+            "provider": observation.provider,
+            "tool": tool,
+            "latency_ms": round(latency_ms, 1),
+            "success": success,
+            "arg_len": arg_len,
+            "result_len": result_len,
+        },
+    )
+
+
+def capture_model_error(
+    observation: StreamObservation | None,
+    *,
+    error_type: str,
+    status_code: int | None = None,
+) -> None:
+    """Record a failed provider call (metadata only)."""
+    if observation is None:
+        return
+    capture(
+        observation.distinct_id,
+        "model_error",
+        {
+            "response_id": observation.response_id,
+            "model": observation.model,
+            "provider": observation.provider,
+            "error_type": error_type,
+            "status_code": status_code,
+        },
+    )
+
+
+def capture_model_fallback(
+    observation: StreamObservation | None,
+    *,
+    from_model: str,
+    to_model: str,
+    reason: str,
+) -> None:
+    """Record a switch to a different model/path (metadata only)."""
+    if observation is None:
+        return
+    capture(
+        observation.distinct_id,
+        "model_fallback",
+        {
+            "response_id": observation.response_id,
+            "from_model": from_model,
+            "to_model": to_model,
+            "reason": reason,
+        },
+    )
 
 
 def stream_sync_gen_as_sse(gen: Generator[str]) -> StreamingResponse:
@@ -152,29 +274,65 @@ def _accumulate_usage(usage: dict[str, int], output: object) -> None:
 async def create_agent_token_generator(
     agent: CompiledStateGraph,
     messages: list[BaseMessage],
+    observation: StreamObservation | None = None,
 ) -> AsyncGenerator[str]:
     """Stream an agent run as SSE, mapping `astream_events` onto the protocol: each
     `on_tool_start` becomes a `status`, and a `reset` precedes the answer so any
-    pre-tool preamble is dropped."""
+    pre-tool preamble is dropped.
+
+    When an `observation` is supplied, real token usage is folded into its shared `usage`
+    dict (read by the SSE wrapper), each tool call is recorded as a `tool_called` event,
+    and a failed provider call is recorded as a `model_error` event — metadata only.
+    """
     streamed_text = False
     pending_reset = False
-    usage = {"input": 0, "output": 0, "total": 0}
+    # Share the observation's usage dict by reference when present, so the SSE wrapper sees
+    # the real provider counts as they accumulate; fall back to a local dict otherwise.
+    usage = (
+        observation.usage
+        if observation is not None
+        else {"input": 0, "output": 0, "total": 0}
+    )
+    # run_id -> (tool name, start time, arg length), to pair on_tool_start with its end.
+    tool_runs: dict[str, tuple[str, float, int]] = {}
     try:
         async for event in agent.astream_events(
             {"messages": messages},
             {"configurable": {"thread_id": "default"}},
             version="v2",
         ):
-            if event["event"] == "on_tool_start":
+            kind = event["event"]
+            if kind == "on_tool_start":
+                tool_runs[event["run_id"]] = (
+                    event["name"],
+                    time.perf_counter(),
+                    _content_len(event["data"].get("input")),
+                )
                 yield status_event(event["name"])
                 pending_reset = True
                 continue
 
-            if event["event"] == "on_chat_model_end":
+            if kind in ("on_tool_end", "on_tool_error"):
+                started = tool_runs.pop(event["run_id"], None)
+                if started is not None:
+                    name, start, arg_len = started
+                    is_error = kind == "on_tool_error"
+                    output = None if is_error else event["data"].get("output")
+                    capture_tool_called(
+                        observation,
+                        tool=name,
+                        latency_ms=(time.perf_counter() - start) * 1000.0,
+                        success=not is_error and _tool_succeeded(output),
+                        arg_len=arg_len,
+                        result_len=_content_len(output),
+                    )
+                continue
+
+            if kind == "on_chat_model_end":
                 _accumulate_usage(usage, event["data"].get("output"))
                 continue
 
-            if event["event"] != "on_chat_model_stream":
+            if kind != "on_chat_model_stream":
                 continue
 
             chunk = event["data"].get("chunk")
@@ -203,8 +361,13 @@ async def create_agent_token_generator(
             yield meta_event({"tokens": usage})
         yield DONE_EVENT
 
-    except Exception:
+    except Exception as exc:
         logger.exception("Agent error occurred during streaming")
+        capture_model_error(
+            observation,
+            error_type=type(exc).__name__,
+            status_code=_error_status_code(exc),
+        )
         # Tokens already streamed: a fresh "try again" would contradict the partial answer.
         if streamed_text:
             yield error_event("interrupted", _INTERRUPTED_MSG)

--- a/api/app/llms/agents.py
+++ b/api/app/llms/agents.py
@@ -54,14 +54,6 @@ DONE_EVENT = _sse("done", {})
 
 @dataclass
 class StreamObservation:
-    """Per-request, mutable analytics holder threaded into the agent generator.
-
-    Carries the request ids so per-invocation events (``tool_called``, ``model_error``,
-    ``model_fallback``) group with the rest of the request, and exposes the live token
-    ``usage`` dict by reference so the SSE wrapper reads real provider counts directly
-    instead of sniffing a trailing meta frame. Residency: every field is metadata only.
-    """
-
     distinct_id: str
     response_id: str
     model: str = ""
@@ -72,7 +64,6 @@ class StreamObservation:
 
 
 def _error_status_code(exc: BaseException) -> int | None:
-    """An HTTP status code carried by a provider exception (e.g. 429), if any."""
     status = getattr(exc, "status_code", None)
     if isinstance(status, int):
         return status
@@ -82,7 +73,6 @@ def _error_status_code(exc: BaseException) -> int | None:
 
 
 def _content_len(value: object) -> int:
-    """Character length of a value's text form (a length only — never the text)."""
     if value is None:
         return 0
     if isinstance(value, str):
@@ -94,7 +84,6 @@ def _content_len(value: object) -> int:
 
 
 def _tool_succeeded(output: object) -> bool:
-    """Whether a tool's output indicates success; an error ToolMessage flips it to False."""
     return getattr(output, "status", None) != "error"
 
 
@@ -107,7 +96,6 @@ def capture_tool_called(
     arg_len: int,
     result_len: int,
 ) -> None:
-    """Record one tool invocation (lengths/timings only — never the tool args/result)."""
     if observation is None:
         return
     capture(
@@ -132,7 +120,6 @@ def capture_model_error(
     error_type: str,
     status_code: int | None = None,
 ) -> None:
-    """Record a failed provider call (metadata only)."""
     if observation is None:
         return
     capture(
@@ -155,7 +142,6 @@ def capture_model_fallback(
     to_model: str,
     reason: str,
 ) -> None:
-    """Record a switch to a different model/path (metadata only)."""
     if observation is None:
         return
     capture(
@@ -278,22 +264,14 @@ async def create_agent_token_generator(
 ) -> AsyncGenerator[str]:
     """Stream an agent run as SSE, mapping `astream_events` onto the protocol: each
     `on_tool_start` becomes a `status`, and a `reset` precedes the answer so any
-    pre-tool preamble is dropped.
-
-    When an `observation` is supplied, real token usage is folded into its shared `usage`
-    dict (read by the SSE wrapper), each tool call is recorded as a `tool_called` event,
-    and a failed provider call is recorded as a `model_error` event — metadata only.
-    """
+    pre-tool preamble is dropped."""
     streamed_text = False
     pending_reset = False
-    # Share the observation's usage dict by reference when present, so the SSE wrapper sees
-    # the real provider counts as they accumulate; fall back to a local dict otherwise.
     usage = (
         observation.usage
         if observation is not None
         else {"input": 0, "output": 0, "total": 0}
     )
-    # run_id -> (tool name, start time, arg length), to pair on_tool_start with its end.
     tool_runs: dict[str, tuple[str, float, int]] = {}
     try:
         async for event in agent.astream_events(

--- a/api/app/llms/agents.py
+++ b/api/app/llms/agents.py
@@ -59,8 +59,19 @@ class StreamObservation:
     model: str = ""
     provider: str = ""
     usage: dict[str, int] = field(
-        default_factory=lambda: {"input": 0, "output": 0, "total": 0},
+        default_factory=lambda: {
+            "input": 0,
+            "output": 0,
+            "total": 0,
+            "cache_read": 0,
+            "reasoning": 0,
+        },
     )
+    answer_chars: int = 0
+    tool_call_count: int = 0
+    tool_names: set[str] = field(default_factory=set)
+    finish_reason: str = ""
+    context_chars: int = 0
 
 
 def _error_status_code(exc: BaseException) -> int | None:
@@ -255,6 +266,34 @@ def _accumulate_usage(usage: dict[str, int], output: object) -> None:
     usage["output"] += metadata.get("output_tokens") or 0
     # Derive total from the parts so the shown counts always reconcile.
     usage["total"] = usage["input"] + usage["output"]
+    input_details = metadata.get("input_token_details") or {}
+    output_details = metadata.get("output_token_details") or {}
+    usage["cache_read"] = usage.get("cache_read", 0) + (
+        input_details.get("cache_read") or 0
+    )
+    usage["reasoning"] = usage.get("reasoning", 0) + (
+        output_details.get("reasoning") or 0
+    )
+
+
+def _finish_reason(output: object) -> str:
+    """A normalised finish/stop reason from a chat-model end message, or "" if absent."""
+    metadata = getattr(output, "response_metadata", None)
+    if not isinstance(metadata, dict):
+        return ""
+    raw = metadata.get("finish_reason") or metadata.get("stop_reason") or ""
+    mapping = {
+        "length": "length",
+        "max_tokens": "length",
+        "model_length": "length",
+        "content_filter": "content_filter",
+        "stop": "stop",
+        "end_turn": "stop",
+        "stop_sequence": "stop",
+        "tool_calls": "tool_calls",
+        "tool_use": "tool_calls",
+    }
+    return mapping.get(str(raw), str(raw))
 
 
 async def create_agent_token_generator(
@@ -304,10 +343,18 @@ async def create_agent_token_generator(
                         arg_len=arg_len,
                         result_len=_content_len(output),
                     )
+                    if observation is not None:
+                        observation.tool_call_count += 1
+                        observation.tool_names.add(name)
                 continue
 
             if kind == "on_chat_model_end":
-                _accumulate_usage(usage, event["data"].get("output"))
+                output = event["data"].get("output")
+                _accumulate_usage(usage, output)
+                if observation is not None:
+                    reason = _finish_reason(output)
+                    if reason:
+                        observation.finish_reason = reason
                 continue
 
             if kind != "on_chat_model_stream":
@@ -327,9 +374,15 @@ async def create_agent_token_generator(
 
             if pending_reset:
                 pending_reset = False
+                # The client clears any pre-tool preamble on reset; mirror that so the
+                # length reflects the final answer only.
+                if observation is not None:
+                    observation.answer_chars = 0
                 yield RESET_EVENT
 
             streamed_text = True
+            if observation is not None:
+                observation.answer_chars += len(text)
             yield token_event(text)
 
         if not streamed_text:

--- a/api/app/llms/anthropic.py
+++ b/api/app/llms/anthropic.py
@@ -8,6 +8,8 @@ from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from pydantic import SecretStr
 
 from app.llms.agents import (
+    StreamObservation,
+    capture_model_fallback,
     content_to_text,
     create_agent_token_generator,
     stream_sync_gen_as_sse,
@@ -173,6 +175,7 @@ async def stream_anthropic_agent_response(
     top_p: float,
     max_tokens: int,
     reasoning: bool = False,
+    observation: StreamObservation | None = None,
 ) -> StreamingResponse:
     """
     Stream a response from an Anthropic agent with MCP tools.
@@ -205,13 +208,19 @@ async def stream_anthropic_agent_response(
         messages = build_agent_messages(system_prompt, history or [], user_prompt)
 
         return StreamingResponse(
-            create_agent_token_generator(agent, messages),
+            create_agent_token_generator(agent, messages, observation),
             media_type="text/event-stream",
         )
 
     except Exception:
         logger.exception(
             "Failed to stream Anthropic agent response. Falling back to regular response",
+        )
+        capture_model_fallback(
+            observation,
+            from_model=model.value,
+            to_model=model.value,
+            reason="agent_setup_failed",
         )
 
         return stream_anthropic_response(

--- a/api/app/llms/chat.py
+++ b/api/app/llms/chat.py
@@ -2,6 +2,7 @@ import logging
 
 from fastapi.responses import StreamingResponse
 
+from app.llms.agents import StreamObservation
 from app.llms.prompts import (
     DEFAULT_AGENT_SYSTEM_PROMPT,
     build_user_agent_prompt,
@@ -19,6 +20,7 @@ settings = Settings()
 async def handle_chat(
     payload: ChatSchema,
     context: str,
+    observation: StreamObservation | None = None,
 ) -> StreamingResponse:
     """
     Handle chat using an agent with MCP tool support.
@@ -48,4 +50,5 @@ async def handle_chat(
         top_p=payload.top_p,
         max_tokens=payload.max_tokens,
         reasoning=payload.reasoning,
+        observation=observation,
     )

--- a/api/app/llms/context.py
+++ b/api/app/llms/context.py
@@ -21,6 +21,7 @@ from app.utils.exceptions import RetrievalError
 from app.utils.http_client import get_http_client
 from app.utils.settings import Settings
 from app.utils.timing import (
+    current_distinct_id,
     current_response_id,
     record_reranker_scores,
     record_retrieval_ids,
@@ -57,11 +58,17 @@ async def _post_rerank(payload: dict) -> httpx.Response:
     client = get_http_client()
     for attempt in range(_RERANKER_MAX_RETRIES + 1):
         try:
+            headers: dict[str, str] = {}
             rid = current_response_id()
+            if rid:
+                headers["X-Response-Id"] = rid
+            did = current_distinct_id()
+            if did:
+                headers["X-Distinct-Id"] = did
             response = await client.post(
                 f"{settings.GPU_API_URL}/rerank/",
                 json=payload,
-                headers={"X-Response-Id": rid} if rid else None,
+                headers=headers or None,
                 timeout=_RERANKER_TIMEOUT,
             )
             response.raise_for_status()

--- a/api/app/llms/context.py
+++ b/api/app/llms/context.py
@@ -20,7 +20,12 @@ from app.schemas.questions import QuestionSchema
 from app.utils.exceptions import RetrievalError
 from app.utils.http_client import get_http_client
 from app.utils.settings import Settings
-from app.utils.timing import record_retrieval_ids, record_retrieval_shape, timed
+from app.utils.timing import (
+    record_reranker_scores,
+    record_retrieval_ids,
+    record_retrieval_shape,
+    timed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -337,6 +342,11 @@ async def get_retrieved_context(
                 )
                 continue
             ranked_candidates.append(candidates[idx])
+
+        record_reranker_scores(
+            [item["score"] for item in ranked if 0 <= item["index"] < len(candidates)],
+            above_threshold=len(ranked_candidates),
+        )
 
         if dropped:
             logger.info(

--- a/api/app/llms/context.py
+++ b/api/app/llms/context.py
@@ -21,6 +21,7 @@ from app.utils.exceptions import RetrievalError
 from app.utils.http_client import get_http_client
 from app.utils.settings import Settings
 from app.utils.timing import (
+    current_response_id,
     record_reranker_scores,
     record_retrieval_ids,
     record_retrieval_shape,
@@ -56,9 +57,11 @@ async def _post_rerank(payload: dict) -> httpx.Response:
     client = get_http_client()
     for attempt in range(_RERANKER_MAX_RETRIES + 1):
         try:
+            rid = current_response_id()
             response = await client.post(
                 f"{settings.GPU_API_URL}/rerank/",
                 json=payload,
+                headers={"X-Response-Id": rid} if rid else None,
                 timeout=_RERANKER_TIMEOUT,
             )
             response.raise_for_status()

--- a/api/app/llms/context.py
+++ b/api/app/llms/context.py
@@ -33,7 +33,6 @@ _RERANKER_TIMEOUT = httpx.Timeout(timeout=30.0)
 _RERANKER_MAX_RETRIES: int = 1
 # Chunks pulled in on each side of a retrieved chunk, to give the model a contiguous passage.
 _NEIGHBOR_WINDOW: int = 1
-# Cap on the corpus ids reported per request (ids only) — the top of the ranked set.
 _RETRIEVAL_IDS_CAP: int = 10
 
 

--- a/api/app/llms/context.py
+++ b/api/app/llms/context.py
@@ -20,7 +20,7 @@ from app.schemas.questions import QuestionSchema
 from app.utils.exceptions import RetrievalError
 from app.utils.http_client import get_http_client
 from app.utils.settings import Settings
-from app.utils.timing import record_retrieval_shape, timed
+from app.utils.timing import record_retrieval_ids, record_retrieval_shape, timed
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +33,8 @@ _RERANKER_TIMEOUT = httpx.Timeout(timeout=30.0)
 _RERANKER_MAX_RETRIES: int = 1
 # Chunks pulled in on each side of a retrieved chunk, to give the model a contiguous passage.
 _NEIGHBOR_WINDOW: int = 1
+# Cap on the corpus ids reported per request (ids only) — the top of the ranked set.
+_RETRIEVAL_IDS_CAP: int = 10
 
 
 @dataclass(frozen=True)
@@ -375,6 +377,8 @@ async def get_retrieved_context(
             "Reranking call failed. Using vector search order as a fallback",
         )
         final = _select_with_faq_reservation(candidates, top_k)
+
+    record_retrieval_ids([c.key for c in final[:_RETRIEVAL_IDS_CAP]])
 
     with timed("retrieval.expand"):
         return await _expand_and_render(db, final)

--- a/api/app/llms/google.py
+++ b/api/app/llms/google.py
@@ -10,6 +10,8 @@ from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmb
 from pydantic import SecretStr
 
 from app.llms.agents import (
+    StreamObservation,
+    capture_model_fallback,
     content_to_text,
     create_agent_token_generator,
     stream_sync_gen_as_sse,
@@ -218,6 +220,7 @@ async def stream_google_agent_response(
     top_p: float,
     max_tokens: int,
     reasoning: bool = False,
+    observation: StreamObservation | None = None,
 ) -> StreamingResponse:
     """
     Stream a response from a Google agent with MCP tools.
@@ -244,13 +247,19 @@ async def stream_google_agent_response(
         messages = build_agent_messages(system_prompt, history or [], user_prompt)
 
         return StreamingResponse(
-            create_agent_token_generator(agent, messages),
+            create_agent_token_generator(agent, messages, observation),
             media_type="text/event-stream",
         )
 
     except Exception:
         logger.exception(
             "Failed to stream Google agent response. Falling back to regular response",
+        )
+        capture_model_fallback(
+            observation,
+            from_model=model.value,
+            to_model=model.value,
+            reason="agent_setup_failed",
         )
 
         return stream_google_response(

--- a/api/app/llms/gpu_api.py
+++ b/api/app/llms/gpu_api.py
@@ -16,6 +16,7 @@ from app.llms.models import GPU_API_MODELS, Model
 from app.llms.prompts import history_transcript
 from app.utils.http_client import get_http_client
 from app.utils.settings import Settings
+from app.utils.timing import current_response_id
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,11 @@ settings = Settings()
 _STREAMING_TIMEOUT = httpx.Timeout(timeout=300.0)
 _EMBEDDINGS_TIMEOUT = httpx.Timeout(timeout=60.0)
 _GPU_ERROR_MESSAGE = "Се случи грешка при обработката на барањето. Обидете се повторно."
+
+
+def _response_id_headers() -> dict[str, str]:
+    rid = current_response_id()
+    return {"X-Response-Id": rid} if rid else {}
 
 
 async def generate_gpu_api_embeddings(
@@ -50,7 +56,7 @@ async def generate_gpu_api_embeddings(
     response = await client.post(
         gpu_api_url,
         json=payload,
-        headers={"Content-Type": "application/json"},
+        headers={"Content-Type": "application/json", **_response_id_headers()},
         timeout=_EMBEDDINGS_TIMEOUT,
     )
 
@@ -111,7 +117,7 @@ def stream_gpu_api_response(
                 "POST",
                 gpu_api_url,
                 json=payload,
-                headers={"Content-Type": "application/json"},
+                headers={"Content-Type": "application/json", **_response_id_headers()},
                 timeout=_STREAMING_TIMEOUT,
             ) as response:
                 if response.status_code != 200:

--- a/api/app/llms/gpu_api.py
+++ b/api/app/llms/gpu_api.py
@@ -16,7 +16,7 @@ from app.llms.models import GPU_API_MODELS, Model
 from app.llms.prompts import history_transcript
 from app.utils.http_client import get_http_client
 from app.utils.settings import Settings
-from app.utils.timing import current_response_id
+from app.utils.timing import current_distinct_id, current_response_id
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +27,15 @@ _EMBEDDINGS_TIMEOUT = httpx.Timeout(timeout=60.0)
 _GPU_ERROR_MESSAGE = "Се случи грешка при обработката на барањето. Обидете се повторно."
 
 
-def _response_id_headers() -> dict[str, str]:
+def _forwarded_headers() -> dict[str, str]:
+    headers: dict[str, str] = {}
     rid = current_response_id()
-    return {"X-Response-Id": rid} if rid else {}
+    if rid:
+        headers["X-Response-Id"] = rid
+    did = current_distinct_id()
+    if did:
+        headers["X-Distinct-Id"] = did
+    return headers
 
 
 async def generate_gpu_api_embeddings(
@@ -56,7 +62,7 @@ async def generate_gpu_api_embeddings(
     response = await client.post(
         gpu_api_url,
         json=payload,
-        headers={"Content-Type": "application/json", **_response_id_headers()},
+        headers={"Content-Type": "application/json", **_forwarded_headers()},
         timeout=_EMBEDDINGS_TIMEOUT,
     )
 
@@ -117,7 +123,7 @@ def stream_gpu_api_response(
                 "POST",
                 gpu_api_url,
                 json=payload,
-                headers={"Content-Type": "application/json", **_response_id_headers()},
+                headers={"Content-Type": "application/json", **_forwarded_headers()},
                 timeout=_STREAMING_TIMEOUT,
             ) as response:
                 if response.status_code != 200:

--- a/api/app/llms/gpu_api.py
+++ b/api/app/llms/gpu_api.py
@@ -6,7 +6,12 @@ import httpx
 from fastapi.responses import StreamingResponse
 from langchain_core.messages import BaseMessage
 
-from app.llms.agents import DONE_EVENT, error_event
+from app.llms.agents import (
+    DONE_EVENT,
+    StreamObservation,
+    capture_model_error,
+    error_event,
+)
 from app.llms.models import GPU_API_MODELS, Model
 from app.llms.prompts import history_transcript
 from app.utils.http_client import get_http_client
@@ -69,6 +74,7 @@ def stream_gpu_api_response(
     temperature: float,
     top_p: float,
     max_tokens: int,
+    observation: StreamObservation | None = None,
 ) -> StreamingResponse:
     """
     Stream a response from the GPU API service.
@@ -115,6 +121,11 @@ def stream_gpu_api_response(
                         response.status_code,
                         error_text.decode(),
                     )
+                    capture_model_error(
+                        observation,
+                        error_type="http_status",
+                        status_code=response.status_code,
+                    )
                     yield error_event("agent_error", _GPU_ERROR_MESSAGE)
                     yield DONE_EVENT
                     return
@@ -127,16 +138,18 @@ def stream_gpu_api_response(
 
             yield DONE_EVENT
 
-        except httpx.RequestError:
+        except httpx.RequestError as exc:
             logger.exception("Connection error to GPU API")
+            capture_model_error(observation, error_type=type(exc).__name__)
             yield error_event("agent_error", _GPU_ERROR_MESSAGE)
             yield DONE_EVENT
         except asyncio.CancelledError:
             logger.exception("Streaming cancelled from GPU API")
 
             raise
-        except Exception:
+        except Exception as exc:
             logger.exception("Unexpected error while streaming from GPU API")
+            capture_model_error(observation, error_type=type(exc).__name__)
             yield error_event("agent_error", _GPU_ERROR_MESSAGE)
             yield DONE_EVENT
 

--- a/api/app/llms/ollama.py
+++ b/api/app/llms/ollama.py
@@ -8,7 +8,12 @@ from langchain.agents import create_agent
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from langchain_ollama import ChatOllama, OllamaEmbeddings
 
-from app.llms.agents import create_agent_token_generator, stream_sync_gen_as_sse
+from app.llms.agents import (
+    StreamObservation,
+    capture_model_fallback,
+    create_agent_token_generator,
+    stream_sync_gen_as_sse,
+)
 from app.llms.mcp import get_mcp_tools
 from app.llms.models import Model
 from app.llms.prompts import build_agent_messages, stitch_conversation
@@ -184,6 +189,7 @@ async def stream_ollama_agent_response(
     top_p: float,
     max_tokens: int,
     reasoning: bool = False,
+    observation: StreamObservation | None = None,
 ) -> StreamingResponse:
     """
     Stream a response from an Ollama agent with MCP tools.
@@ -210,13 +216,19 @@ async def stream_ollama_agent_response(
         messages = build_agent_messages(system_prompt, history or [], user_prompt)
 
         return StreamingResponse(
-            create_agent_token_generator(agent, messages),
+            create_agent_token_generator(agent, messages, observation),
             media_type="text/event-stream",
         )
 
     except Exception:
         logger.exception(
             "Failed to stream Ollama agent response. Falling back to regular response",
+        )
+        capture_model_fallback(
+            observation,
+            from_model=model.value,
+            to_model=model.value,
+            reason="agent_setup_failed",
         )
 
         return stream_ollama_response(

--- a/api/app/llms/openai.py
+++ b/api/app/llms/openai.py
@@ -10,6 +10,8 @@ from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from pydantic import SecretStr
 
 from app.llms.agents import (
+    StreamObservation,
+    capture_model_fallback,
     content_to_text,
     create_agent_token_generator,
     stream_sync_gen_as_sse,
@@ -182,6 +184,7 @@ async def stream_openai_agent_response(
     top_p: float,
     max_tokens: int,
     reasoning: bool = False,
+    observation: StreamObservation | None = None,
 ) -> StreamingResponse:
     """
     Stream a response from an OpenAI agent with MCP tools.
@@ -208,13 +211,19 @@ async def stream_openai_agent_response(
         messages = build_agent_messages(system_prompt, history or [], user_prompt)
 
         return StreamingResponse(
-            create_agent_token_generator(agent, messages),
+            create_agent_token_generator(agent, messages, observation),
             media_type="text/event-stream",
         )
 
     except Exception:
         logger.exception(
             "Failed to stream OpenAI agent response. Falling back to regular response",
+        )
+        capture_model_fallback(
+            observation,
+            from_model=model.value,
+            to_model=model.value,
+            reason="agent_setup_failed",
         )
 
         return stream_openai_response(

--- a/api/app/llms/pricing.py
+++ b/api/app/llms/pricing.py
@@ -1,0 +1,62 @@
+"""Single source of truth for hosted-model token prices (USD per 1M tokens).
+
+Update prices here when a provider changes them. Self-hosted models (Ollama and the local
+GPU) have no marginal token cost and are priced at 0; brand-new hosted models without a
+reliable published price are omitted, so callers treat their cost as unknown rather than
+guessing.
+"""
+
+from app.llms.models import Model
+
+# (input_usd_per_1m, output_usd_per_1m) for hosted models with a reliable published price.
+HOSTED_PRICING: dict[Model, tuple[float, float]] = {
+    Model.GPT_4O_MINI: (0.15, 0.60),
+    Model.GPT_4_1: (2.00, 8.00),
+    Model.GPT_4_1_MINI: (0.40, 1.60),
+    Model.GPT_4_1_NANO: (0.10, 0.40),
+    Model.GEMINI_2_5_FLASH: (0.30, 2.50),
+    Model.GEMINI_2_5_PRO: (1.25, 10.00),
+    Model.CLAUDE_HAIKU_4_5: (1.00, 5.00),
+    Model.CLAUDE_SONNET_4_6: (3.00, 15.00),
+}
+
+# Models we run ourselves (Ollama + local GPU): zero marginal token cost.
+SELF_HOSTED_MODELS: frozenset[Model] = frozenset(
+    {
+        Model.LLAMA_3_3_70B,
+        Model.MISTRAL,
+        Model.DEEPSEEK_R1_70B,
+        Model.QWEN2_5_72B,
+        Model.BGE_M3,
+        Model.DOMESTIC_YAK_8B_INSTRUCT_GGUF,
+        Model.VEZILKALLM_GGUF,
+        Model.MULTILINGUAL_E5_LARGE,
+        Model.BGE_M3_LOCAL,
+        Model.QWEN2_1_5_B_INSTRUCT,
+        Model.QWEN2_5_7B_INSTRUCT,
+    },
+)
+
+
+def is_self_hosted(model: Model) -> bool:
+    return model in SELF_HOSTED_MODELS
+
+
+def cost_usd(
+    model: Model,
+    input_tokens: int,
+    output_tokens: int,
+) -> tuple[float, float, float] | None:
+    """(input, output, total) USD for a generation, or None when the price is unknown.
+
+    Self-hosted models cost 0; an unpriced hosted model returns None so the caller can flag
+    the cost as unknown instead of recording a fabricated 0.
+    """
+    if model in SELF_HOSTED_MODELS:
+        return (0.0, 0.0, 0.0)
+    price = HOSTED_PRICING.get(model)
+    if price is None:
+        return None
+    input_cost = input_tokens / 1_000_000 * price[0]
+    output_cost = output_tokens / 1_000_000 * price[1]
+    return (input_cost, output_cost, input_cost + output_cost)

--- a/api/app/llms/streams.py
+++ b/api/app/llms/streams.py
@@ -3,6 +3,7 @@ import logging
 from fastapi.responses import StreamingResponse
 from langchain_core.messages import BaseMessage
 
+from app.llms.agents import StreamObservation
 from app.llms.anthropic import stream_anthropic_agent_response
 from app.llms.google import stream_google_agent_response
 from app.llms.gpu_api import stream_gpu_api_response
@@ -11,6 +12,11 @@ from app.llms.ollama import stream_ollama_agent_response
 from app.llms.openai import stream_openai_agent_response
 
 logger = logging.getLogger(__name__)
+
+
+def _tag_provider(observation: StreamObservation | None, provider: str) -> None:
+    if observation is not None:
+        observation.provider = provider
 
 
 async def stream_response_with_agent(
@@ -23,6 +29,7 @@ async def stream_response_with_agent(
     top_p: float,
     max_tokens: int,
     reasoning: bool = False,
+    observation: StreamObservation | None = None,
 ) -> StreamingResponse:
     """
     Stream a response from the specified model using the provided user prompt and system prompt with agent.
@@ -37,6 +44,9 @@ async def stream_response_with_agent(
 
     reasoning = reasoning and model in REASONING_CAPABLE_MODELS
 
+    if observation is not None:
+        observation.model = model.value
+
     match model:
         case (
             Model.LLAMA_3_3_70B
@@ -46,6 +56,7 @@ async def stream_response_with_agent(
             | Model.DOMESTIC_YAK_8B_INSTRUCT_GGUF
             | Model.VEZILKALLM_GGUF
         ):
+            _tag_provider(observation, "ollama")
             return await stream_ollama_agent_response(
                 user_prompt,
                 model,
@@ -55,6 +66,7 @@ async def stream_response_with_agent(
                 top_p=top_p,
                 max_tokens=max_tokens,
                 reasoning=reasoning,
+                observation=observation,
             )
 
         case (
@@ -68,6 +80,7 @@ async def stream_response_with_agent(
             | Model.GPT_5_MINI
             | Model.GPT_5_NANO
         ):
+            _tag_provider(observation, "openai")
             return await stream_openai_agent_response(
                 user_prompt,
                 model,
@@ -77,11 +90,13 @@ async def stream_response_with_agent(
                 top_p=top_p,
                 max_tokens=max_tokens,
                 reasoning=reasoning,
+                observation=observation,
             )
 
         case (
             Model.GEMINI_2_5_FLASH | Model.GEMINI_2_5_PRO | Model.GEMINI_3_FLASH_PREVIEW
         ):
+            _tag_provider(observation, "google")
             return await stream_google_agent_response(
                 user_prompt,
                 model,
@@ -91,6 +106,7 @@ async def stream_response_with_agent(
                 top_p=top_p,
                 max_tokens=max_tokens,
                 reasoning=reasoning,
+                observation=observation,
             )
 
         case (
@@ -99,6 +115,7 @@ async def stream_response_with_agent(
             | Model.CLAUDE_SONNET_4_6
             | Model.CLAUDE_HAIKU_4_5
         ):
+            _tag_provider(observation, "anthropic")
             return await stream_anthropic_agent_response(
                 user_prompt,
                 model,
@@ -108,9 +125,11 @@ async def stream_response_with_agent(
                 top_p=top_p,
                 max_tokens=max_tokens,
                 reasoning=reasoning,
+                observation=observation,
             )
 
         case Model.QWEN2_1_5_B_INSTRUCT | Model.QWEN2_5_7B_INSTRUCT:
+            _tag_provider(observation, "gpu_api")
             return stream_gpu_api_response(
                 user_prompt,
                 model,
@@ -119,6 +138,7 @@ async def stream_response_with_agent(
                 temperature=temperature,
                 top_p=top_p,
                 max_tokens=max_tokens,
+                observation=observation,
             )
 
         case _:

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -6,7 +7,9 @@ from fastapi import FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from starlette.datastructures import Headers
 from starlette.middleware.cors import CORSMiddleware
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.api.chat import router as chat_router
 from app.api.diplomas import router as diplomas_router
@@ -21,7 +24,7 @@ from app.data.connection import Database
 from app.utils.exceptions import RetrievalError
 from app.utils.http_client import close_http_client, init_http_client
 from app.utils.logger import setup_logging
-from app.utils.posthog_client import capture_exception
+from app.utils.posthog_client import capture, capture_exception, safe_distinct_id
 from app.utils.settings import Settings
 
 logger = logging.getLogger(__name__)
@@ -67,6 +70,71 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     await close_http_client()
 
 
+# Extreme-noise paths kept out of request_completed to control event volume.
+_SKIP_PATHS: frozenset[str] = frozenset(
+    {"/docs", "/redoc", "/openapi.json", "/favicon.ico"},
+)
+_SKIP_PREFIXES: tuple[str, ...] = ("/health",)
+
+
+def _request_outcome(status_code: int) -> str:
+    if status_code >= 500:
+        return "server_error"
+    if status_code >= 400:
+        return "client_error"
+    return "ok"
+
+
+class RequestTrackingMiddleware:
+    """Emit one ``request_completed`` PostHog event per HTTP request (metadata only).
+
+    A pure ASGI middleware, not BaseHTTPMiddleware, so it never buffers the SSE chat body:
+    it only reads the status off ``http.response.start`` and times the whole request. The
+    matched route TEMPLATE is reported (never the raw path), so ids never leak and route /
+    person cardinality stays bounded.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        path = scope.get("path", "")
+        if path in _SKIP_PATHS or path.startswith(_SKIP_PREFIXES):
+            await self.app(scope, receive, send)
+            return
+
+        start = time.perf_counter()
+        status_code = 500
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            # FastAPI puts the matched APIRoute (template path) on the scope; absent on a
+            # 404, where the raw path is the only thing available.
+            route = scope.get("route")
+            template = getattr(route, "path", None) or path
+            capture(
+                safe_distinct_id(Headers(scope=scope).get("x-distinct-id"), "api"),
+                "request_completed",
+                {
+                    "route": template,
+                    "method": scope.get("method", ""),
+                    "status_code": status_code,
+                    "duration_ms": round((time.perf_counter() - start) * 1000, 1),
+                    "outcome": _request_outcome(status_code),
+                },
+            )
+
+
 def make_app(settings: Settings) -> FastAPI:
     """
     Create and configure the FastAPI application.
@@ -110,6 +178,11 @@ def make_app(settings: Settings) -> FastAPI:
         allow_headers=["*"],
         expose_headers=settings.EXPOSE_HEADERS,
     )
+
+    # Added last so it sits outermost and times the whole request. A handled error (e.g.
+    # 422/503) arrives as a normal response we read the status off; an unhandled 500
+    # propagates here as an exception, so status_code stays 500 and we still emit in finally.
+    app.add_middleware(RequestTrackingMiddleware)
 
     app.include_router(health_router)
     app.include_router(questions_router)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -7,9 +6,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-from starlette.datastructures import Headers
 from starlette.middleware.cors import CORSMiddleware
-from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.api.chat import router as chat_router
 from app.api.diplomas import router as diplomas_router
@@ -24,7 +21,10 @@ from app.data.connection import Database
 from app.utils.exceptions import RetrievalError
 from app.utils.http_client import close_http_client, init_http_client
 from app.utils.logger import setup_logging
-from app.utils.posthog_client import capture, capture_exception, safe_distinct_id
+from app.utils.posthog_client import (
+    capture_request_exception,
+    register_request_middleware,
+)
 from app.utils.settings import Settings
 
 logger = logging.getLogger(__name__)
@@ -68,71 +68,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     await db.disconnect()
     await close_http_client()
-
-
-# Extreme-noise paths kept out of request_completed to control event volume.
-_SKIP_PATHS: frozenset[str] = frozenset(
-    {"/docs", "/redoc", "/openapi.json", "/favicon.ico"},
-)
-_SKIP_PREFIXES: tuple[str, ...] = ("/health",)
-
-
-def _request_outcome(status_code: int) -> str:
-    if status_code >= 500:
-        return "server_error"
-    if status_code >= 400:
-        return "client_error"
-    return "ok"
-
-
-class RequestTrackingMiddleware:
-    """Emit one ``request_completed`` PostHog event per HTTP request (metadata only).
-
-    A pure ASGI middleware, not BaseHTTPMiddleware, so it never buffers the SSE chat body:
-    it only reads the status off ``http.response.start`` and times the whole request. The
-    matched route TEMPLATE is reported (never the raw path), so ids never leak and route /
-    person cardinality stays bounded.
-    """
-
-    def __init__(self, app: ASGIApp) -> None:
-        self.app = app
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http":
-            await self.app(scope, receive, send)
-            return
-        path = scope.get("path", "")
-        if path in _SKIP_PATHS or path.startswith(_SKIP_PREFIXES):
-            await self.app(scope, receive, send)
-            return
-
-        start = time.perf_counter()
-        status_code = 500
-
-        async def send_wrapper(message: Message) -> None:
-            nonlocal status_code
-            if message["type"] == "http.response.start":
-                status_code = message["status"]
-            await send(message)
-
-        try:
-            await self.app(scope, receive, send_wrapper)
-        finally:
-            # FastAPI puts the matched APIRoute (template path) on the scope; absent on a
-            # 404, where the raw path is the only thing available.
-            route = scope.get("route")
-            template = getattr(route, "path", None) or path
-            capture(
-                safe_distinct_id(Headers(scope=scope).get("x-distinct-id"), "api"),
-                "request_completed",
-                {
-                    "route": template,
-                    "method": scope.get("method", ""),
-                    "status_code": status_code,
-                    "duration_ms": round((time.perf_counter() - start) * 1000, 1),
-                    "outcome": _request_outcome(status_code),
-                },
-            )
 
 
 def make_app(settings: Settings) -> FastAPI:
@@ -179,10 +114,8 @@ def make_app(settings: Settings) -> FastAPI:
         expose_headers=settings.EXPOSE_HEADERS,
     )
 
-    # Added last so it sits outermost and times the whole request. A handled error (e.g.
-    # 422/503) arrives as a normal response we read the status off; an unhandled 500
-    # propagates here as an exception, so status_code stays 500 and we still emit in finally.
-    app.add_middleware(RequestTrackingMiddleware)
+    # Added last so it sits outermost and times the whole request.
+    register_request_middleware(app)
 
     app.include_router(health_router)
     app.include_router(questions_router)
@@ -222,10 +155,7 @@ def make_app(settings: Settings) -> FastAPI:
         exc: Exception,
     ) -> JSONResponse:
         logger.exception("Unhandled exception")
-        capture_exception(
-            exc,
-            properties={"path": request.url.path, "method": request.method},
-        )
+        capture_request_exception(request, exc)
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content={"detail": "An unexpected internal server error occurred."},

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -21,6 +21,7 @@ from app.data.connection import Database
 from app.utils.exceptions import RetrievalError
 from app.utils.http_client import close_http_client, init_http_client
 from app.utils.logger import setup_logging
+from app.utils.posthog_client import capture_exception
 from app.utils.settings import Settings
 
 logger = logging.getLogger(__name__)
@@ -148,6 +149,10 @@ def make_app(settings: Settings) -> FastAPI:
         exc: Exception,
     ) -> JSONResponse:
         logger.exception("Unhandled exception")
+        capture_exception(
+            exc,
+            properties={"path": request.url.path, "method": request.method},
+        )
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content={"detail": "An unexpected internal server error occurred."},

--- a/api/app/utils/posthog_client.py
+++ b/api/app/utils/posthog_client.py
@@ -61,21 +61,32 @@ def capture_exception(
     distinct_id: str = "server",
     properties: dict[str, object] | None = None,
 ) -> None:
-    """Report an unhandled exception to PostHog Error Tracking; a no-op when disabled,
-    and never raising into the caller.
+    """Report an unhandled exception to PostHog Error Tracking as a metadata-only
+    ``$exception`` event; a no-op when disabled, and never raising into the caller.
 
-    Residency: callers must pass metadata only (request path, method, status) — never
-    raw prompt or answer text.
+    Residency: the exception object is NEVER handed to the SDK. posthog-python's
+    ``capture_exception`` serializes the full stacktrace WITH frame-local variables and
+    the raw ``str(exc)`` message, both of which can embed sovereign text (the user query,
+    the answer, retrieved chunks). Only the exception type, service and caller metadata
+    (request path, method, status) leave; the message/value is redacted.
     """
     client = _state.client
     if client is None:
         return
 
+    error_type = type(exc).__name__
     try:
-        client.capture_exception(
-            exc,
+        client.capture(
+            event="$exception",
             distinct_id=distinct_id,
-            properties={"service": _SERVICE, **(properties or {})},
+            properties={
+                "service": _SERVICE,
+                "error_type": error_type,
+                "$exception_list": [
+                    {"type": error_type, "value": "(redacted for residency)"},
+                ],
+                **(properties or {}),
+            },
         )
     except Exception:
         logger.exception("PostHog capture_exception failed")

--- a/api/app/utils/posthog_client.py
+++ b/api/app/utils/posthog_client.py
@@ -1,7 +1,11 @@
 import logging
 import re
+import time
 
+from fastapi import FastAPI, Request
 from posthog import Posthog
+from starlette.datastructures import Headers
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.utils.settings import Settings
 
@@ -97,3 +101,79 @@ def shutdown_posthog() -> None:
 
     client.flush()
     client.shutdown()
+
+
+def capture_request_exception(request: Request, exc: Exception) -> None:
+    """Report an unhandled request exception (path/method metadata only, redacted body)."""
+    capture_exception(
+        exc,
+        properties={"path": request.url.path, "method": request.method},
+    )
+
+
+# Extreme-noise paths kept out of request_completed to control event volume.
+_SKIP_PATHS: frozenset[str] = frozenset(
+    {"/docs", "/redoc", "/openapi.json", "/favicon.ico"},
+)
+_SKIP_PREFIXES: tuple[str, ...] = ("/health",)
+
+
+def _request_outcome(status_code: int) -> str:
+    if status_code >= 500:
+        return "server_error"
+    if status_code >= 400:
+        return "client_error"
+    return "ok"
+
+
+class _RequestTrackingMiddleware:
+    """Emit one ``request_completed`` PostHog event per HTTP request (metadata only).
+
+    A pure ASGI middleware, not BaseHTTPMiddleware, so it never buffers the SSE chat body:
+    it only reads the status off ``http.response.start`` and times the whole request. The
+    matched route TEMPLATE is reported (never the raw path), so ids never leak and route /
+    person cardinality stays bounded.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        path = scope.get("path", "")
+        if path in _SKIP_PATHS or path.startswith(_SKIP_PREFIXES):
+            await self.app(scope, receive, send)
+            return
+
+        start = time.perf_counter()
+        status_code = 500
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            route = scope.get("route")
+            template = getattr(route, "path", None) or path
+            capture(
+                safe_distinct_id(Headers(scope=scope).get("x-distinct-id"), "api"),
+                "request_completed",
+                {
+                    "route": template,
+                    "method": scope.get("method", ""),
+                    "status_code": status_code,
+                    "duration_ms": round((time.perf_counter() - start) * 1000, 1),
+                    "outcome": _request_outcome(status_code),
+                },
+            )
+
+
+def register_request_middleware(app: FastAPI) -> None:
+    """Attach the request_completed middleware (added outermost to time the whole request)."""
+    app.add_middleware(_RequestTrackingMiddleware)

--- a/api/app/utils/posthog_client.py
+++ b/api/app/utils/posthog_client.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from posthog import Posthog
 
@@ -7,6 +8,22 @@ from app.utils.settings import Settings
 logger = logging.getLogger(__name__)
 
 _SERVICE = "chat-bot-api"
+
+_DISTINCT_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
+
+
+def safe_distinct_id(raw: str | None, fallback: str) -> str:
+    """The caller-supplied analytics id if it is a short opaque token, else ``fallback``.
+
+    The header is untrusted: bounding length and charset stops a caller injecting PII,
+    smuggling free text, or exploding person cardinality.
+    """
+    if raw is None:
+        return fallback
+    candidate = raw.strip()
+    if _DISTINCT_ID_RE.fullmatch(candidate):
+        return candidate
+    return fallback
 
 
 class _State:

--- a/api/app/utils/posthog_client.py
+++ b/api/app/utils/posthog_client.py
@@ -71,24 +71,16 @@ def capture_exception(
     distinct_id: str = "server",
     properties: dict[str, object] | None = None,
 ) -> None:
-    # Residency: never forward the exc object — posthog-python serialises frame-locals + str(exc), which leak sovereign query/answer/retrieved text. Send a redacted $exception instead.
     client = _state.client
     if client is None:
         return
 
-    error_type = type(exc).__name__
+    # Capture the real exception (type, message, stacktrace) for debugging.
     try:
-        client.capture(
-            event="$exception",
+        client.capture_exception(
+            exc,
             distinct_id=distinct_id,
-            properties={
-                "service": _SERVICE,
-                "error_type": error_type,
-                "$exception_list": [
-                    {"type": error_type, "value": "(redacted for residency)"},
-                ],
-                **(properties or {}),
-            },
+            properties={"service": _SERVICE, **(properties or {})},
         )
     except Exception:
         logger.exception("PostHog capture_exception failed")

--- a/api/app/utils/posthog_client.py
+++ b/api/app/utils/posthog_client.py
@@ -56,6 +56,31 @@ def capture(
         logger.exception("PostHog capture failed (event=%s)", event)
 
 
+def capture_exception(
+    exc: BaseException,
+    distinct_id: str = "server",
+    properties: dict[str, object] | None = None,
+) -> None:
+    """Report an unhandled exception to PostHog Error Tracking; a no-op when disabled,
+    and never raising into the caller.
+
+    Residency: callers must pass metadata only (request path, method, status) — never
+    raw prompt or answer text.
+    """
+    client = _state.client
+    if client is None:
+        return
+
+    try:
+        client.capture_exception(
+            exc,
+            distinct_id=distinct_id,
+            properties={"service": _SERVICE, **(properties or {})},
+        )
+    except Exception:
+        logger.exception("PostHog capture_exception failed")
+
+
 def shutdown_posthog() -> None:
     """Flush and stop the client (the gunicorn ``worker_exit`` hook)."""
     client = _state.client

--- a/api/app/utils/posthog_client.py
+++ b/api/app/utils/posthog_client.py
@@ -17,12 +17,6 @@ _state = _State()
 
 
 def init_posthog(settings: Settings) -> None:
-    """Construct the per-worker PostHog client.
-
-    Call AFTER gunicorn forks (the ``post_fork`` hook): posthog-python's background
-    flush thread does not survive ``os.fork()``, so a client built pre-fork silently
-    drops every event in the workers. A no-op when ``POSTHOG_KEY`` is unset (dev/CI/tests).
-    """
     if not settings.POSTHOG_KEY:
         return
 
@@ -37,11 +31,6 @@ def capture(
     event: str,
     properties: dict[str, object] | None = None,
 ) -> None:
-    """Send one analytics event; a no-op when disabled, and never raising into the caller.
-
-    Residency: callers must pass metadata only (model ids, lengths, token counts,
-    timings) — never raw prompt or answer text.
-    """
     client = _state.client
     if client is None:
         return
@@ -61,15 +50,7 @@ def capture_exception(
     distinct_id: str = "server",
     properties: dict[str, object] | None = None,
 ) -> None:
-    """Report an unhandled exception to PostHog Error Tracking as a metadata-only
-    ``$exception`` event; a no-op when disabled, and never raising into the caller.
-
-    Residency: the exception object is NEVER handed to the SDK. posthog-python's
-    ``capture_exception`` serializes the full stacktrace WITH frame-local variables and
-    the raw ``str(exc)`` message, both of which can embed sovereign text (the user query,
-    the answer, retrieved chunks). Only the exception type, service and caller metadata
-    (request path, method, status) leave; the message/value is redacted.
-    """
+    # Residency: never forward the exc object — posthog-python serialises frame-locals + str(exc), which leak sovereign query/answer/retrieved text. Send a redacted $exception instead.
     client = _state.client
     if client is None:
         return
@@ -93,7 +74,6 @@ def capture_exception(
 
 
 def shutdown_posthog() -> None:
-    """Flush and stop the client (the gunicorn ``worker_exit`` hook)."""
     client = _state.client
     if client is None:
         return

--- a/api/app/utils/posthog_client.py
+++ b/api/app/utils/posthog_client.py
@@ -1,0 +1,66 @@
+import logging
+
+from posthog import Posthog
+
+from app.utils.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+_SERVICE = "chat-bot-api"
+
+
+class _State:
+    client: Posthog | None = None
+
+
+_state = _State()
+
+
+def init_posthog(settings: Settings) -> None:
+    """Construct the per-worker PostHog client.
+
+    Call AFTER gunicorn forks (the ``post_fork`` hook): posthog-python's background
+    flush thread does not survive ``os.fork()``, so a client built pre-fork silently
+    drops every event in the workers. A no-op when ``POSTHOG_KEY`` is unset (dev/CI/tests).
+    """
+    if not settings.POSTHOG_KEY:
+        return
+
+    _state.client = Posthog(
+        host=settings.POSTHOG_HOST,
+        project_api_key=settings.POSTHOG_KEY,
+    )
+
+
+def capture(
+    distinct_id: str,
+    event: str,
+    properties: dict[str, object] | None = None,
+) -> None:
+    """Send one analytics event; a no-op when disabled, and never raising into the caller.
+
+    Residency: callers must pass metadata only (model ids, lengths, token counts,
+    timings) — never raw prompt or answer text.
+    """
+    client = _state.client
+    if client is None:
+        return
+
+    try:
+        client.capture(
+            distinct_id=distinct_id,
+            event=event,
+            properties={"service": _SERVICE, **(properties or {})},
+        )
+    except Exception:
+        logger.exception("PostHog capture failed (event=%s)", event)
+
+
+def shutdown_posthog() -> None:
+    """Flush and stop the client (the gunicorn ``worker_exit`` hook)."""
+    client = _state.client
+    if client is None:
+        return
+
+    client.flush()
+    client.shutdown()

--- a/api/app/utils/settings.py
+++ b/api/app/utils/settings.py
@@ -37,6 +37,9 @@ class Settings(BaseSettings):
     GOOGLE_BASE_URL: str = ""
     ANTHROPIC_BASE_URL: str = ""
 
+    POSTHOG_KEY: str = ""
+    POSTHOG_HOST: str = "https://eu.i.posthog.com"
+
     CHAT_HISTORY_MAX_TURNS: int = 10
 
     ALLOWED_ORIGINS: list[str] = ["*"]

--- a/api/app/utils/timing.py
+++ b/api/app/utils/timing.py
@@ -28,6 +28,7 @@ class RequestTimings:
         self.reranker_score_max: float | None = None
         self.reranker_score_min: float | None = None
         self.reranker_above_threshold: int | None = None
+        self.response_id: str | None = None
 
     def record(self, name: str, elapsed_ms: float) -> None:
         self.spans[name] = self.spans.get(name, 0.0) + elapsed_ms
@@ -95,6 +96,17 @@ def record_reranker_scores(scores: list[float], above_threshold: int) -> None:
     timings.reranker_score_max = max(scores)
     timings.reranker_score_min = min(scores)
     timings.reranker_above_threshold = above_threshold
+
+
+def record_response_id(response_id: str) -> None:
+    timings = _current.get()
+    if timings is not None:
+        timings.response_id = response_id
+
+
+def current_response_id() -> str | None:
+    timings = _current.get()
+    return timings.response_id if timings is not None else None
 
 
 @contextmanager

--- a/api/app/utils/timing.py
+++ b/api/app/utils/timing.py
@@ -80,7 +80,6 @@ def record_retrieval_shape(candidate_count: int, top_distance: float | None) -> 
 
 
 def record_retrieval_ids(ids: list[str]) -> None:
-    """Record the corpus ids of the items kept for the prompt (ids only — never text)."""
     timings = _current.get()
     if timings is not None:
         timings.retrieval_ids = ids

--- a/api/app/utils/timing.py
+++ b/api/app/utils/timing.py
@@ -24,6 +24,7 @@ class RequestTimings:
         self.thinking_ms: float | None = None
         self.candidate_count: int | None = None
         self.top_distance: float | None = None
+        self.retrieval_ids: list[str] = []
 
     def record(self, name: str, elapsed_ms: float) -> None:
         self.spans[name] = self.spans.get(name, 0.0) + elapsed_ms
@@ -76,6 +77,13 @@ def record_retrieval_shape(candidate_count: int, top_distance: float | None) -> 
     if timings is not None:
         timings.candidate_count = candidate_count
         timings.top_distance = top_distance
+
+
+def record_retrieval_ids(ids: list[str]) -> None:
+    """Record the corpus ids of the items kept for the prompt (ids only — never text)."""
+    timings = _current.get()
+    if timings is not None:
+        timings.retrieval_ids = ids
 
 
 @contextmanager

--- a/api/app/utils/timing.py
+++ b/api/app/utils/timing.py
@@ -29,6 +29,7 @@ class RequestTimings:
         self.reranker_score_min: float | None = None
         self.reranker_above_threshold: int | None = None
         self.response_id: str | None = None
+        self.distinct_id: str | None = None
 
     def record(self, name: str, elapsed_ms: float) -> None:
         self.spans[name] = self.spans.get(name, 0.0) + elapsed_ms
@@ -107,6 +108,17 @@ def record_response_id(response_id: str) -> None:
 def current_response_id() -> str | None:
     timings = _current.get()
     return timings.response_id if timings is not None else None
+
+
+def record_distinct_id(distinct_id: str) -> None:
+    timings = _current.get()
+    if timings is not None:
+        timings.distinct_id = distinct_id
+
+
+def current_distinct_id() -> str | None:
+    timings = _current.get()
+    return timings.distinct_id if timings is not None else None
 
 
 @contextmanager

--- a/api/app/utils/timing.py
+++ b/api/app/utils/timing.py
@@ -25,6 +25,9 @@ class RequestTimings:
         self.candidate_count: int | None = None
         self.top_distance: float | None = None
         self.retrieval_ids: list[str] = []
+        self.reranker_score_max: float | None = None
+        self.reranker_score_min: float | None = None
+        self.reranker_above_threshold: int | None = None
 
     def record(self, name: str, elapsed_ms: float) -> None:
         self.spans[name] = self.spans.get(name, 0.0) + elapsed_ms
@@ -83,6 +86,15 @@ def record_retrieval_ids(ids: list[str]) -> None:
     timings = _current.get()
     if timings is not None:
         timings.retrieval_ids = ids
+
+
+def record_reranker_scores(scores: list[float], above_threshold: int) -> None:
+    timings = _current.get()
+    if timings is None or not scores:
+        return
+    timings.reranker_score_max = max(scores)
+    timings.reranker_score_min = min(scores)
+    timings.reranker_above_threshold = above_threshold
 
 
 @contextmanager

--- a/api/app/utils/topic.py
+++ b/api/app/utils/topic.py
@@ -1,0 +1,182 @@
+"""Lightweight, residency-safe topic classification for chat queries.
+
+Maps a query to a coarse university-FAQ topic by keyword matching so analytics can group
+questions by subject WITHOUT the raw query text ever leaving the server: only the resulting
+``topic`` label is emitted. Covers Macedonian (Cyrillic) and English terms; extend
+``_TOPIC_KEYWORDS`` to refine coverage. Returns ``OTHER_TOPIC`` when nothing matches.
+
+Matching is plain casefolded substring containment, which catches Macedonian inflections
+(``испит`` matches ``испитот`` / ``испити`` / ``испитна``) without a stemmer.
+"""
+
+OTHER_TOPIC = "other"
+
+# Ordered: the first topic with a keyword hit wins, so the more specific intents (thesis,
+# exams) are checked before the broader ones. ``technical_account`` precedes
+# ``courses_syllabus`` so a login/password question that names ``courses.finki`` is not
+# claimed by the ``course`` keyword. Keep keywords as stems so they match inflected forms
+# via substring containment.
+_TOPIC_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "thesis_diploma",
+        (
+            "дипломск",
+            "дипломир",
+            "ментор",
+            "магистер",
+            "магистр",
+            "докторск",
+            "thesis",
+            "diploma",
+            "mentor",
+        ),
+    ),
+    (
+        "exams_grades",
+        (
+            "испит",
+            "колоквиум",
+            "оцен",
+            "обврск",
+            "положив",
+            "паднав",
+            "пријав",
+            "рокови",
+            "сесиј",
+            "поправ",
+            "exam",
+            "grade",
+            "colloqui",
+            "midterm",
+            "retake",
+            "resit",
+        ),
+    ),
+    (
+        "schedule_timetable",
+        (
+            "распоред",
+            "термин",
+            "предавањ",
+            "вежб",
+            "часови",
+            "сала",
+            "schedule",
+            "timetable",
+            "lecture",
+        ),
+    ),
+    (
+        "admissions_enrollment",
+        (
+            "упис",
+            "запишув",
+            "конкурс",
+            "бруцош",
+            "прв циклус",
+            "втор циклус",
+            "enrol",
+            "admiss",
+            "applic",
+            "freshman",
+        ),
+    ),
+    (
+        "fees_payments",
+        (
+            "уплат",
+            "плаќањ",
+            "школарин",
+            "партиципациј",
+            "стипенди",
+            "цена",
+            "чини",
+            "кошта",
+            "fee",
+            "payment",
+            "tuition",
+            "scholarship",
+            "refund",
+        ),
+    ),
+    (
+        "technical_account",
+        (
+            "лозинк",
+            "најав",
+            "профил",
+            "налог",
+            "платформ",
+            "пристап",
+            "courses.finki",
+            "iknow",
+            "moodle",
+            "portal",
+            "login",
+            "log in",
+            "password",
+            "account",
+        ),
+    ),
+    (
+        "courses_syllabus",
+        (
+            "предмет",
+            "силабус",
+            "програм",
+            "кредит",
+            "ектс",
+            "изборен",
+            "course",
+            "subject",
+            "syllabus",
+            "curricul",
+            "ects",
+            "elective",
+        ),
+    ),
+    (
+        "administration_documents",
+        (
+            "документ",
+            "потврд",
+            "уверение",
+            "барањ",
+            "индекс",
+            "студентски прашањ",
+            "архив",
+            "печат",
+            "молб",
+            "document",
+            "certificate",
+            "transcript",
+            "stamp",
+        ),
+    ),
+    (
+        "professors_contacts",
+        (
+            "професор",
+            "асистент",
+            "кабинет",
+            "контакт",
+            "мејл",
+            "е-пошт",
+            "professor",
+            "assistant",
+            "office hour",
+            "contact",
+            "email",
+            "e-mail",
+        ),
+    ),
+)
+
+
+def classify_topic(query: str) -> str:
+    """The coarse FAQ topic of ``query`` (a label only — the query text never leaves)."""
+    text = query.casefold()
+    for topic, keywords in _TOPIC_KEYWORDS:
+        if any(keyword in text for keyword in keywords):
+            return topic
+    return OTHER_TOPIC

--- a/api/app/utils/topic.py
+++ b/api/app/utils/topic.py
@@ -1,21 +1,7 @@
-"""Lightweight, residency-safe topic classification for chat queries.
-
-Maps a query to a coarse university-FAQ topic by keyword matching so analytics can group
-questions by subject WITHOUT the raw query text ever leaving the server: only the resulting
-``topic`` label is emitted. Covers Macedonian (Cyrillic) and English terms; extend
-``_TOPIC_KEYWORDS`` to refine coverage. Returns ``OTHER_TOPIC`` when nothing matches.
-
-Matching is plain casefolded substring containment, which catches Macedonian inflections
-(``испит`` matches ``испитот`` / ``испити`` / ``испитна``) without a stemmer.
-"""
+"""Residency-safe coarse topic labelling for chat queries (keyword match; label only)."""
 
 OTHER_TOPIC = "other"
 
-# Ordered: the first topic with a keyword hit wins, so the more specific intents (thesis,
-# exams) are checked before the broader ones. ``technical_account`` precedes
-# ``courses_syllabus`` so a login/password question that names ``courses.finki`` is not
-# claimed by the ``course`` keyword. Keep keywords as stems so they match inflected forms
-# via substring containment.
 _TOPIC_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
         "thesis_diploma",
@@ -174,7 +160,6 @@ _TOPIC_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
 
 
 def classify_topic(query: str) -> str:
-    """The coarse FAQ topic of ``query`` (a label only — the query text never leaves)."""
     text = query.casefold()
     for topic, keywords in _TOPIC_KEYWORDS:
         if any(keyword in text for keyword in keywords):

--- a/api/app/utils/topic.py
+++ b/api/app/utils/topic.py
@@ -165,3 +165,14 @@ def classify_topic(query: str) -> str:
         if any(keyword in text for keyword in keywords):
             return topic
     return OTHER_TOPIC
+
+
+def classify_language(query: str) -> str:
+    """Coarse script-based language label of ``query``: "mk", "en" or "other" (label only)."""
+    cyrillic = sum("Ѐ" <= ch <= "ӿ" for ch in query)
+    latin = sum(("a" <= ch <= "z") or ("A" <= ch <= "Z") for ch in query)
+    if cyrillic == 0 and latin == 0:
+        return "other"
+    if cyrillic >= latin:
+        return "mk"
+    return "en"

--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -11,3 +11,17 @@ worker_class = "uvicorn.workers.UvicornWorker"
 accesslog = "-"
 errorlog = "-"
 loglevel = os.getenv("LOG_LEVEL", "info")
+
+
+def post_fork(server: object, worker: object) -> None:
+    # Build the PostHog client AFTER fork — its flush thread does not survive os.fork().
+    from app.utils.posthog_client import init_posthog  # noqa: PLC0415
+    from app.utils.settings import Settings  # noqa: PLC0415
+
+    init_posthog(Settings())
+
+
+def worker_exit(server: object, worker: object) -> None:
+    from app.utils.posthog_client import shutdown_posthog  # noqa: PLC0415
+
+    shutdown_posthog()

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "langchain-openai>=1.3.3",
     "langchain-text-splitters>=1.1.2",
     "langgraph>=1.2.6",
+    "posthog>=7.21.0",
     "pydantic>=2.13.4",
 ]
 

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -68,6 +68,7 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "langchain-text-splitters" },
     { name = "langgraph" },
+    { name = "posthog" },
     { name = "pydantic" },
 ]
 
@@ -92,6 +93,7 @@ requires-dist = [
     { name = "langchain-openai", specifier = ">=1.3.3" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langgraph", specifier = ">=1.2.6" },
+    { name = "posthog", specifier = ">=7.21.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
 ]
 
@@ -186,6 +188,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
 ]
 
 [[package]]
@@ -1195,6 +1206,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/14/edebfb265f7141f4681b7f2d1cd8dea2621010a9ad7d3819831db2037f13/posthog-7.21.0.tar.gz", hash = "sha256:182ab7572748ae5199cb72c281a3549b70920cb8071e037ff6e07acbfae80876", size = 308788, upload-time = "2026-06-26T15:57:01.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/07/ca761fd0e3b23e9bfeaaeeffa5df4c235fd0c5086d89934553583e6902f3/posthog-7.21.0-py3-none-any.whl", hash = "sha256:11dca1e9772bedcb6721751fb0945fa8dcddbf9a4e72e2430483b53cdb8d1ec0", size = 370932, upload-time = "2026-06-26T15:56:59.844Z" },
 ]
 
 [[package]]

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -29,7 +29,7 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
       POSTHOG_HOST: ${POSTHOG_HOST:-https://eu.i.posthog.com}
-      POSTHOG_KEY: ${POSTHOG_KEY:-phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd}
+      POSTHOG_KEY: ${POSTHOG_KEY:-}
       RERANKER_MIN_SCORE: ${RERANKER_MIN_SCORE:-0.1}
       TZ: ${TZ}
       WORKERS: ${WORKERS}
@@ -68,7 +68,7 @@ services:
       HF_HOME: /huggingface_cache
       LOG_LEVEL: ${LOG_LEVEL}
       POSTHOG_HOST: ${POSTHOG_HOST:-https://eu.i.posthog.com}
-      POSTHOG_KEY: ${POSTHOG_KEY:-phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd}
+      POSTHOG_KEY: ${POSTHOG_KEY:-}
       PRELOAD_BGEM3: ${PRELOAD_BGEM3}
       RERANKER_MODEL: ${RERANKER_MODEL:-BAAI/bge-reranker-v2-m3}
       TZ: ${TZ}

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -28,6 +28,8 @@ services:
       OLLAMA_URL: ${OLLAMA_URL}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
+      POSTHOG_HOST: ${POSTHOG_HOST:-https://eu.i.posthog.com}
+      POSTHOG_KEY: ${POSTHOG_KEY:-phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd}
       RERANKER_MIN_SCORE: ${RERANKER_MIN_SCORE:-0.1}
       TZ: ${TZ}
       WORKERS: ${WORKERS}
@@ -65,6 +67,8 @@ services:
     environment:
       HF_HOME: /huggingface_cache
       LOG_LEVEL: ${LOG_LEVEL}
+      POSTHOG_HOST: ${POSTHOG_HOST:-https://eu.i.posthog.com}
+      POSTHOG_KEY: ${POSTHOG_KEY:-phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd}
       PRELOAD_BGEM3: ${PRELOAD_BGEM3}
       RERANKER_MODEL: ${RERANKER_MODEL:-BAAI/bge-reranker-v2-m3}
       TZ: ${TZ}

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,6 +30,8 @@ services:
       OLLAMA_URL: ${OLLAMA_URL}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
+      POSTHOG_HOST: ${POSTHOG_HOST:-https://eu.i.posthog.com}
+      POSTHOG_KEY: ${POSTHOG_KEY:-phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd}
       RERANKER_MIN_SCORE: ${RERANKER_MIN_SCORE:-0.1}
       TZ: ${TZ}
       WORKERS: ${WORKERS}
@@ -70,6 +72,8 @@ services:
     environment:
       HF_HOME: /huggingface_cache
       LOG_LEVEL: ${LOG_LEVEL}
+      POSTHOG_HOST: ${POSTHOG_HOST:-https://eu.i.posthog.com}
+      POSTHOG_KEY: ${POSTHOG_KEY:-phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd}
       PRELOAD_BGEM3: ${PRELOAD_BGEM3}
       RERANKER_MODEL: ${RERANKER_MODEL:-BAAI/bge-reranker-v2-m3}
       TZ: ${TZ}

--- a/compose.yaml
+++ b/compose.yaml
@@ -31,7 +31,7 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
       POSTHOG_HOST: ${POSTHOG_HOST:-https://eu.i.posthog.com}
-      POSTHOG_KEY: ${POSTHOG_KEY:-phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd}
+      POSTHOG_KEY: ${POSTHOG_KEY:-}
       RERANKER_MIN_SCORE: ${RERANKER_MIN_SCORE:-0.1}
       TZ: ${TZ}
       WORKERS: ${WORKERS}
@@ -73,7 +73,7 @@ services:
       HF_HOME: /huggingface_cache
       LOG_LEVEL: ${LOG_LEVEL}
       POSTHOG_HOST: ${POSTHOG_HOST:-https://eu.i.posthog.com}
-      POSTHOG_KEY: ${POSTHOG_KEY:-phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd}
+      POSTHOG_KEY: ${POSTHOG_KEY:-}
       PRELOAD_BGEM3: ${PRELOAD_BGEM3}
       RERANKER_MODEL: ${RERANKER_MODEL:-BAAI/bge-reranker-v2-m3}
       TZ: ${TZ}

--- a/gpu-api/app/api/embeddings.py
+++ b/gpu-api/app/api/embeddings.py
@@ -2,12 +2,11 @@ import json
 import logging
 from time import perf_counter
 
-import torch
 from fastapi import APIRouter, Request, status
 
 from app.llms.embeddings import generate_embeddings
 from app.schemas.embeddings import EmbedRequestSchema, EmbedResponseSchema
-from app.utils.analytics import capture, safe_response_id
+from app.utils.analytics import capture_chat_inference
 
 logger = logging.getLogger(__name__)
 
@@ -50,18 +49,14 @@ async def embed(payload: EmbedRequestSchema, request: Request) -> EmbedResponseS
             },
         ),
     )
-    response_id = safe_response_id(request.headers.get("X-Response-Id"))
-    capture(
-        response_id or "gpu-api",
-        "chat_inference",
-        {
-            "stage": "embed",
+    capture_chat_inference(
+        request,
+        stage="embed",
+        ms=ms,
+        props={
             "model": payload.embeddings_model.value,
             "count": count,
             "input_chars": input_chars,
-            "ms": ms,
-            "device": "cuda" if torch.cuda.is_available() else "cpu",
-            "response_id": response_id,
         },
     )
     return EmbedResponseSchema(embeddings=embeddings)

--- a/gpu-api/app/api/embeddings.py
+++ b/gpu-api/app/api/embeddings.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Request, status
 
 from app.llms.embeddings import generate_embeddings
 from app.schemas.embeddings import EmbedRequestSchema, EmbedResponseSchema
-from app.utils.analytics import capture
+from app.utils.analytics import capture, safe_response_id
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ async def embed(payload: EmbedRequestSchema, request: Request) -> EmbedResponseS
             },
         ),
     )
-    response_id = request.headers.get("X-Response-Id")
+    response_id = safe_response_id(request.headers.get("X-Response-Id"))
     capture(
         response_id or "gpu-api",
         "chat_inference",

--- a/gpu-api/app/api/embeddings.py
+++ b/gpu-api/app/api/embeddings.py
@@ -2,10 +2,12 @@ import json
 import logging
 from time import perf_counter
 
-from fastapi import APIRouter, status
+import torch
+from fastapi import APIRouter, Request, status
 
 from app.llms.embeddings import generate_embeddings
 from app.schemas.embeddings import EmbedRequestSchema, EmbedResponseSchema
+from app.utils.analytics import capture
 
 logger = logging.getLogger(__name__)
 
@@ -28,18 +30,38 @@ router = APIRouter(
         },
     },
 )
-async def embed(payload: EmbedRequestSchema) -> EmbedResponseSchema:
+async def embed(payload: EmbedRequestSchema, request: Request) -> EmbedResponseSchema:
     start = perf_counter()
     embeddings = await generate_embeddings(payload.input, payload.embeddings_model)
     count = 1 if isinstance(payload.input, str) else len(payload.input)
+    input_chars = (
+        len(payload.input)
+        if isinstance(payload.input, str)
+        else sum(len(item) for item in payload.input)
+    )
+    ms = round((perf_counter() - start) * 1000, 1)
     logger.info(
         "gpu.embed %s",
         json.dumps(
             {
                 "model": payload.embeddings_model.value,
                 "count": count,
-                "ms": round((perf_counter() - start) * 1000, 1),
+                "ms": ms,
             },
         ),
+    )
+    response_id = request.headers.get("X-Response-Id")
+    capture(
+        response_id or "gpu-api",
+        "chat_inference",
+        {
+            "stage": "embed",
+            "model": payload.embeddings_model.value,
+            "count": count,
+            "input_chars": input_chars,
+            "ms": ms,
+            "device": "cuda" if torch.cuda.is_available() else "cpu",
+            "response_id": response_id,
+        },
     )
     return EmbedResponseSchema(embeddings=embeddings)

--- a/gpu-api/app/api/rerank.py
+++ b/gpu-api/app/api/rerank.py
@@ -3,10 +3,12 @@ import json
 import logging
 from time import perf_counter
 
-from fastapi import APIRouter, status
+import torch
+from fastapi import APIRouter, Request, status
 
 from app.llms.reranker import rerank_documents
 from app.schemas.rerank import RankedDocument, RerankRequestSchema, RerankResponseSchema
+from app.utils.analytics import capture
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +38,10 @@ router = APIRouter(
         },
     },
 )
-async def handle_rerank(payload: RerankRequestSchema) -> RerankResponseSchema:
+async def handle_rerank(
+    payload: RerankRequestSchema,
+    request: Request,
+) -> RerankResponseSchema:
     logger.info(
         "Received rerank request with query: %s and %d documents",
         payload.query,
@@ -52,14 +57,29 @@ async def handle_rerank(payload: RerankRequestSchema) -> RerankResponseSchema:
         payload.query,
         payload.documents,
     )
+    ms = round((perf_counter() - start) * 1000, 1)
     logger.info(
         "gpu.rerank %s",
         json.dumps(
             {
                 "docs": len(payload.documents),
-                "ms": round((perf_counter() - start) * 1000, 1),
+                "ms": ms,
             },
         ),
+    )
+    response_id = request.headers.get("X-Response-Id")
+    capture(
+        response_id or "gpu-api",
+        "chat_inference",
+        {
+            "stage": "rerank",
+            "docs": len(payload.documents),
+            "query_chars": len(payload.query),
+            "doc_chars": sum(len(doc) for doc in payload.documents),
+            "ms": ms,
+            "device": "cuda" if torch.cuda.is_available() else "cpu",
+            "response_id": response_id,
+        },
     )
 
     return RerankResponseSchema(

--- a/gpu-api/app/api/rerank.py
+++ b/gpu-api/app/api/rerank.py
@@ -3,12 +3,11 @@ import json
 import logging
 from time import perf_counter
 
-import torch
 from fastapi import APIRouter, Request, status
 
 from app.llms.reranker import rerank_documents
 from app.schemas.rerank import RankedDocument, RerankRequestSchema, RerankResponseSchema
-from app.utils.analytics import capture, safe_response_id
+from app.utils.analytics import capture_chat_inference
 
 logger = logging.getLogger(__name__)
 
@@ -67,18 +66,14 @@ async def handle_rerank(
             },
         ),
     )
-    response_id = safe_response_id(request.headers.get("X-Response-Id"))
-    capture(
-        response_id or "gpu-api",
-        "chat_inference",
-        {
-            "stage": "rerank",
+    capture_chat_inference(
+        request,
+        stage="rerank",
+        ms=ms,
+        props={
             "docs": len(payload.documents),
             "query_chars": len(payload.query),
             "doc_chars": sum(len(doc) for doc in payload.documents),
-            "ms": ms,
-            "device": "cuda" if torch.cuda.is_available() else "cpu",
-            "response_id": response_id,
         },
     )
 

--- a/gpu-api/app/api/rerank.py
+++ b/gpu-api/app/api/rerank.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Request, status
 
 from app.llms.reranker import rerank_documents
 from app.schemas.rerank import RankedDocument, RerankRequestSchema, RerankResponseSchema
-from app.utils.analytics import capture
+from app.utils.analytics import capture, safe_response_id
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +67,7 @@ async def handle_rerank(
             },
         ),
     )
-    response_id = request.headers.get("X-Response-Id")
+    response_id = safe_response_id(request.headers.get("X-Response-Id"))
     capture(
         response_id or "gpu-api",
         "chat_inference",

--- a/gpu-api/app/main.py
+++ b/gpu-api/app/main.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from asyncio import gather, to_thread
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -8,7 +9,9 @@ from fastapi import FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from starlette.datastructures import Headers
 from starlette.middleware.cors import CORSMiddleware
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.api.embeddings import router as embeddings_router
 from app.api.health import router as health_router
@@ -20,6 +23,7 @@ from app.utils.analytics import (
     capture,
     capture_exception,
     init_analytics,
+    safe_response_id,
     shutdown_analytics,
 )
 from app.utils.exceptions import ModelNotReadyError
@@ -60,6 +64,70 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     shutdown_analytics()
 
 
+# Extreme-noise paths kept out of request_completed to control event volume.
+_SKIP_PATHS: frozenset[str] = frozenset(
+    {"/docs", "/redoc", "/openapi.json", "/favicon.ico"},
+)
+_SKIP_PREFIXES: tuple[str, ...] = ("/health",)
+
+
+def _request_outcome(status_code: int) -> str:
+    if status_code >= 500:
+        return "server_error"
+    if status_code >= 400:
+        return "client_error"
+    return "ok"
+
+
+class RequestTrackingMiddleware:
+    """Emit one ``request_completed`` PostHog event per HTTP request (metadata only).
+
+    A pure ASGI middleware, not BaseHTTPMiddleware, so it never buffers a streaming body:
+    it only reads the status off ``http.response.start`` and times the whole request. The
+    matched route TEMPLATE is reported (never the raw path), so ids never leak and route /
+    person cardinality stays bounded.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        path = scope.get("path", "")
+        if path in _SKIP_PATHS or path.startswith(_SKIP_PREFIXES):
+            await self.app(scope, receive, send)
+            return
+
+        start = time.perf_counter()
+        status_code = 500
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            route = scope.get("route")
+            template = getattr(route, "path", None) or path
+            capture(
+                safe_response_id(Headers(scope=scope).get("x-response-id"))
+                or "gpu-api",
+                "request_completed",
+                {
+                    "route": template,
+                    "method": scope.get("method", ""),
+                    "status_code": status_code,
+                    "duration_ms": round((time.perf_counter() - start) * 1000, 1),
+                    "outcome": _request_outcome(status_code),
+                },
+            )
+
+
 def make_app(settings: Settings) -> FastAPI:
     """
     Create and configure the FastAPI application.
@@ -86,6 +154,11 @@ def make_app(settings: Settings) -> FastAPI:
         allow_headers=["*"],
         expose_headers=settings.EXPOSE_HEADERS,
     )
+
+    # Added last so it sits outermost and times the whole request. A handled error (e.g.
+    # 422/503) arrives as a normal response we read the status off; an unhandled 500
+    # propagates here as an exception, so status_code stays 500 and we still emit in finally.
+    app.add_middleware(RequestTrackingMiddleware)
 
     app.include_router(embeddings_router)
     app.include_router(streams_router)

--- a/gpu-api/app/main.py
+++ b/gpu-api/app/main.py
@@ -16,7 +16,12 @@ from app.api.rerank import router as rerank_router
 from app.api.streams import router as streams_router
 from app.llms.bge_m3 import init_bge_m3_embedder
 from app.llms.reranker import init_reranker
-from app.utils.analytics import capture, init_analytics, shutdown_analytics
+from app.utils.analytics import (
+    capture,
+    capture_exception,
+    init_analytics,
+    shutdown_analytics,
+)
 from app.utils.exceptions import ModelNotReadyError
 from app.utils.logger import setup_logging
 from app.utils.settings import Settings
@@ -124,6 +129,10 @@ def make_app(settings: Settings) -> FastAPI:
         exc: Exception,
     ) -> JSONResponse:
         logger.exception("Unhandled exception")
+        capture_exception(
+            exc,
+            properties={"path": request.url.path, "method": request.method},
+        )
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content={"detail": "An unexpected internal server error occurred."},

--- a/gpu-api/app/main.py
+++ b/gpu-api/app/main.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from asyncio import gather, to_thread
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -9,9 +8,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-from starlette.datastructures import Headers
 from starlette.middleware.cors import CORSMiddleware
-from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.api.embeddings import router as embeddings_router
 from app.api.health import router as health_router
@@ -21,9 +18,9 @@ from app.llms.bge_m3 import init_bge_m3_embedder
 from app.llms.reranker import init_reranker
 from app.utils.analytics import (
     capture,
-    capture_exception,
+    capture_request_exception,
     init_analytics,
-    safe_response_id,
+    register_request_middleware,
     shutdown_analytics,
 )
 from app.utils.exceptions import ModelNotReadyError
@@ -64,70 +61,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     shutdown_analytics()
 
 
-# Extreme-noise paths kept out of request_completed to control event volume.
-_SKIP_PATHS: frozenset[str] = frozenset(
-    {"/docs", "/redoc", "/openapi.json", "/favicon.ico"},
-)
-_SKIP_PREFIXES: tuple[str, ...] = ("/health",)
-
-
-def _request_outcome(status_code: int) -> str:
-    if status_code >= 500:
-        return "server_error"
-    if status_code >= 400:
-        return "client_error"
-    return "ok"
-
-
-class RequestTrackingMiddleware:
-    """Emit one ``request_completed`` PostHog event per HTTP request (metadata only).
-
-    A pure ASGI middleware, not BaseHTTPMiddleware, so it never buffers a streaming body:
-    it only reads the status off ``http.response.start`` and times the whole request. The
-    matched route TEMPLATE is reported (never the raw path), so ids never leak and route /
-    person cardinality stays bounded.
-    """
-
-    def __init__(self, app: ASGIApp) -> None:
-        self.app = app
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http":
-            await self.app(scope, receive, send)
-            return
-        path = scope.get("path", "")
-        if path in _SKIP_PATHS or path.startswith(_SKIP_PREFIXES):
-            await self.app(scope, receive, send)
-            return
-
-        start = time.perf_counter()
-        status_code = 500
-
-        async def send_wrapper(message: Message) -> None:
-            nonlocal status_code
-            if message["type"] == "http.response.start":
-                status_code = message["status"]
-            await send(message)
-
-        try:
-            await self.app(scope, receive, send_wrapper)
-        finally:
-            route = scope.get("route")
-            template = getattr(route, "path", None) or path
-            capture(
-                safe_response_id(Headers(scope=scope).get("x-response-id"))
-                or "gpu-api",
-                "request_completed",
-                {
-                    "route": template,
-                    "method": scope.get("method", ""),
-                    "status_code": status_code,
-                    "duration_ms": round((time.perf_counter() - start) * 1000, 1),
-                    "outcome": _request_outcome(status_code),
-                },
-            )
-
-
 def make_app(settings: Settings) -> FastAPI:
     """
     Create and configure the FastAPI application.
@@ -155,10 +88,8 @@ def make_app(settings: Settings) -> FastAPI:
         expose_headers=settings.EXPOSE_HEADERS,
     )
 
-    # Added last so it sits outermost and times the whole request. A handled error (e.g.
-    # 422/503) arrives as a normal response we read the status off; an unhandled 500
-    # propagates here as an exception, so status_code stays 500 and we still emit in finally.
-    app.add_middleware(RequestTrackingMiddleware)
+    # Added last so it sits outermost and times the whole request.
+    register_request_middleware(app)
 
     app.include_router(embeddings_router)
     app.include_router(streams_router)
@@ -202,10 +133,7 @@ def make_app(settings: Settings) -> FastAPI:
         exc: Exception,
     ) -> JSONResponse:
         logger.exception("Unhandled exception")
-        capture_exception(
-            exc,
-            properties={"path": request.url.path, "method": request.method},
-        )
+        capture_request_exception(request, exc)
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content={"detail": "An unexpected internal server error occurred."},

--- a/gpu-api/app/main.py
+++ b/gpu-api/app/main.py
@@ -16,6 +16,7 @@ from app.api.rerank import router as rerank_router
 from app.api.streams import router as streams_router
 from app.llms.bge_m3 import init_bge_m3_embedder
 from app.llms.reranker import init_reranker
+from app.utils.analytics import capture, init_analytics, shutdown_analytics
 from app.utils.exceptions import ModelNotReadyError
 from app.utils.logger import setup_logging
 from app.utils.settings import Settings
@@ -29,7 +30,8 @@ setup_logging(level=settings.LOG_LEVEL)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
-    if torch.cuda.is_available():
+    cuda_available = torch.cuda.is_available()
+    if cuda_available:
         logger.info(
             "gpu.cuda available=True device=%s count=%d",
             torch.cuda.get_device_name(0),
@@ -38,6 +40,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     else:
         logger.warning("gpu.cuda available=False - models will run on CPU")
 
+    init_analytics(settings)
+    if not cuda_available:
+        capture("gpu-api", "cuda_fallback", {"device": "cpu"})
+
     tasks = [to_thread(init_reranker, settings.RERANKER_MODEL)]
     if settings.PRELOAD_BGEM3:
         tasks.append(to_thread(init_bge_m3_embedder))
@@ -45,6 +51,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     await gather(*tasks)
 
     yield
+
+    shutdown_analytics()
 
 
 def make_app(settings: Settings) -> FastAPI:

--- a/gpu-api/app/utils/analytics.py
+++ b/gpu-api/app/utils/analytics.py
@@ -9,14 +9,10 @@ logger = logging.getLogger(__name__)
 
 _SERVICE = "chat-bot-gpu-api"
 
-# X-Response-Id is an untrusted client header used as the PostHog person id. Bound it to a
-# short, opaque token (the api forwards a UUID) so a caller can't inject PII/free text or
-# explode person cardinality.
 _RESPONSE_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
 
 
 def safe_response_id(raw: str | None) -> str | None:
-    """The caller's ``X-Response-Id`` if it's a short opaque token, else ``None``."""
     if raw is None:
         return None
     candidate = raw.strip()
@@ -31,11 +27,6 @@ _state = _State()
 
 
 def init_analytics(settings: Settings) -> None:
-    """Construct the PostHog client; a no-op when ``POSTHOG_KEY`` is unset (dev/CI/tests).
-
-    Called from the app lifespan, which runs per-worker after gunicorn forks, so the
-    posthog-python background flush thread is created in the worker that uses it.
-    """
     if not settings.POSTHOG_KEY:
         return
 
@@ -50,11 +41,6 @@ def capture(
     event: str,
     properties: dict[str, object] | None = None,
 ) -> None:
-    """Send one analytics event; a no-op when disabled, and never raising into the caller.
-
-    Residency: callers must pass metadata only (model ids, counts, char lengths,
-    timings) — never the embedded or reranked text.
-    """
     client = _state.client
     if client is None:
         return
@@ -74,15 +60,7 @@ def capture_exception(
     distinct_id: str = "server",
     properties: dict[str, object] | None = None,
 ) -> None:
-    """Report an unhandled exception to PostHog Error Tracking as a metadata-only
-    ``$exception`` event; a no-op when disabled, and never raising into the caller.
-
-    Residency: the exception object is NEVER handed to the SDK. posthog-python's
-    ``capture_exception`` serializes the full stacktrace WITH frame-local variables and
-    the raw ``str(exc)`` message, both of which can embed sovereign text (the embedded or
-    reranked query/documents). Only the exception type, service and caller metadata
-    (request path, method, status) leave; the message/value is redacted.
-    """
+    # Residency: never forward the exc object — posthog-python serialises frame-locals + str(exc), which leak sovereign embedded/reranked text. Send a redacted $exception instead.
     client = _state.client
     if client is None:
         return
@@ -106,7 +84,6 @@ def capture_exception(
 
 
 def shutdown_analytics() -> None:
-    """Flush and stop the client (called after the lifespan ``yield``)."""
     client = _state.client
     if client is None:
         return

--- a/gpu-api/app/utils/analytics.py
+++ b/gpu-api/app/utils/analytics.py
@@ -55,6 +55,31 @@ def capture(
         logger.exception("PostHog capture failed (event=%s)", event)
 
 
+def capture_exception(
+    exc: BaseException,
+    distinct_id: str = "server",
+    properties: dict[str, object] | None = None,
+) -> None:
+    """Report an unhandled exception to PostHog Error Tracking; a no-op when disabled,
+    and never raising into the caller.
+
+    Residency: callers must pass metadata only (request path, method, status) — never
+    the embedded or reranked text.
+    """
+    client = _state.client
+    if client is None:
+        return
+
+    try:
+        client.capture_exception(
+            exc,
+            distinct_id=distinct_id,
+            properties={"service": _SERVICE, **(properties or {})},
+        )
+    except Exception:
+        logger.exception("PostHog capture_exception failed")
+
+
 def shutdown_analytics() -> None:
     """Flush and stop the client (called after the lifespan ``yield``)."""
     client = _state.client

--- a/gpu-api/app/utils/analytics.py
+++ b/gpu-api/app/utils/analytics.py
@@ -72,24 +72,16 @@ def capture_exception(
     distinct_id: str = "server",
     properties: dict[str, object] | None = None,
 ) -> None:
-    # Residency: never forward the exc object — posthog-python serialises frame-locals + str(exc), which leak sovereign embedded/reranked text. Send a redacted $exception instead.
     client = _state.client
     if client is None:
         return
 
-    error_type = type(exc).__name__
+    # Capture the real exception (type, message, stacktrace) for debugging.
     try:
-        client.capture(
-            event="$exception",
+        client.capture_exception(
+            exc,
             distinct_id=distinct_id,
-            properties={
-                "service": _SERVICE,
-                "error_type": error_type,
-                "$exception_list": [
-                    {"type": error_type, "value": "(redacted for residency)"},
-                ],
-                **(properties or {}),
-            },
+            properties={"service": _SERVICE, **(properties or {})},
         )
     except Exception:
         logger.exception("PostHog capture_exception failed")

--- a/gpu-api/app/utils/analytics.py
+++ b/gpu-api/app/utils/analytics.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from posthog import Posthog
 
@@ -7,6 +8,19 @@ from app.utils.settings import Settings
 logger = logging.getLogger(__name__)
 
 _SERVICE = "chat-bot-gpu-api"
+
+# X-Response-Id is an untrusted client header used as the PostHog person id. Bound it to a
+# short, opaque token (the api forwards a UUID) so a caller can't inject PII/free text or
+# explode person cardinality.
+_RESPONSE_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
+
+
+def safe_response_id(raw: str | None) -> str | None:
+    """The caller's ``X-Response-Id`` if it's a short opaque token, else ``None``."""
+    if raw is None:
+        return None
+    candidate = raw.strip()
+    return candidate if _RESPONSE_ID_RE.fullmatch(candidate) else None
 
 
 class _State:

--- a/gpu-api/app/utils/analytics.py
+++ b/gpu-api/app/utils/analytics.py
@@ -1,0 +1,65 @@
+import logging
+
+from posthog import Posthog
+
+from app.utils.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+_SERVICE = "chat-bot-gpu-api"
+
+
+class _State:
+    client: Posthog | None = None
+
+
+_state = _State()
+
+
+def init_analytics(settings: Settings) -> None:
+    """Construct the PostHog client; a no-op when ``POSTHOG_KEY`` is unset (dev/CI/tests).
+
+    Called from the app lifespan, which runs per-worker after gunicorn forks, so the
+    posthog-python background flush thread is created in the worker that uses it.
+    """
+    if not settings.POSTHOG_KEY:
+        return
+
+    _state.client = Posthog(
+        host=settings.POSTHOG_HOST,
+        project_api_key=settings.POSTHOG_KEY,
+    )
+
+
+def capture(
+    distinct_id: str,
+    event: str,
+    properties: dict[str, object] | None = None,
+) -> None:
+    """Send one analytics event; a no-op when disabled, and never raising into the caller.
+
+    Residency: callers must pass metadata only (model ids, counts, char lengths,
+    timings) — never the embedded or reranked text.
+    """
+    client = _state.client
+    if client is None:
+        return
+
+    try:
+        client.capture(
+            distinct_id=distinct_id,
+            event=event,
+            properties={"service": _SERVICE, **(properties or {})},
+        )
+    except Exception:
+        logger.exception("PostHog capture failed (event=%s)", event)
+
+
+def shutdown_analytics() -> None:
+    """Flush and stop the client (called after the lifespan ``yield``)."""
+    client = _state.client
+    if client is None:
+        return
+
+    client.flush()
+    client.shutdown()

--- a/gpu-api/app/utils/analytics.py
+++ b/gpu-api/app/utils/analytics.py
@@ -60,21 +60,32 @@ def capture_exception(
     distinct_id: str = "server",
     properties: dict[str, object] | None = None,
 ) -> None:
-    """Report an unhandled exception to PostHog Error Tracking; a no-op when disabled,
-    and never raising into the caller.
+    """Report an unhandled exception to PostHog Error Tracking as a metadata-only
+    ``$exception`` event; a no-op when disabled, and never raising into the caller.
 
-    Residency: callers must pass metadata only (request path, method, status) — never
-    the embedded or reranked text.
+    Residency: the exception object is NEVER handed to the SDK. posthog-python's
+    ``capture_exception`` serializes the full stacktrace WITH frame-local variables and
+    the raw ``str(exc)`` message, both of which can embed sovereign text (the embedded or
+    reranked query/documents). Only the exception type, service and caller metadata
+    (request path, method, status) leave; the message/value is redacted.
     """
     client = _state.client
     if client is None:
         return
 
+    error_type = type(exc).__name__
     try:
-        client.capture_exception(
-            exc,
+        client.capture(
+            event="$exception",
             distinct_id=distinct_id,
-            properties={"service": _SERVICE, **(properties or {})},
+            properties={
+                "service": _SERVICE,
+                "error_type": error_type,
+                "$exception_list": [
+                    {"type": error_type, "value": "(redacted for residency)"},
+                ],
+                **(properties or {}),
+            },
         )
     except Exception:
         logger.exception("PostHog capture_exception failed")

--- a/gpu-api/app/utils/analytics.py
+++ b/gpu-api/app/utils/analytics.py
@@ -24,6 +24,13 @@ def safe_response_id(raw: str | None) -> str | None:
     return candidate if _RESPONSE_ID_RE.fullmatch(candidate) else None
 
 
+def safe_distinct_id(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    candidate = raw.strip()
+    return candidate if _RESPONSE_ID_RE.fullmatch(candidate) else None
+
+
 class _State:
     client: Posthog | None = None
 
@@ -104,17 +111,52 @@ def capture_chat_inference(
     ms: float,
     props: dict[str, object],
 ) -> None:
-    """Record one embed/rerank stage (metadata only); distinct_id is the bounded caller id."""
-    response_id = safe_response_id(request.headers.get("X-Response-Id"))
-    capture(
-        response_id or "gpu-api",
-        "chat_inference",
-        {
-            "stage": stage,
-            "ms": ms,
-            "device": "cuda" if torch.cuda.is_available() else "cpu",
-            "response_id": response_id,
+    """Record an embed/rerank stage as an LLM-analytics span on the chat's trace.
+
+    With a chat trace id (``X-Response-Id``) the stage is emitted as a native
+    ``$ai_embedding`` / ``$ai_span`` sharing that ``$ai_trace_id`` so it nests under the
+    chat's trace in PostHog; only size/latency metadata is sent, never content
+    (residency). Calls without a trace id (e.g. document fills) fall back to a plain
+    metadata event.
+    """
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    trace_id = safe_response_id(request.headers.get("X-Response-Id"))
+
+    if trace_id is None:
+        capture(
+            "gpu-api",
+            "chat_inference",
+            {"stage": stage, "ms": ms, "device": device, **props},
+        )
+        return
+
+    distinct_id = safe_distinct_id(request.headers.get("X-Distinct-Id")) or trace_id
+    latency_s = round(ms / 1000.0, 4)
+
+    if stage == "embed":
+        properties: dict[str, object] = {
+            "$ai_trace_id": trace_id,
+            "$ai_provider": "gpu-api",
+            "$ai_latency": latency_s,
+            "device": device,
             **props,
+        }
+        model = props.get("model")
+        if model is not None:
+            properties["$ai_model"] = model
+        capture(distinct_id, "$ai_embedding", properties)
+        return
+
+    capture(
+        distinct_id,
+        "$ai_span",
+        {
+            "$ai_trace_id": trace_id,
+            "$ai_span_name": stage,
+            "$ai_latency": latency_s,
+            "$ai_input_state": dict(props),
+            "$ai_output_state": {"reranked_documents": props.get("docs")},
+            "device": device,
         },
     )
 

--- a/gpu-api/app/utils/analytics.py
+++ b/gpu-api/app/utils/analytics.py
@@ -1,7 +1,12 @@
 import logging
 import re
+import time
 
+import torch
+from fastapi import FastAPI, Request
 from posthog import Posthog
+from starlette.datastructures import Headers
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.utils.settings import Settings
 
@@ -90,3 +95,102 @@ def shutdown_analytics() -> None:
 
     client.flush()
     client.shutdown()
+
+
+def capture_chat_inference(
+    request: Request,
+    *,
+    stage: str,
+    ms: float,
+    props: dict[str, object],
+) -> None:
+    """Record one embed/rerank stage (metadata only); distinct_id is the bounded caller id."""
+    response_id = safe_response_id(request.headers.get("X-Response-Id"))
+    capture(
+        response_id or "gpu-api",
+        "chat_inference",
+        {
+            "stage": stage,
+            "ms": ms,
+            "device": "cuda" if torch.cuda.is_available() else "cpu",
+            "response_id": response_id,
+            **props,
+        },
+    )
+
+
+def capture_request_exception(request: Request, exc: Exception) -> None:
+    """Report an unhandled request exception (path/method metadata only, redacted body)."""
+    capture_exception(
+        exc,
+        properties={"path": request.url.path, "method": request.method},
+    )
+
+
+# Extreme-noise paths kept out of request_completed to control event volume.
+_SKIP_PATHS: frozenset[str] = frozenset(
+    {"/docs", "/redoc", "/openapi.json", "/favicon.ico"},
+)
+_SKIP_PREFIXES: tuple[str, ...] = ("/health",)
+
+
+def _request_outcome(status_code: int) -> str:
+    if status_code >= 500:
+        return "server_error"
+    if status_code >= 400:
+        return "client_error"
+    return "ok"
+
+
+class _RequestTrackingMiddleware:
+    """Emit one ``request_completed`` PostHog event per HTTP request (metadata only).
+
+    A pure ASGI middleware, not BaseHTTPMiddleware, so it never buffers a streaming body:
+    it only reads the status off ``http.response.start`` and times the whole request. The
+    matched route TEMPLATE is reported (never the raw path), so ids never leak and route /
+    person cardinality stays bounded.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        path = scope.get("path", "")
+        if path in _SKIP_PATHS or path.startswith(_SKIP_PREFIXES):
+            await self.app(scope, receive, send)
+            return
+
+        start = time.perf_counter()
+        status_code = 500
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            route = scope.get("route")
+            template = getattr(route, "path", None) or path
+            capture(
+                safe_response_id(Headers(scope=scope).get("x-response-id"))
+                or "gpu-api",
+                "request_completed",
+                {
+                    "route": template,
+                    "method": scope.get("method", ""),
+                    "status_code": status_code,
+                    "duration_ms": round((time.perf_counter() - start) * 1000, 1),
+                    "outcome": _request_outcome(status_code),
+                },
+            )
+
+
+def register_request_middleware(app: FastAPI) -> None:
+    """Attach the request_completed middleware (added outermost to time the whole request)."""
+    app.add_middleware(_RequestTrackingMiddleware)

--- a/gpu-api/app/utils/settings.py
+++ b/gpu-api/app/utils/settings.py
@@ -18,6 +18,9 @@ class Settings(BaseSettings):
 
     RERANKER_MODEL: str = "BAAI/bge-reranker-v2-m3"
 
+    POSTHOG_KEY: str = ""
+    POSTHOG_HOST: str = "https://eu.i.posthog.com"
+
     ALLOWED_ORIGINS: list[str] = ["*"]
     EXPOSE_HEADERS: list[str] = ["*"]
 

--- a/gpu-api/pyproject.toml
+++ b/gpu-api/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "gunicorn>=26.0.0",
   "langchain>=1.3.11",
   "langchain-huggingface>=1.2.2",
+  "posthog>=7.21.0",
   "sentence-transformers>=5.6.0",
   "torch>=2.11.0",
   "transformers>=5.12.1",

--- a/gpu-api/uv.lock
+++ b/gpu-api/uv.lock
@@ -96,6 +96,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -409,6 +418,7 @@ dependencies = [
     { name = "gunicorn" },
     { name = "langchain" },
     { name = "langchain-huggingface" },
+    { name = "posthog" },
     { name = "sentence-transformers" },
     { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
@@ -428,6 +438,7 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=26.0.0" },
     { name = "langchain", specifier = ">=1.3.11" },
     { name = "langchain-huggingface", specifier = ">=1.2.2" },
+    { name = "posthog", specifier = ">=7.21.0" },
     { name = "sentence-transformers", specifier = ">=5.6.0" },
     { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32'", specifier = ">=2.11.0" },
     { name = "torch", marker = "sys_platform == 'linux' or sys_platform == 'win32'", specifier = ">=2.11.0", index = "https://download.pytorch.org/whl/cu128" },
@@ -1149,6 +1160,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/14/edebfb265f7141f4681b7f2d1cd8dea2621010a9ad7d3819831db2037f13/posthog-7.21.0.tar.gz", hash = "sha256:182ab7572748ae5199cb72c281a3549b70920cb8071e037ff6e07acbfae80876", size = 308788, upload-time = "2026-06-26T15:57:01.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/07/ca761fd0e3b23e9bfeaaeeffa5df4c235fd0c5086d89934553583e6902f3/posthog-7.21.0-py3-none-any.whl", hash = "sha256:11dca1e9772bedcb6721751fb0945fa8dcddbf9a4e72e2430483b53cdb8d1ec0", size = 370932, upload-time = "2026-06-26T15:56:59.844Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds PostHog (EU Cloud), metadata-only / residency-safe, to the API and gpu-api backends.

**Events:** `chat_request`, `retrieval_miss`, `$ai_generation` (PostHog AI-observability — model id, token counts, latency; **never** prompt/answer text), `chat_feedback` (excludes question/answer text), `cuda_fallback`, `chat_inference` (embed/rerank: counts + char-lengths only).
**Fork-safe:** client built in the gunicorn `post_fork` hook, flushed in `worker_exit`. No-op when `POSTHOG_KEY` empty.
**Deferred (noted):** `tool_called` and accurate token-threading (used the meta-frame token sniff); gpu `X-Response-Id` forwarding.
Verified: `ruff format --check` + `ruff check` + `mypy` clean (api 69 files, gpu-api 28). Part of the fleet-wide PostHog rollout.