### PR TITLE
feat(web): show trace ID in diagnostics

### DIFF
--- a/web/components/chat/message.tsx
+++ b/web/components/chat/message.tsx
@@ -43,10 +43,18 @@ const FOOTNOTE_CLASS =
 const formatMs = (ms: null | number | undefined): string =>
   typeof ms === 'number' ? formatDuration(ms) : '—';
 
-const DiagnosticsRow = ({ label, value }: { label: string; value: string }) => (
+const DiagnosticsRow = ({
+  label,
+  value,
+  valueClassName = 'shrink-0 tabular-nums',
+}: {
+  label: string;
+  value: string;
+  valueClassName?: string;
+}) => (
   <div className="flex items-center justify-between gap-6">
     <span className="min-w-0 truncate text-muted-foreground">{label}</span>
-    <span className="shrink-0 tabular-nums">{value}</span>
+    <span className={valueClassName}>{value}</span>
   </div>
 );
 
@@ -59,9 +67,11 @@ const DiagnosticsGroup = ({ children }: { children: ReactNode }) => (
 const DiagnosticsCard = ({
   diagnostics,
   inferenceModel,
+  traceId,
 }: {
   diagnostics: NonNullable<Diagnostics>;
   inferenceModel?: string;
+  traceId?: string;
 }) => {
   const spans = Object.entries(diagnostics.spans ?? {});
   const { tokens } = diagnostics;
@@ -73,12 +83,21 @@ const DiagnosticsCard = ({
   return (
     <div className="flex flex-col gap-2 text-xs">
       <p className="font-medium text-foreground">{t('diagnostics.title')}</p>
-      {inferenceModel ? (
+      {inferenceModel || traceId ? (
         <DiagnosticsGroup>
-          <DiagnosticsRow
-            label={t('diagnostics.model')}
-            value={inferenceModel}
-          />
+          {inferenceModel ? (
+            <DiagnosticsRow
+              label={t('diagnostics.model')}
+              value={inferenceModel}
+            />
+          ) : null}
+          {traceId ? (
+            <DiagnosticsRow
+              label={t('diagnostics.traceId')}
+              value={traceId}
+              valueClassName="max-w-44 break-all text-right font-mono text-[11px] leading-snug"
+            />
+          ) : null}
         </DiagnosticsGroup>
       ) : null}
       <DiagnosticsGroup>
@@ -173,10 +192,12 @@ const TimingSummary = ({ timing }: { timing: NonNullable<Timing> }) => (
 const MessageTiming = ({
   diagnostics,
   inferenceModel,
+  responseId,
   timing,
 }: {
   diagnostics: Diagnostics;
   inferenceModel?: string;
+  responseId?: string;
   timing: Timing;
 }) => {
   if (timing === undefined) {
@@ -223,6 +244,7 @@ const MessageTiming = ({
         <DiagnosticsCard
           diagnostics={diagnostics}
           inferenceModel={inferenceModel}
+          traceId={responseId}
         />
       </HoverCardContent>
     </HoverCard>
@@ -363,6 +385,7 @@ export const AssistantMessage = ({
   const diagnostics = message.metadata?.diagnostics;
   const inferenceModel = message.metadata?.inferenceModel;
   const sources = message.metadata?.sources ?? [];
+  const responseId = message.metadata?.responseId;
 
   return (
     <Message from="assistant">
@@ -385,6 +408,7 @@ export const AssistantMessage = ({
           <MessageTiming
             diagnostics={diagnostics}
             inferenceModel={inferenceModel}
+            responseId={responseId}
             timing={timing}
           />
         )}

--- a/web/e2e/chat.spec.ts
+++ b/web/e2e/chat.spec.ts
@@ -13,12 +13,13 @@ const STATUS_LABEL = '🔍 Пребарувам…';
 const TOOL = 'search_documents';
 const ANSWER = 'Резултатите од испитите се објавуваат на https://finki.ukim.mk';
 const LINK_NAME = /finki\.ukim\.mk/u;
+const DIAGNOSTICS_LABEL = /Дијагностика/u;
 
 test.describe('chat streaming (mocked BFF)', () => {
   test('shows the search chip, drops the preamble, renders the answer, and likes', async ({
     page,
   }) => {
-    const chunks = toolRunChunks({
+    const chatChunks = toolRunChunks({
       answer: ANSWER,
       inferenceModel: INFERENCE_MODEL,
       preamble: PREAMBLE,
@@ -26,6 +27,21 @@ test.describe('chat streaming (mocked BFF)', () => {
       statusLabel: STATUS_LABEL,
       tool: TOOL,
     });
+    const diagnosticsChunk = {
+      messageMetadata: {
+        diagnostics: {
+          serverTotalMs: 1_700,
+          serverTtftMs: 200,
+          tokens: { input: 10, output: 30, total: 40 },
+        },
+      },
+      type: 'message-metadata',
+    } satisfies (typeof chatChunks)[number];
+    const chunks = [
+      ...chatChunks.slice(0, -1),
+      diagnosticsChunk,
+      ...chatChunks.slice(-1),
+    ];
     const statusIndex = chunks.findIndex((c) => c.type === 'data-status');
     const chatServer = await startChatStreamServer({
       gapMs: 600,
@@ -86,6 +102,14 @@ test.describe('chat streaming (mocked BFF)', () => {
     const timing = page.getByTestId('message-timing');
     await expect(timing).toBeVisible();
     await expect(timing).toContainText('прв токен');
+    const diagnosticsTrigger = page.getByRole('button', {
+      name: DIAGNOSTICS_LABEL,
+    });
+    await expect(diagnosticsTrigger).toBeVisible();
+    await diagnosticsTrigger.hover();
+    await expect(page.getByText('trace ID')).toBeVisible();
+    await expect(page.getByText(RESPONSE_ID)).toBeVisible();
+    await page.mouse.move(0, 0);
 
     await page.getByTestId('like-button').click();
     await expect.poll(() => feedbackBody).not.toBeNull();

--- a/web/e2e/helpers/sse.ts
+++ b/web/e2e/helpers/sse.ts
@@ -24,6 +24,16 @@ export type UiChunk =
   | { id: string; type: 'text-end' }
   | { id: string; type: 'text-start' }
   | {
+      messageMetadata: {
+        diagnostics: {
+          serverTotalMs: number;
+          serverTtftMs: number;
+          tokens: { input: number; output: number; total: number };
+        };
+      };
+      type: 'message-metadata';
+    }
+  | {
       messageMetadata?: { inferenceModel?: string; responseId?: string };
       type: 'start';
     }

--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -39,6 +39,7 @@ export const messages = {
   'diagnostics.tokensOutput': 'токени (излез)',
   'diagnostics.tokensTotal': 'токени (вкупно)',
   'diagnostics.topDistance': 'најблиска дистанца',
+  'diagnostics.traceId': 'trace ID',
   'error.description': 'Се случи неочекувана грешка. Обидете се повторно.',
   'error.interrupted': 'Одговорот е прекинат.',
   'error.retry': 'Обиди се повторно',

--- a/web/test/thread.test.tsx
+++ b/web/test/thread.test.tsx
@@ -375,7 +375,7 @@ describe('AssistantMessage', () => {
     );
   });
 
-  it('reveals the model and throughput rows in the diagnostics popover', async () => {
+  it('reveals the model, trace ID, and throughput rows in the diagnostics popover', async () => {
     const user = userEvent.setup();
     const msg: MyUIMessage = {
       id: 'a1',
@@ -387,6 +387,7 @@ describe('AssistantMessage', () => {
           tokens: { input: 10, output: 30, total: 40 },
         },
         inferenceModel: 'claude-sonnet-4-6',
+        responseId: '00000000-0000-4000-8000-000000000123',
         timing: { totalMs: 2_000, ttftMs: 200 },
       },
       parts: [{ text: 'Готово', type: 'text' }],
@@ -398,6 +399,10 @@ describe('AssistantMessage', () => {
 
     await expect(screen.findByText('модел')).resolves.toBeInTheDocument();
     expect(screen.getByText('claude-sonnet-4-6')).toBeInTheDocument();
+    expect(screen.getByText('trace ID')).toBeInTheDocument();
+    expect(
+      screen.getByText('00000000-0000-4000-8000-000000000123'),
+    ).toBeInTheDocument();
     expect(screen.getByText('брзина (ток./сек)')).toBeInTheDocument();
     expect(screen.getByText('20')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- show the chat response ID as the analytics trace ID in the diagnostics hover card
- preserve long trace IDs with a monospace wrapped value
- cover the trace ID row in unit and Playwright chat tests

## Verification
- npm run typecheck
- npm run lint (passes with existing max-lines warnings)
- npm test -- test/thread.test.tsx test/sse.test.ts test/chat-translate.test.ts
- API_BASE_URL=http://127.0.0.1:8880 CHAT_API_KEY=test-key npm run build
- API_BASE_URL=http://127.0.0.1:8880 CHAT_API_KEY=test-key npx playwright test e2e/chat.spec.ts