### PR TITLE
fix(web): normalize generated markdown links

### DIFF
--- a/web/components/ai-elements/message.tsx
+++ b/web/components/ai-elements/message.tsx
@@ -57,6 +57,16 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
 const streamdownPlugins = { cjk, code, math, mermaid };
 
+const markdownDomainLinkPattern =
+  /(\[[^\]\n]+\]\(\s*)(?![a-z][a-z\d+.-]*:|[#/.])((?:www\.)?(?:[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?\.)+[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?(?:[/?#][^\s)]*)?)(\s*(?:["'][^"']*["']|\([^)]*\))?\))/giu;
+
+const normalizeGeneratedMarkdownLinks = (content: string): string =>
+  content.replace(
+    markdownDomainLinkPattern,
+    (_match, prefix: string, target: string, suffix: string) =>
+      `${prefix}https://${target}${suffix}`
+  );
+
 const LinkSafetyModal = ({
   isOpen,
   onClose,
@@ -90,17 +100,26 @@ const linkSafety: LinkSafetyConfig = {
 };
 
 export const MessageResponse = memo(
-  ({ className, ...props }: MessageResponseProps) => (
-    <Streamdown
-      className={cn(
-        "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
-        className
-      )}
-      plugins={streamdownPlugins}
-      linkSafety={linkSafety}
-      {...props}
-    />
-  ),
+  ({ children, className, ...props }: MessageResponseProps) => {
+    const normalizedChildren =
+      typeof children === "string"
+        ? normalizeGeneratedMarkdownLinks(children)
+        : children;
+
+    return (
+      <Streamdown
+        className={cn(
+          "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+          className
+        )}
+        plugins={streamdownPlugins}
+        linkSafety={linkSafety}
+        {...props}
+      >
+        {normalizedChildren}
+      </Streamdown>
+    );
+  },
   (prevProps, nextProps) =>
     prevProps.children === nextProps.children &&
     nextProps.isAnimating === prevProps.isAnimating

--- a/web/components/ai-elements/message.tsx
+++ b/web/components/ai-elements/message.tsx
@@ -14,6 +14,7 @@ import {
   type LinkSafetyConfig,
   type LinkSafetyModalProps,
   Streamdown,
+  defaultRemarkPlugins,
 } from "streamdown";
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
@@ -57,15 +58,55 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
 const streamdownPlugins = { cjk, code, math, mermaid };
 
-const markdownDomainLinkPattern =
-  /(\[[^\]\n]+\]\(\s*)(?![a-z][a-z\d+.-]*:|[#/.])((?:www\.)?(?:[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?\.)+[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?(?:[/?#][^\s)]*)?)(\s*(?:["'][^"']*["']|\([^)]*\))?\))/giu;
+type MarkdownNode = {
+  children?: unknown;
+  type?: unknown;
+  url?: unknown;
+};
 
-const normalizeGeneratedMarkdownLinks = (content: string): string =>
-  content.replace(
-    markdownDomainLinkPattern,
-    (_match, prefix: string, target: string, suffix: string) =>
-      `${prefix}https://${target}${suffix}`
-  );
+const urlSchemePattern = /^[a-z][a-z\d+.-]*:/iu;
+const domainUrlPattern =
+  /^(?:www\.)?(?:[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?\.)+[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?(?:[/?#].*)?$/iu;
+
+const isMarkdownNode = (value: unknown): value is MarkdownNode =>
+  typeof value === "object" && value !== null;
+
+const normalizeMarkdownLinkTarget = (url: string): string => {
+  if (
+    urlSchemePattern.test(url) ||
+    url.startsWith("#") ||
+    url.startsWith("/") ||
+    url.startsWith(".") ||
+    !domainUrlPattern.test(url)
+  ) {
+    return url;
+  }
+
+  return `https://${url}`;
+};
+
+const normalizeMarkdownLinks = (node: unknown): void => {
+  if (!isMarkdownNode(node)) {
+    return;
+  }
+
+  if (node.type === "link" && typeof node.url === "string") {
+    node.url = normalizeMarkdownLinkTarget(node.url);
+  }
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      normalizeMarkdownLinks(child);
+    }
+  }
+};
+
+const normalizeGeneratedMarkdownLinks = () => normalizeMarkdownLinks;
+
+const remarkPlugins = [
+  ...Object.values(defaultRemarkPlugins),
+  normalizeGeneratedMarkdownLinks,
+] satisfies NonNullable<MessageResponseProps["remarkPlugins"]>;
 
 const LinkSafetyModal = ({
   isOpen,
@@ -100,26 +141,18 @@ const linkSafety: LinkSafetyConfig = {
 };
 
 export const MessageResponse = memo(
-  ({ children, className, ...props }: MessageResponseProps) => {
-    const normalizedChildren =
-      typeof children === "string"
-        ? normalizeGeneratedMarkdownLinks(children)
-        : children;
-
-    return (
-      <Streamdown
-        className={cn(
-          "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
-          className
-        )}
-        plugins={streamdownPlugins}
-        linkSafety={linkSafety}
-        {...props}
-      >
-        {normalizedChildren}
-      </Streamdown>
-    );
-  },
+  ({ className, ...props }: MessageResponseProps) => (
+    <Streamdown
+      className={cn(
+        "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+        className
+      )}
+      plugins={streamdownPlugins}
+      linkSafety={linkSafety}
+      remarkPlugins={remarkPlugins}
+      {...props}
+    />
+  ),
   (prevProps, nextProps) =>
     prevProps.children === nextProps.children &&
     nextProps.isAnimating === prevProps.isAnimating

--- a/web/e2e/confirm.spec.ts
+++ b/web/e2e/confirm.spec.ts
@@ -76,7 +76,9 @@ test('protocol-less markdown links render as safe https links', async ({
 }) => {
   const server = await mockBackend(
     page,
-    answer('Повеќе на [FINKI](finki.ukim.mk) тука.'),
+    answer(
+      'Пример:\n\n```md\nUse [FINKI](finki.ukim.mk)\n```\n\nПовеќе на [FINKI](finki.ukim.mk) тука.',
+    ),
   );
   await page.goto('/');
   await send(page, 'Каде да видам повеќе?');
@@ -88,6 +90,13 @@ test('protocol-less markdown links render as safe https links', async ({
     hasText: 'FINKI',
   });
   await expect(link).toBeVisible();
+
+  const code = answerText.locator('code', {
+    hasText: 'Use [FINKI](finki.ukim.mk)',
+  });
+  await expect(code).toBeVisible();
+  await expect(code).not.toContainText('https://finki.ukim.mk');
+
   await link.click();
 
   const dialog = page.getByRole('dialog');

--- a/web/e2e/confirm.spec.ts
+++ b/web/e2e/confirm.spec.ts
@@ -71,6 +71,32 @@ test('clicking a link opens the shared confirmation modal', async ({
   await server.close();
 });
 
+test('protocol-less markdown links render as safe https links', async ({
+  page,
+}) => {
+  const server = await mockBackend(
+    page,
+    answer('Повеќе на [FINKI](finki.ukim.mk) тука.'),
+  );
+  await page.goto('/');
+  await send(page, 'Каде да видам повеќе?');
+
+  const answerText = page.getByTestId('answer-text');
+  await expect(answerText).not.toContainText('[blocked]');
+
+  const link = answerText.locator('[data-streamdown="link"]', {
+    hasText: 'FINKI',
+  });
+  await expect(link).toBeVisible();
+  await link.click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText('https://finki.ukim.mk/');
+
+  await server.close();
+});
+
 test('delete-all clears the entire history after confirmation', async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- normalize protocol-less generated Markdown link targets to https before Streamdown hardening
- keep Streamdown link-safety confirmation behavior unchanged
- add E2E coverage for the [blocked] regression

## Verification
- npm run check
- npm test
- npm run lint (passes with existing max-lines warnings)
- API_BASE_URL=http://localhost:8880 CHAT_API_KEY=test npm run build
- port-isolated Playwright: protocol-less markdown links render as safe https links