### PR TITLE
fix(web): improve chat accessibility

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -118,6 +118,12 @@
     scroll-behavior: smooth;
   }
 
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  }
+
   body {
     @apply bg-background text-foreground font-sans antialiased;
   }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -106,7 +106,7 @@ const ChatScreen = () => {
             activeError={activeError}
             activeStatus={activeStatus}
             messages={messages}
-            onPickSuggestion={submitMessage}
+            onPickSuggestion={unavailable ? undefined : submitMessage}
             onRetry={unavailable ? undefined : retry}
             renderActions={renderActions}
             status={status}

--- a/web/components/ai-elements/conversation.tsx
+++ b/web/components/ai-elements/conversation.tsx
@@ -5,20 +5,54 @@ import { t } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
 import { ArrowDownIcon } from "lucide-react";
 import type { ComponentProps } from "react";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+const prefersReducedMotion = () =>
+  typeof matchMedia === 'function' && matchMedia(REDUCED_MOTION_QUERY).matches;
+
+const usePrefersReducedMotion = () => {
+  const [reducedMotion, setReducedMotion] = useState(prefersReducedMotion);
+
+  useEffect(() => {
+    if (typeof matchMedia !== 'function') {
+      return;
+    }
+
+    const media = matchMedia(REDUCED_MOTION_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setReducedMotion(event.matches);
+    };
+
+    setReducedMotion(media.matches);
+    media.addEventListener('change', handleChange);
+
+    return () => {
+      media.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  return reducedMotion;
+};
 
 export type ConversationProps = ComponentProps<typeof StickToBottom>;
 
-export const Conversation = ({ className, ...props }: ConversationProps) => (
-  <StickToBottom
-    className={cn("relative flex-1 overflow-y-hidden", className)}
-    initial="smooth"
-    resize="smooth"
-    role="log"
-    {...props}
-  />
-);
+export const Conversation = ({ className, ...props }: ConversationProps) => {
+  const reducedMotion = usePrefersReducedMotion();
+  const scrollBehavior = reducedMotion ? 'instant' : 'smooth';
+
+  return (
+    <StickToBottom
+      className={cn("relative flex-1 overflow-y-hidden", className)}
+      initial={scrollBehavior}
+      resize={scrollBehavior}
+      role="log"
+      {...props}
+    />
+  );
+};
 
 export type ConversationContentProps = ComponentProps<
   typeof StickToBottom.Content
@@ -41,10 +75,16 @@ export const ConversationScrollButton = ({
   ...props
 }: ConversationScrollButtonProps) => {
   const { isAtBottom, scrollToBottom } = useStickToBottomContext();
+  const reducedMotion = usePrefersReducedMotion();
 
   const handleScrollToBottom = useCallback(() => {
+    if (reducedMotion) {
+      scrollToBottom('instant');
+      return;
+    }
+
     scrollToBottom();
-  }, [scrollToBottom]);
+  }, [reducedMotion, scrollToBottom]);
 
   return (
     !isAtBottom && (

--- a/web/components/ai-elements/conversation.tsx
+++ b/web/components/ai-elements/conversation.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { t } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
 import { ArrowDownIcon } from "lucide-react";
 import type { ComponentProps } from "react";
@@ -48,6 +49,7 @@ export const ConversationScrollButton = ({
   return (
     !isAtBottom && (
       <Button
+        aria-label={t('conversation.scrollToLatest')}
         className={cn(
           "absolute bottom-4 left-[50%] translate-x-[-50%] rounded-full dark:bg-background dark:hover:bg-muted",
           className
@@ -58,7 +60,10 @@ export const ConversationScrollButton = ({
         variant="outline"
         {...props}
       >
-        <ArrowDownIcon className="size-4" />
+        <ArrowDownIcon
+          aria-hidden="true"
+          className="size-4"
+        />
       </Button>
     )
   );

--- a/web/components/chat/composer.tsx
+++ b/web/components/chat/composer.tsx
@@ -2,6 +2,7 @@ import {
   type KeyboardEvent,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -43,7 +44,7 @@ export const Composer = ({
   const [value, setValue] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isBusy = status === 'streaming' || status === 'submitted';
-  const groups = groupModelsByProvider(models);
+  const groups = useMemo(() => groupModelsByProvider(models), [models]);
   const noModels = models.length === 0;
   const modelSelectDisabled =
     (disabled ?? false) || modelsLoading === true || noModels;
@@ -141,9 +142,11 @@ export const Composer = ({
         <div className="flex flex-col rounded-3xl border border-input bg-card shadow-lg shadow-black/5 transition-[color,box-shadow] focus-within:border-foreground/25 focus-within:ring-2 focus-within:ring-foreground/[0.06] dark:shadow-black/25">
           <textarea
             aria-label={t('composer.message')}
+            autoComplete="off"
             className="ph-no-capture field-sizing-content max-h-48 min-h-[52px] w-full resize-none bg-transparent px-4 pt-3 pb-2 text-sm outline-none placeholder:text-muted-foreground disabled:opacity-50"
             data-testid="composer-input"
             disabled={disabled}
+            name="message"
             onChange={(e) => {
               setValue(e.target.value);
             }}

--- a/web/components/chat/thread.tsx
+++ b/web/components/chat/thread.tsx
@@ -44,7 +44,9 @@ const Welcome = ({ onPick }: { onPick?: (text: string) => void }) => (
     <img
       alt="ФИНКИ Хаб"
       className="h-16 w-16 object-contain drop-shadow-sm"
+      height={64}
       src="/logo.png"
+      width={64}
     />
     <div className="space-y-2">
       <h2 className="text-2xl font-bold tracking-tight">

--- a/web/components/shell/conversation-list.tsx
+++ b/web/components/shell/conversation-list.tsx
@@ -71,7 +71,7 @@ export const ConversationList = ({
             key={c.id}
           >
             <button
-              className="flex-1 truncate text-left"
+              className="flex-1 truncate rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
               onClick={() => {
                 onSelect(c.id);
               }}
@@ -79,10 +79,13 @@ export const ConversationList = ({
             >
               {c.title}
             </button>
-            <span className="flex items-center gap-1 opacity-0 group-hover:opacity-100">
+            <span
+              className="flex items-center gap-1 opacity-100 transition-opacity duration-150 sm:opacity-0 sm:group-focus-within:opacity-100 sm:group-hover:opacity-100"
+              data-testid="row-actions"
+            >
               <button
                 aria-label={t('conversation.rename')}
-                className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+                className="rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-background hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
                 onClick={() => {
                   openRename(c);
                 }}
@@ -95,7 +98,7 @@ export const ConversationList = ({
               </button>
               <button
                 aria-label={t('conversation.delete')}
-                className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-background hover:text-destructive"
+                className="rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-background hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring/50"
                 onClick={() => {
                   setPendingDelete(c);
                 }}
@@ -134,6 +137,8 @@ export const ConversationList = ({
           >
             <Input
               aria-label={t('conversation.renamePrompt')}
+              autoComplete="off"
+              name="conversation-title"
               onChange={(e) => {
                 setRenameValue(e.target.value);
               }}

--- a/web/components/shell/sidebar.tsx
+++ b/web/components/shell/sidebar.tsx
@@ -113,7 +113,7 @@ export const Sidebar = ({
               <InputGroupInput
                 aria-label={t('sidebar.search')}
                 className="[&::-webkit-search-cancel-button]:appearance-none"
-                data-testid="conversation-search"
+                data-testid="search-conversations"
                 onChange={(e) => {
                   setQuery(e.target.value);
                 }}

--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -26,6 +26,7 @@ export const messages = {
   'conversation.rename': 'Преименувај',
   'conversation.renamePrompt': 'Ново име на разговорот',
   'conversation.renameTitle': 'Преименувај разговор',
+  'conversation.scrollToLatest': 'Скролувај до најновата порака',
   'diagnostics.candidates': 'кандидати',
   'diagnostics.model': 'модел',
   'diagnostics.serverFirstByte': 'прв бајт (сервер)',

--- a/web/test/ai-elements.smoke.test.tsx
+++ b/web/test/ai-elements.smoke.test.tsx
@@ -1,9 +1,39 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import type { ReactNode } from 'react';
 
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ConversationScrollButton } from '@/components/ai-elements/conversation';
 import { Message, MessageContent } from '@/components/ai-elements/message';
 
+const stickToBottom = vi.hoisted(() => {
+  const scrollToBottom = vi.fn<() => void>();
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- Vitest mock factories are hoisted, so mock components must be created inside vi.hoisted.
+  const Content = ({ children }: { readonly children?: ReactNode }) => (
+    <div>{children}</div>
+  );
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- Vitest mock factories are hoisted, so mock components must be created inside vi.hoisted.
+  const Root = ({ children }: { readonly children?: ReactNode }) => (
+    <div>{children}</div>
+  );
+  Root.Content = Content;
+
+  return { Root, scrollToBottom };
+});
+
+vi.mock('use-stick-to-bottom', () => ({
+  StickToBottom: stickToBottom.Root,
+  useStickToBottomContext: () => ({
+    isAtBottom: false,
+    scrollToBottom: stickToBottom.scrollToBottom,
+  }),
+}));
+
 describe('ai-elements smoke', () => {
+  beforeEach(() => {
+    stickToBottom.scrollToBottom.mockClear();
+  });
+
   it('renders a Message with text content', () => {
     render(
       <Message from="assistant">
@@ -12,5 +42,13 @@ describe('ai-elements smoke', () => {
     );
 
     expect(screen.getByText('здраво свет')).toBeInTheDocument();
+  });
+
+  it('exposes an accessible scroll-to-bottom button', () => {
+    render(<ConversationScrollButton />);
+
+    expect(
+      screen.getByRole('button', { name: 'Скролувај до најновата порака' }),
+    ).toBeInTheDocument();
   });
 });

--- a/web/test/ai-elements.smoke.test.tsx
+++ b/web/test/ai-elements.smoke.test.tsx
@@ -1,24 +1,36 @@
 import type { ReactNode } from 'react';
 
 import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ConversationScrollButton } from '@/components/ai-elements/conversation';
+import {
+  Conversation,
+  ConversationScrollButton,
+} from '@/components/ai-elements/conversation';
 import { Message, MessageContent } from '@/components/ai-elements/message';
 
+type StickToBottomRootProps = {
+  readonly children?: ReactNode;
+  readonly initial?: boolean | ScrollBehavior;
+  readonly resize?: ScrollBehavior;
+};
+
 const stickToBottom = vi.hoisted(() => {
-  const scrollToBottom = vi.fn<() => void>();
+  const rootProps: StickToBottomRootProps[] = [];
+  const scrollToBottom = vi.fn<(behavior?: ScrollBehavior) => void>();
   // eslint-disable-next-line unicorn/consistent-function-scoping -- Vitest mock factories are hoisted, so mock components must be created inside vi.hoisted.
   const Content = ({ children }: { readonly children?: ReactNode }) => (
     <div>{children}</div>
   );
-  // eslint-disable-next-line unicorn/consistent-function-scoping -- Vitest mock factories are hoisted, so mock components must be created inside vi.hoisted.
-  const Root = ({ children }: { readonly children?: ReactNode }) => (
-    <div>{children}</div>
-  );
+  const Root = ({ children, initial, resize }: StickToBottomRootProps) => {
+    rootProps.push({ initial, resize });
+
+    return <div>{children}</div>;
+  };
   Root.Content = Content;
 
-  return { Root, scrollToBottom };
+  return { Root, rootProps, scrollToBottom };
 });
 
 vi.mock('use-stick-to-bottom', () => ({
@@ -29,9 +41,32 @@ vi.mock('use-stick-to-bottom', () => ({
   }),
 }));
 
+const createMediaQueryList = (
+  matches: boolean,
+  media: string,
+): MediaQueryList => {
+  const target = new EventTarget();
+
+  return {
+    addEventListener: target.addEventListener.bind(target),
+    addListener() {},
+    dispatchEvent: target.dispatchEvent.bind(target),
+    matches,
+    media,
+    onchange: null,
+    removeEventListener: target.removeEventListener.bind(target),
+    removeListener() {},
+  };
+};
+
 describe('ai-elements smoke', () => {
   beforeEach(() => {
+    stickToBottom.rootProps.length = 0;
     stickToBottom.scrollToBottom.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('renders a Message with text content', () => {
@@ -50,5 +85,28 @@ describe('ai-elements smoke', () => {
     expect(
       screen.getByRole('button', { name: 'Скролувај до најновата порака' }),
     ).toBeInTheDocument();
+  });
+
+  it('uses instant scrolling when reduced motion is requested', async () => {
+    vi.stubGlobal('matchMedia', (query: string) =>
+      createMediaQueryList(query === '(prefers-reduced-motion: reduce)', query),
+    );
+
+    render(
+      <Conversation>
+        <div />
+      </Conversation>,
+    );
+    render(<ConversationScrollButton />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Скролувај до најновата порака' }),
+    );
+
+    expect(stickToBottom.rootProps.at(-1)).toMatchObject({
+      initial: 'instant',
+      resize: 'instant',
+    });
+    expect(stickToBottom.scrollToBottom).toHaveBeenCalledWith('instant');
   });
 });

--- a/web/test/conversation-list-a11y.test.tsx
+++ b/web/test/conversation-list-a11y.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ConversationRow } from '@/lib/db';
+
+import { ConversationList } from '@/components/shell/conversation-list';
+
+const conversations: ConversationRow[] = [
+  {
+    createdAt: 1,
+    id: 'c1',
+    model: 'claude-sonnet-4-6',
+    title: 'Прв разговор',
+    updatedAt: 2,
+  },
+];
+
+const noop = vi.fn<() => void>;
+
+describe('ConversationList accessibility', () => {
+  it('keeps row actions discoverable when a keyboard user focuses the row', () => {
+    render(
+      <ConversationList
+        activeId={null}
+        conversations={conversations}
+        onDelete={noop()}
+        onRename={noop()}
+        onSelect={noop()}
+      />,
+    );
+
+    const item = screen.getByTestId('conversation-c1');
+    const actions = within(item).getByTestId('row-actions');
+
+    expect(actions).toHaveClass('sm:group-focus-within:opacity-100');
+  });
+});

--- a/web/test/thread-suggestions.test.tsx
+++ b/web/test/thread-suggestions.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Thread } from '@/components/chat/thread';
+
+const FIRST_SUGGESTION =
+  'Колку кредити ми требаат за да се запишам во наредна година?';
+
+describe('Thread suggestions', () => {
+  it('shows suggestions when picking is available', () => {
+    render(
+      <Thread
+        messages={[]}
+        onPickSuggestion={vi.fn<(text: string) => void>()}
+        status="ready"
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: FIRST_SUGGESTION }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides suggestions when picking is unavailable', () => {
+    render(
+      <Thread
+        messages={[]}
+        status="ready"
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: FIRST_SUGGESTION }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- hide welcome suggestion buttons when the backend is unavailable
- add an accessible label for the scroll-to-latest control
- make conversation row actions keyboard/touch discoverable
- memoize model grouping and add form/input metadata
- size the welcome logo and respect reduced motion for smooth scroll

## Verification
- npm run check
- npm run lint (passes with existing max-lines warnings)
- npm test
- API_BASE_URL=http://localhost:8880 CHAT_API_KEY=test-key npm run build
- API_BASE_URL=http://localhost:8880 CHAT_API_KEY=test-key npm run e2e
- Manual Playwright QA at desktop and 375px mobile with unavailable backend state