### PR TITLE
feat(web): tag PostHog events with service

### DIFF
--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -28,4 +28,5 @@ if (key !== undefined && key.length > 0) {
     },
   });
   /* eslint-enable camelcase -- end of PostHog snake_case options. */
+  posthog.register({ service: 'chat-bot-web' });
 }


### PR DESCRIPTION
Registers `service: 'chat-bot-web'` as a posthog-js super-property in instrumentation-client, so every web event is attributed to this app.