### PR TITLE
fix(web): stabilize health banner recovery

### DIFF
--- a/web/lib/use-health.ts
+++ b/web/lib/use-health.ts
@@ -1,9 +1,11 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
 
 const HEALTHY_INTERVAL_MS = 30_000;
 const DOWN_INTERVAL_MS = 5_000;
+const RECOVERY_CHECKS_TO_CLEAR = 2;
 
 const fetchHealth = async (): Promise<true> => {
   const res = await fetch('/api/health');
@@ -15,17 +17,47 @@ const fetchHealth = async (): Promise<true> => {
 };
 
 export const useHealth = (): { unavailable: boolean } => {
+  const [unavailable, setUnavailable] = useState(false);
+  const recoveryChecks = useRef(0);
   const query = useQuery({
     queryFn: fetchHealth,
     queryKey: ['health'],
     refetchInterval: (q) =>
-      q.state.status === 'error' ? DOWN_INTERVAL_MS : HEALTHY_INTERVAL_MS,
+      unavailable || q.state.status === 'error'
+        ? DOWN_INTERVAL_MS
+        : HEALTHY_INTERVAL_MS,
     refetchOnWindowFocus: 'always',
     // One retry absorbs a transient blip before flagging the backend down.
     retry: 1,
     staleTime: HEALTHY_INTERVAL_MS,
   });
 
-  // Optimistic: only flag unavailable after a check actually fails (post-retry).
-  return { unavailable: query.isError };
+  useEffect(() => {
+    if (query.fetchStatus !== 'idle') {
+      return;
+    }
+
+    if (query.isError) {
+      recoveryChecks.current = 0;
+      setUnavailable(true);
+      return;
+    }
+
+    if (!query.isSuccess) {
+      return;
+    }
+
+    recoveryChecks.current += 1;
+    if (recoveryChecks.current >= RECOVERY_CHECKS_TO_CLEAR) {
+      setUnavailable(false);
+    }
+  }, [
+    query.dataUpdatedAt,
+    query.errorUpdatedAt,
+    query.fetchStatus,
+    query.isError,
+    query.isSuccess,
+  ]);
+
+  return { unavailable };
 };

--- a/web/test/use-health.test.tsx
+++ b/web/test/use-health.test.tsx
@@ -1,0 +1,75 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useHealth } from '@/lib/use-health';
+
+const HealthProbe = () => {
+  const { unavailable } = useHealth();
+
+  return <div data-testid="health-state">{unavailable ? 'down' : 'up'}</div>;
+};
+
+const renderHealthProbe = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retryDelay: 0 } },
+  });
+
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <HealthProbe />
+    </QueryClientProvider>,
+  );
+
+  return { queryClient, ...view };
+};
+
+const healthResponse = (status: number): Response =>
+  Response.json({ ok: status === 200 }, { status });
+
+const nextCheckTick = (): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 1);
+  });
+
+describe('useHealth', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps the outage banner visible until two recovery checks succeed', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(healthResponse(503))
+      .mockResolvedValueOnce(healthResponse(503))
+      .mockResolvedValueOnce(healthResponse(200))
+      .mockResolvedValueOnce(healthResponse(200));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { queryClient } = renderHealthProbe();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('health-state')).toHaveTextContent('down');
+    });
+
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ['health'] });
+    });
+
+    expect(screen.getByTestId('health-state')).toHaveTextContent('down');
+
+    await act(async () => {
+      await nextCheckTick();
+    });
+
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ['health'] });
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('health-state')).toHaveTextContent('up');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- keep the API unavailable banner visible until two successful recovery checks complete
- continue polling at the down interval while the banner is visible
- add a regression test for the one-success recovery flicker case

## Verification
- npm test
- npm test -- --run test/use-health.test.tsx test/shell.test.tsx
- npm run typecheck
- npm run lint (passes with existing max-lines warnings)
- API_BASE_URL=http://localhost:8880 CHAT_API_KEY=test-key npm run build
- Playwright QA against production Next server with fake API: banner visible after confirmed down, still visible after first recovery success, hidden after second recovery success