### PR TITLE
fix(web): render desktop sidebar open initially

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useLayoutEffect } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 
 import { Composer } from '@/components/chat/composer';
 import { ServiceBanner } from '@/components/chat/service-banner';
@@ -39,6 +39,7 @@ const ChatScreen = () => {
   const reasoningActive = reasoning && isReasoningCapableModel(model);
   const toggleSidebar = useUiStore((s) => s.toggleSidebar);
   const setSidebarOpen = useUiStore((s) => s.setSidebarOpen);
+  const [sidebarSynced, setSidebarSynced] = useState(false);
 
   const { unavailable } = useHealth();
 
@@ -53,6 +54,7 @@ const ChatScreen = () => {
     };
 
     setSidebarOpen(media.matches);
+    setSidebarSynced(true);
 
     return subscribeToMediaQuery(media, syncSidebarWithViewport);
   }, [setSidebarOpen]);
@@ -98,6 +100,7 @@ const ChatScreen = () => {
           onRename={onRename}
           onSelect={onSelect}
           open={sidebarOpen}
+          synced={sidebarSynced}
         />
         <main className="flex min-w-0 flex-1 flex-col">
           <Thread

--- a/web/components/shell/sidebar.tsx
+++ b/web/components/shell/sidebar.tsx
@@ -24,6 +24,7 @@ export type SidebarProps = {
   onRename: (id: string, title: string) => void;
   onSelect: (id: string) => void;
   open: boolean;
+  synced?: boolean;
 };
 
 const closeIfMobile = (onClose: () => void) => {
@@ -45,6 +46,7 @@ export const Sidebar = ({
   onRename,
   onSelect,
   open,
+  synced = true,
 }: SidebarProps) => {
   const [confirmingClearAll, setConfirmingClearAll] = useState(false);
   const [query, setQuery] = useState('');
@@ -63,10 +65,16 @@ export const Sidebar = ({
   const filtered = term
     ? conversations.filter((c) => c.title.toLowerCase().includes(term))
     : conversations;
+  let responsiveStateClass = '-translate-x-full md:w-64 md:translate-x-0';
+  if (synced) {
+    responsiveStateClass = open
+      ? 'translate-x-0 md:w-64'
+      : '-translate-x-full md:w-0 md:translate-x-0';
+  }
 
   return (
     <>
-      {open ? (
+      {synced && open ? (
         <button
           aria-label={t('header.toggleSidebar')}
           className="fixed inset-y-0 left-64 right-0 z-40 bg-black/40 md:hidden"
@@ -75,16 +83,15 @@ export const Sidebar = ({
         />
       ) : null}
       <aside
-        aria-hidden={!open}
+        aria-hidden={synced ? !open : undefined}
         aria-label={t('sidebar.label')}
         className={cn(
-          'fixed inset-y-0 left-0 z-50 w-64 shrink-0 overflow-hidden border-r border-border/60 bg-background transition-transform duration-300 ease-in-out md:static md:z-auto md:bg-muted/30 md:transition-[width]',
-          open
-            ? 'translate-x-0 md:w-64'
-            : '-translate-x-full md:w-0 md:translate-x-0',
+          'fixed inset-y-0 left-0 z-50 w-64 shrink-0 overflow-hidden border-r border-border/60 bg-background transition-transform duration-300 ease-in-out md:static md:z-auto md:bg-muted/30',
+          synced ? 'md:transition-[width]' : 'md:transition-none',
+          responsiveStateClass,
         )}
-        data-collapsed={!open}
-        inert={!open}
+        data-collapsed={synced ? !open : undefined}
+        inert={synced && !open}
       >
         <div className="flex h-full w-64 flex-col gap-3 p-3">
           <button


### PR DESCRIPTION
## Summary
- make the sidebar SSR/pre-sync CSS state desktop-open and mobile-closed
- delay state-driven desktop width transitions until after the viewport sync runs
- preserve normal mobile drawer behavior after sync

## Verification
- npm run lint
- npm run check
- npm test -- shell.test.tsx
- npm test
- npm run build
- Playwright desktop 1280px: sidebar width stayed 256px at now/raf1/raf2/after350ms
- Playwright mobile 375px: sidebar stayed left=-256/right=0 at now/raf1/after350ms with bodyScrollWidth=375

Note: standalone browser smoke logs /api health errors when the backend is not running; layout verification is unaffected.