### PR TITLE
fix(web): avoid desktop sidebar load animation

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 
 import { Composer } from '@/components/chat/composer';
 import { ServiceBanner } from '@/components/chat/service-banner';
@@ -38,7 +38,7 @@ const ChatScreen = () => {
 
   const { unavailable } = useHealth();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const cleanup = () => {};
 
     if (typeof matchMedia !== 'function') {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useLayoutEffect } from 'react';
+import { useEffect, useLayoutEffect } from 'react';
 
 import { Composer } from '@/components/chat/composer';
 import { ServiceBanner } from '@/components/chat/service-banner';
@@ -14,6 +14,10 @@ import { useHealth } from '@/lib/use-health';
 import { useModels } from '@/lib/use-models';
 
 const DESKTOP_SIDEBAR_QUERY = '(min-width: 768px)';
+const useIsomorphicLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+const noop = () => {};
 
 const subscribeToMediaQuery = (
   media: MediaQueryList,
@@ -38,11 +42,9 @@ const ChatScreen = () => {
 
   const { unavailable } = useHealth();
 
-  useLayoutEffect(() => {
-    const cleanup = () => {};
-
+  useIsomorphicLayoutEffect(() => {
     if (typeof matchMedia !== 'function') {
-      return cleanup;
+      return noop;
     }
 
     const media = matchMedia(DESKTOP_SIDEBAR_QUERY);


### PR DESCRIPTION
## Summary
- switch the sidebar breakpoint sync to useLayoutEffect so desktop applies the open state before visible paint
- keep mobile fresh loads closed/off-canvas

## Verification
- npm run lint
- npm run check
- npm test -- shell.test.tsx
- Playwright smoke: 1280px fresh load sidebar open at 256px, 375px fresh load sidebar closed/off-canvas

Note: standalone browser smoke still logs /api health errors when the backend is not running; layout verification is unaffected.