### PR TITLE
feat(api): add claude sonnet 5 model support

### DIFF
--- a/api/app/llms/models.py
+++ b/api/app/llms/models.py
@@ -30,6 +30,7 @@ class Model(Enum):
 
     CLAUDE_OPUS_4_8 = "claude-opus-4-8"
     CLAUDE_OPUS_4_7 = "claude-opus-4-7"
+    CLAUDE_SONNET_5 = "claude-sonnet-5"
     CLAUDE_SONNET_4_6 = "claude-sonnet-4-6"
     CLAUDE_HAIKU_4_5 = "claude-haiku-4-5"
 
@@ -93,6 +94,7 @@ CHAT_MODELS: frozenset[Model] = frozenset(
         Model.GEMINI_3_FLASH_PREVIEW,
         Model.CLAUDE_OPUS_4_8,
         Model.CLAUDE_OPUS_4_7,
+        Model.CLAUDE_SONNET_5,
         Model.CLAUDE_SONNET_4_6,
         Model.CLAUDE_HAIKU_4_5,
         Model.QWEN2_1_5_B_INSTRUCT,
@@ -124,6 +126,7 @@ ANTHROPIC_QUERY_TRANSFORM_MODELS: frozenset[Model] = frozenset(
     {
         Model.CLAUDE_OPUS_4_8,
         Model.CLAUDE_OPUS_4_7,
+        Model.CLAUDE_SONNET_5,
         Model.CLAUDE_SONNET_4_6,
         Model.CLAUDE_HAIKU_4_5,
     },
@@ -160,6 +163,7 @@ REASONING_CAPABLE_MODELS: frozenset[Model] = frozenset(
         Model.GEMINI_3_FLASH_PREVIEW,
         Model.CLAUDE_OPUS_4_8,
         Model.CLAUDE_OPUS_4_7,
+        Model.CLAUDE_SONNET_5,
         Model.CLAUDE_SONNET_4_6,
         Model.CLAUDE_HAIKU_4_5,
     },

--- a/api/app/llms/streams.py
+++ b/api/app/llms/streams.py
@@ -112,6 +112,7 @@ async def stream_response_with_agent(
         case (
             Model.CLAUDE_OPUS_4_8
             | Model.CLAUDE_OPUS_4_7
+            | Model.CLAUDE_SONNET_5
             | Model.CLAUDE_SONNET_4_6
             | Model.CLAUDE_HAIKU_4_5
         ):

--- a/api/tests/test_models.py
+++ b/api/tests/test_models.py
@@ -1,6 +1,6 @@
 from collections.abc import AsyncIterator
 
-import pytest
+import anyio
 from fastapi.responses import StreamingResponse
 from langchain_core.messages import BaseMessage
 
@@ -22,8 +22,7 @@ def test_claude_sonnet_5_is_a_supported_anthropic_chat_model():
     assert model in REASONING_CAPABLE_MODELS
 
 
-@pytest.mark.anyio
-async def test_claude_sonnet_5_routes_to_anthropic(monkeypatch):
+def test_claude_sonnet_5_routes_to_anthropic(monkeypatch):
     model = Model("claude-sonnet-5")
 
     async def fake_stream_anthropic_agent_response(
@@ -52,14 +51,17 @@ async def test_claude_sonnet_5_routes_to_anthropic(monkeypatch):
         fake_stream_anthropic_agent_response,
     )
 
-    response = await streams.stream_response_with_agent(
-        "test",
-        model,
-        system_prompt="system",
-        history=[],
-        temperature=0.0,
-        top_p=1.0,
-        max_tokens=128,
-    )
+    async def route_response() -> StreamingResponse:
+        return await streams.stream_response_with_agent(
+            "test",
+            model,
+            system_prompt="system",
+            history=[],
+            temperature=0.0,
+            top_p=1.0,
+            max_tokens=128,
+        )
+
+    response = anyio.run(route_response)
 
     assert response.headers["x-routed-model"] == "claude-sonnet-5"

--- a/api/tests/test_models.py
+++ b/api/tests/test_models.py
@@ -1,3 +1,11 @@
+from collections.abc import AsyncIterator
+
+import pytest
+from fastapi.responses import StreamingResponse
+from langchain_core.messages import BaseMessage
+
+from app.llms import streams
+from app.llms.agents import StreamObservation
 from app.llms.models import (
     ANTHROPIC_QUERY_TRANSFORM_MODELS,
     CHAT_MODELS,
@@ -12,3 +20,46 @@ def test_claude_sonnet_5_is_a_supported_anthropic_chat_model():
     assert model in CHAT_MODELS
     assert model in ANTHROPIC_QUERY_TRANSFORM_MODELS
     assert model in REASONING_CAPABLE_MODELS
+
+
+@pytest.mark.anyio
+async def test_claude_sonnet_5_routes_to_anthropic(monkeypatch):
+    model = Model("claude-sonnet-5")
+
+    async def fake_stream_anthropic_agent_response(
+        user_prompt: str,
+        routed_model: Model,
+        *,
+        system_prompt: str,
+        history: list[BaseMessage] | None = None,
+        temperature: float,
+        top_p: float,
+        max_tokens: int,
+        reasoning: bool = False,
+        observation: StreamObservation | None = None,
+    ) -> StreamingResponse:
+        async def empty_body() -> AsyncIterator[bytes]:
+            if False:
+                yield b""
+
+        response = StreamingResponse(empty_body(), media_type="text/event-stream")
+        response.headers["x-routed-model"] = routed_model.value
+        return response
+
+    monkeypatch.setattr(
+        streams,
+        "stream_anthropic_agent_response",
+        fake_stream_anthropic_agent_response,
+    )
+
+    response = await streams.stream_response_with_agent(
+        "test",
+        model,
+        system_prompt="system",
+        history=[],
+        temperature=0.0,
+        top_p=1.0,
+        max_tokens=128,
+    )
+
+    assert response.headers["x-routed-model"] == "claude-sonnet-5"

--- a/api/tests/test_models.py
+++ b/api/tests/test_models.py
@@ -1,0 +1,14 @@
+from app.llms.models import (
+    ANTHROPIC_QUERY_TRANSFORM_MODELS,
+    CHAT_MODELS,
+    REASONING_CAPABLE_MODELS,
+    Model,
+)
+
+
+def test_claude_sonnet_5_is_a_supported_anthropic_chat_model():
+    model = Model("claude-sonnet-5")
+
+    assert model in CHAT_MODELS
+    assert model in ANTHROPIC_QUERY_TRANSFORM_MODELS
+    assert model in REASONING_CAPABLE_MODELS


### PR DESCRIPTION
## Summary
- add claude-sonnet-5 to backend model registry, chat list, query transform support, and reasoning support
- route claude-sonnet-5 through the Anthropic streamer
- add regression coverage for registry membership and routing

## Verification
- uv run ruff check app/llms/models.py app/llms/streams.py tests/test_models.py
- uv run --with pytest pytest tests/test_models.py tests/test_retrieval_sources.py
- uv run --with pytest mypy app/llms/models.py app/llms/streams.py tests/test_models.py