### PR TITLE
fix(web): improve mobile chat layout

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect } from 'react';
+
 import { Composer } from '@/components/chat/composer';
 import { ServiceBanner } from '@/components/chat/service-banner';
 import { Thread } from '@/components/chat/thread';
@@ -10,6 +12,8 @@ import { useUiStore } from '@/lib/ui-store';
 import { useConversations } from '@/lib/use-conversations';
 import { useHealth } from '@/lib/use-health';
 import { useModels } from '@/lib/use-models';
+
+const DESKTOP_SIDEBAR_QUERY = '(min-width: 768px)';
 
 const ChatScreen = () => {
   const model = useUiStore((s) => s.model);
@@ -22,6 +26,27 @@ const ChatScreen = () => {
   const setSidebarOpen = useUiStore((s) => s.setSidebarOpen);
 
   const { unavailable } = useHealth();
+
+  useEffect(() => {
+    if (typeof matchMedia !== 'function') {
+      return;
+    }
+
+    const media = matchMedia(DESKTOP_SIDEBAR_QUERY);
+    const syncSidebarWithViewport = (
+      event: MediaQueryList | MediaQueryListEvent,
+    ) => {
+      setSidebarOpen(event.matches);
+    };
+
+    syncSidebarWithViewport(media);
+    media.addEventListener('change', syncSidebarWithViewport);
+
+    return () => {
+      media.removeEventListener('change', syncSidebarWithViewport);
+    };
+  }, [setSidebarOpen]);
+
   const {
     data: modelList,
     isError: modelsError,

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -15,6 +15,35 @@ import { useModels } from '@/lib/use-models';
 
 const DESKTOP_SIDEBAR_QUERY = '(min-width: 768px)';
 
+const subscribeToMediaQuery = (
+  media: MediaQueryList,
+  onChange: (event: MediaQueryListEvent) => void,
+) => {
+  if (typeof media.addEventListener === 'function') {
+    media.addEventListener('change', onChange);
+
+    return () => {
+      media.removeEventListener('change', onChange);
+    };
+  }
+
+  const addLegacyListener: unknown = Reflect.get(media, 'addListener');
+  const removeLegacyListener: unknown = Reflect.get(media, 'removeListener');
+
+  if (
+    typeof addLegacyListener !== 'function' ||
+    typeof removeLegacyListener !== 'function'
+  ) {
+    return () => {};
+  }
+
+  addLegacyListener.call(media, onChange);
+
+  return () => {
+    removeLegacyListener.call(media, onChange);
+  };
+};
+
 const ChatScreen = () => {
   const model = useUiStore((s) => s.model);
   const setModel = useUiStore((s) => s.setModel);
@@ -28,23 +57,20 @@ const ChatScreen = () => {
   const { unavailable } = useHealth();
 
   useEffect(() => {
+    const cleanup = () => {};
+
     if (typeof matchMedia !== 'function') {
-      return;
+      return cleanup;
     }
 
     const media = matchMedia(DESKTOP_SIDEBAR_QUERY);
-    const syncSidebarWithViewport = (
-      event: MediaQueryList | MediaQueryListEvent,
-    ) => {
+    const syncSidebarWithViewport = (event: MediaQueryListEvent) => {
       setSidebarOpen(event.matches);
     };
 
-    syncSidebarWithViewport(media);
-    media.addEventListener('change', syncSidebarWithViewport);
+    setSidebarOpen(media.matches);
 
-    return () => {
-      media.removeEventListener('change', syncSidebarWithViewport);
-    };
+    return subscribeToMediaQuery(media, syncSidebarWithViewport);
   }, [setSidebarOpen]);
 
   const {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -15,6 +15,11 @@ import { useModels } from '@/lib/use-models';
 
 const DESKTOP_SIDEBAR_QUERY = '(min-width: 768px)';
 
+type LegacyMediaQueryList = MediaQueryList & {
+  addListener: (listener: (event: MediaQueryListEvent) => void) => void;
+  removeListener: (listener: (event: MediaQueryListEvent) => void) => void;
+};
+
 const subscribeToMediaQuery = (
   media: MediaQueryList,
   onChange: (event: MediaQueryListEvent) => void,
@@ -27,20 +32,14 @@ const subscribeToMediaQuery = (
     };
   }
 
-  const addLegacyListener: unknown = Reflect.get(media, 'addListener');
-  const removeLegacyListener: unknown = Reflect.get(media, 'removeListener');
+  const legacyMedia = media as LegacyMediaQueryList;
 
-  if (
-    typeof addLegacyListener !== 'function' ||
-    typeof removeLegacyListener !== 'function'
-  ) {
-    return () => {};
-  }
-
-  addLegacyListener.call(media, onChange);
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Safari fallback.
+  legacyMedia.addListener(onChange);
 
   return () => {
-    removeLegacyListener.call(media, onChange);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- Safari fallback.
+    legacyMedia.removeListener(onChange);
   };
 };
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -15,31 +15,14 @@ import { useModels } from '@/lib/use-models';
 
 const DESKTOP_SIDEBAR_QUERY = '(min-width: 768px)';
 
-type LegacyMediaQueryList = MediaQueryList & {
-  addListener: (listener: (event: MediaQueryListEvent) => void) => void;
-  removeListener: (listener: (event: MediaQueryListEvent) => void) => void;
-};
-
 const subscribeToMediaQuery = (
   media: MediaQueryList,
   onChange: (event: MediaQueryListEvent) => void,
 ) => {
-  if (typeof media.addEventListener === 'function') {
-    media.addEventListener('change', onChange);
-
-    return () => {
-      media.removeEventListener('change', onChange);
-    };
-  }
-
-  const legacyMedia = media as LegacyMediaQueryList;
-
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Safari fallback.
-  legacyMedia.addListener(onChange);
+  media.addEventListener('change', onChange);
 
   return () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- Safari fallback.
-    legacyMedia.removeListener(onChange);
+    media.removeEventListener('change', onChange);
   };
 };
 

--- a/web/components/chat/composer-actions.tsx
+++ b/web/components/chat/composer-actions.tsx
@@ -1,0 +1,157 @@
+import { ArrowUp, Brain, Loader2, Sparkles, Square } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { t } from '@/lib/i18n';
+import { isReasoningCapableModel } from '@/lib/reasoning';
+import type { ModelGroup } from '@/lib/use-models';
+
+export type ComposerStatus = 'error' | 'ready' | 'streaming' | 'submitted';
+
+export type ComposerActionsProps = {
+  disabled?: boolean;
+  groups: ModelGroup[];
+  isBusy: boolean;
+  model: string;
+  modelPlaceholder: string;
+  modelSelectDisabled: boolean;
+  modelsLoading?: boolean;
+  onButtonClick: () => void;
+  onModelChange: (model: string) => void;
+  onReasoningChange: (reasoning: boolean) => void;
+  reasoning: boolean;
+  status: ComposerStatus;
+  submitDisabled: boolean;
+};
+
+export const ComposerActions = ({
+  disabled,
+  groups,
+  isBusy,
+  model,
+  modelPlaceholder,
+  modelSelectDisabled,
+  modelsLoading,
+  onButtonClick,
+  onModelChange,
+  onReasoningChange,
+  reasoning,
+  status,
+  submitDisabled,
+}: ComposerActionsProps) => {
+  const renderSubmitIcon = () => {
+    if (status === 'submitted') {
+      return (
+        <Loader2
+          aria-hidden="true"
+          className="size-4 animate-spin"
+        />
+      );
+    }
+    if (isBusy) {
+      return (
+        <Square
+          aria-hidden="true"
+          className="size-4 fill-current"
+        />
+      );
+    }
+    return (
+      <ArrowUp
+        aria-hidden="true"
+        className="size-4"
+      />
+    );
+  };
+
+  return (
+    <div className="flex items-center gap-1.5 px-2 pb-2">
+      <div
+        className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto overscroll-x-contain pb-0.5 sm:justify-end"
+        data-testid="composer-chip-scroll"
+      >
+        <Button
+          aria-label={t('composer.reasoning')}
+          aria-pressed={reasoning}
+          className="h-8 w-fit shrink-0 gap-1.5 rounded-full px-3 text-xs font-medium"
+          data-testid="composer-reasoning"
+          disabled={(disabled ?? false) || !isReasoningCapableModel(model)}
+          onClick={() => {
+            onReasoningChange(!reasoning);
+          }}
+          size="sm"
+          type="button"
+          variant={reasoning ? 'default' : 'ghost'}
+        >
+          <Brain
+            aria-hidden="true"
+            className="size-3.5"
+          />
+          {t('composer.reasoning')}
+        </Button>
+        <Select
+          disabled={modelSelectDisabled}
+          onValueChange={onModelChange}
+          value={model}
+        >
+          <SelectTrigger
+            aria-label={t('composer.model')}
+            className="h-8 w-fit max-w-[70vw] shrink-0 gap-1.5 rounded-full border-0 bg-transparent px-3 text-xs font-medium text-muted-foreground shadow-none hover:bg-muted hover:text-foreground sm:max-w-[240px]"
+            data-testid="composer-model"
+            size="sm"
+          >
+            {modelsLoading === true ? (
+              <Loader2
+                aria-hidden="true"
+                className="size-3.5 animate-spin"
+              />
+            ) : (
+              <Sparkles
+                aria-hidden="true"
+                className="size-3.5"
+              />
+            )}
+            <SelectValue placeholder={modelPlaceholder} />
+          </SelectTrigger>
+          <SelectContent
+            align="end"
+            position="popper"
+          >
+            {groups.map((g) => (
+              <SelectGroup key={g.provider}>
+                <SelectLabel>{g.provider}</SelectLabel>
+                {g.models.map((id) => (
+                  <SelectItem
+                    key={id}
+                    value={id}
+                  >
+                    {id}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <Button
+        aria-label={isBusy ? t('composer.stop') : t('composer.send')}
+        className="size-9 shrink-0 rounded-full transition-transform active:scale-95"
+        data-testid="composer-submit"
+        disabled={submitDisabled}
+        onClick={onButtonClick}
+        size="icon"
+        type="button"
+      >
+        {renderSubmitIcon()}
+      </Button>
+    </div>
+  );
+};

--- a/web/components/chat/composer-actions.tsx
+++ b/web/components/chat/composer-actions.tsx
@@ -1,5 +1,7 @@
 import { ArrowUp, Brain, Loader2, Sparkles, Square } from 'lucide-react';
 
+import type { ModelGroup } from '@/lib/use-models';
+
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -12,9 +14,6 @@ import {
 } from '@/components/ui/select';
 import { t } from '@/lib/i18n';
 import { isReasoningCapableModel } from '@/lib/reasoning';
-import type { ModelGroup } from '@/lib/use-models';
-
-export type ComposerStatus = 'error' | 'ready' | 'streaming' | 'submitted';
 
 export type ComposerActionsProps = {
   disabled?: boolean;
@@ -31,6 +30,8 @@ export type ComposerActionsProps = {
   status: ComposerStatus;
   submitDisabled: boolean;
 };
+
+export type ComposerStatus = 'error' | 'ready' | 'streaming' | 'submitted';
 
 export const ComposerActions = ({
   disabled,

--- a/web/components/chat/composer.tsx
+++ b/web/components/chat/composer.tsx
@@ -1,4 +1,3 @@
-import { ArrowUp, Brain, Loader2, Sparkles, Square } from 'lucide-react';
 import {
   type KeyboardEvent,
   useCallback,
@@ -7,18 +6,11 @@ import {
   useState,
 } from 'react';
 
-import { Button } from '@/components/ui/button';
 import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+  ComposerActions,
+  type ComposerStatus,
+} from '@/components/chat/composer-actions';
 import { t } from '@/lib/i18n';
-import { isReasoningCapableModel } from '@/lib/reasoning';
 import { groupModelsByProvider } from '@/lib/use-models';
 
 export type ComposerProps = {
@@ -32,7 +24,7 @@ export type ComposerProps = {
   onStop: () => void;
   onSubmit: (text: string) => void;
   reasoning: boolean;
-  status: 'error' | 'ready' | 'streaming' | 'submitted';
+  status: ComposerStatus;
 };
 
 export const Composer = ({
@@ -143,31 +135,6 @@ export const Composer = ({
     }
   };
 
-  const renderSubmitIcon = () => {
-    if (status === 'submitted') {
-      return (
-        <Loader2
-          aria-hidden="true"
-          className="size-4 animate-spin"
-        />
-      );
-    }
-    if (isBusy) {
-      return (
-        <Square
-          aria-hidden="true"
-          className="size-4 fill-current"
-        />
-      );
-    }
-    return (
-      <ArrowUp
-        aria-hidden="true"
-        className="size-4"
-      />
-    );
-  };
-
   return (
     <div className="bg-background px-3 pb-3 pt-2 sm:px-4">
       <div className="mx-auto w-full max-w-3xl">
@@ -186,85 +153,23 @@ export const Composer = ({
             rows={1}
             value={value}
           />
-          <div className="flex items-center justify-end gap-1.5 px-2 pb-2">
-            <Button
-              aria-label={t('composer.reasoning')}
-              aria-pressed={reasoning}
-              className="h-8 w-fit gap-1.5 rounded-full px-3 text-xs font-medium"
-              data-testid="composer-reasoning"
-              disabled={(disabled ?? false) || !isReasoningCapableModel(model)}
-              onClick={() => {
-                onReasoningChange(!reasoning);
-              }}
-              size="sm"
-              type="button"
-              variant={reasoning ? 'default' : 'ghost'}
-            >
-              <Brain
-                aria-hidden="true"
-                className="size-3.5"
-              />
-              {t('composer.reasoning')}
-            </Button>
-            <Select
-              disabled={modelSelectDisabled}
-              onValueChange={onModelChange}
-              value={model}
-            >
-              <SelectTrigger
-                aria-label={t('composer.model')}
-                className="h-8 w-fit max-w-[55%] gap-1.5 rounded-full border-0 bg-transparent px-3 text-xs font-medium text-muted-foreground shadow-none hover:bg-muted hover:text-foreground sm:max-w-[240px]"
-                data-testid="composer-model"
-                size="sm"
-              >
-                {modelsLoading === true ? (
-                  <Loader2
-                    aria-hidden="true"
-                    className="size-3.5 animate-spin"
-                  />
-                ) : (
-                  <Sparkles
-                    aria-hidden="true"
-                    className="size-3.5"
-                  />
-                )}
-                <SelectValue placeholder={modelPlaceholder} />
-              </SelectTrigger>
-              <SelectContent
-                align="end"
-                position="popper"
-              >
-                {groups.map((g) => (
-                  <SelectGroup key={g.provider}>
-                    <SelectLabel>{g.provider}</SelectLabel>
-                    {g.models.map((id) => (
-                      <SelectItem
-                        key={id}
-                        value={id}
-                      >
-                        {id}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                ))}
-              </SelectContent>
-            </Select>
-            <Button
-              aria-label={isBusy ? t('composer.stop') : t('composer.send')}
-              className="size-9 shrink-0 rounded-full transition-transform active:scale-95"
-              data-testid="composer-submit"
-              disabled={
-                isBusy
-                  ? false
-                  : (disabled ?? false) || value.trim().length === 0
-              }
-              onClick={onButtonClick}
-              size="icon"
-              type="button"
-            >
-              {renderSubmitIcon()}
-            </Button>
-          </div>
+          <ComposerActions
+            disabled={disabled}
+            groups={groups}
+            isBusy={isBusy}
+            model={model}
+            modelPlaceholder={modelPlaceholder}
+            modelSelectDisabled={modelSelectDisabled}
+            modelsLoading={modelsLoading}
+            onButtonClick={onButtonClick}
+            onModelChange={onModelChange}
+            onReasoningChange={onReasoningChange}
+            reasoning={reasoning}
+            status={status}
+            submitDisabled={
+              isBusy ? false : (disabled ?? false) || value.trim().length === 0
+            }
+          />
         </div>
         <p className="mt-2 text-center text-xs text-muted-foreground">
           {t('composer.disclaimer')}

--- a/web/components/shell/sidebar.tsx
+++ b/web/components/shell/sidebar.tsx
@@ -69,7 +69,7 @@ export const Sidebar = ({
       {open ? (
         <button
           aria-label={t('header.toggleSidebar')}
-          className="fixed inset-0 z-40 bg-black/40 md:hidden"
+          className="fixed inset-y-0 left-64 right-0 z-40 bg-black/40 md:hidden"
           onClick={onClose}
           type="button"
         />

--- a/web/lib/ui-store.ts
+++ b/web/lib/ui-store.ts
@@ -71,7 +71,7 @@ export const useUiStore = create<UiState>()(
       setSidebarOpen: (open) => {
         set({ sidebarOpen: open });
       },
-      sidebarOpen: true,
+      sidebarOpen: false,
       toggleSidebar: () => {
         set((s) => ({ sidebarOpen: !s.sidebarOpen }));
       },

--- a/web/test/shell.test.tsx
+++ b/web/test/shell.test.tsx
@@ -91,7 +91,7 @@ describe('useUiStore', () => {
     useUiStore.setState({
       activeConversationId: null,
       model: CLAUDE,
-      sidebarOpen: true,
+      sidebarOpen: false,
     });
   });
 
@@ -101,7 +101,7 @@ describe('useUiStore', () => {
     expect(s).toMatchObject({
       activeConversationId: null,
       model: CLAUDE,
-      sidebarOpen: true,
+      sidebarOpen: false,
     });
   });
 
@@ -120,13 +120,13 @@ describe('useUiStore', () => {
       useUiStore.getState().toggleSidebar();
     });
 
-    expect(useUiStore.getState()).toMatchObject({ sidebarOpen: false });
+    expect(useUiStore.getState()).toMatchObject({ sidebarOpen: true });
 
     act(() => {
-      useUiStore.getState().setSidebarOpen(true);
+      useUiStore.getState().setSidebarOpen(false);
     });
 
-    expect(useUiStore.getState()).toMatchObject({ sidebarOpen: true });
+    expect(useUiStore.getState()).toMatchObject({ sidebarOpen: false });
   });
 
   it('persists the model and active conversation', () => {

--- a/web/test/shell.test.tsx
+++ b/web/test/shell.test.tsx
@@ -41,6 +41,14 @@ const FIRST_TITLE = 'Прв разговор';
 const SECOND_TITLE = 'Втор разговор';
 const REGENERATE_CONVERSATION_ID = 'c-regenerate';
 
+type LegacyOnlyMediaQueryList = Omit<
+  MediaQueryList,
+  'addEventListener' | 'removeEventListener'
+> & {
+  readonly addEventListener?: undefined;
+  readonly removeEventListener?: undefined;
+};
+
 const rows: ConversationRow[] = [
   {
     createdAt: 1,
@@ -478,6 +486,42 @@ describe('ChatPage persistence', () => {
     ).resolves.toBeInTheDocument();
     expect(screen.getByTestId('composer-input')).toBeDisabled();
     expect(screen.getByTestId('composer-submit')).toBeDisabled();
+  });
+
+  it('opens the sidebar on desktop with legacy media query listeners', async () => {
+    const addListener =
+      vi.fn<(listener: (event: MediaQueryListEvent) => void) => void>();
+    const removeListener =
+      vi.fn<(listener: (event: MediaQueryListEvent) => void) => void>();
+
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn<(query: string) => LegacyOnlyMediaQueryList>((query) => ({
+        addEventListener: undefined,
+        addListener,
+        dispatchEvent: () => false,
+        matches: true,
+        media: query,
+        onchange: null,
+        removeEventListener: undefined,
+        removeListener,
+      })),
+    );
+
+    const view = renderChatPage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Странична лента')).toHaveAttribute(
+        'aria-hidden',
+        'false',
+      );
+    });
+
+    expect(addListener).toHaveBeenCalledOnce();
+
+    view.unmount();
+
+    expect(removeListener).toHaveBeenCalledOnce();
   });
 
   it('sends a message, renders the streamed answer, and persists to Dexie', async () => {

--- a/web/test/shell.test.tsx
+++ b/web/test/shell.test.tsx
@@ -41,20 +41,6 @@ const FIRST_TITLE = 'Прв разговор';
 const SECOND_TITLE = 'Втор разговор';
 const REGENERATE_CONVERSATION_ID = 'c-regenerate';
 
-type LegacyOnlyMediaQueryList = Omit<
-  MediaQueryList,
-  'addEventListener' | 'removeEventListener'
-> & {
-  readonly addEventListener?: undefined;
-  readonly addListener: (
-    listener: (event: MediaQueryListEvent) => void,
-  ) => void;
-  readonly removeEventListener?: undefined;
-  readonly removeListener: (
-    listener: (event: MediaQueryListEvent) => void,
-  ) => void;
-};
-
 const rows: ConversationRow[] = [
   {
     createdAt: 1,
@@ -492,42 +478,6 @@ describe('ChatPage persistence', () => {
     ).resolves.toBeInTheDocument();
     expect(screen.getByTestId('composer-input')).toBeDisabled();
     expect(screen.getByTestId('composer-submit')).toBeDisabled();
-  });
-
-  it('opens the sidebar on desktop with legacy media query listeners', async () => {
-    const addListener =
-      vi.fn<(listener: (event: MediaQueryListEvent) => void) => void>();
-    const removeListener =
-      vi.fn<(listener: (event: MediaQueryListEvent) => void) => void>();
-
-    vi.stubGlobal(
-      'matchMedia',
-      vi.fn<(query: string) => LegacyOnlyMediaQueryList>((query) => ({
-        addEventListener: undefined,
-        addListener,
-        dispatchEvent: () => false,
-        matches: true,
-        media: query,
-        onchange: null,
-        removeEventListener: undefined,
-        removeListener,
-      })),
-    );
-
-    const view = renderChatPage();
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('Странична лента')).toHaveAttribute(
-        'aria-hidden',
-        'false',
-      );
-    });
-
-    expect(addListener).toHaveBeenCalledOnce();
-
-    view.unmount();
-
-    expect(removeListener).toHaveBeenCalledOnce();
   });
 
   it('sends a message, renders the streamed answer, and persists to Dexie', async () => {

--- a/web/test/shell.test.tsx
+++ b/web/test/shell.test.tsx
@@ -46,7 +46,13 @@ type LegacyOnlyMediaQueryList = Omit<
   'addEventListener' | 'removeEventListener'
 > & {
   readonly addEventListener?: undefined;
+  readonly addListener: (
+    listener: (event: MediaQueryListEvent) => void,
+  ) => void;
   readonly removeEventListener?: undefined;
+  readonly removeListener: (
+    listener: (event: MediaQueryListEvent) => void,
+  ) => void;
 };
 
 const rows: ConversationRow[] = [


### PR DESCRIPTION
## Summary
- default the sidebar closed on mobile while syncing it open for desktop breakpoints
- constrain mobile drawer backdrop to the area outside the pane
- move composer action chips into a horizontally scrollable strip and extract the action row component

## Verification
- npm run check
- npm test -- composer.test.tsx shell.test.tsx
- npm test
- npm run build
- Playwright manual QA at 375x812 and 1280x800: mobile starts closed, drawer opens/dismisses, no horizontal page overflow, desktop sidebar opens
- Visual QA oracle pass: PASS (no blocking findings)

Note: standalone browser QA showed repeated /api/health 503 console entries because the backend API was not running; layout verification was unaffected.