### PR TITLE
feat(web): expand source cards

### DIFF
--- a/web/components/chat/source-cards.tsx
+++ b/web/components/chat/source-cards.tsx
@@ -7,6 +7,21 @@ import type { RetrievedSource } from '@/lib/api-types';
 
 import { t } from '@/lib/i18n';
 
+const PREVIEW_WORD_LIMIT = 12;
+const SENTENCE_END_RE = /[.!?]/u;
+const WHITESPACE_RE = /\s+/u;
+
+const snippetPreview = (snippet: string): string => {
+  const sentenceEnd = snippet.search(SENTENCE_END_RE);
+  if (sentenceEnd >= 0) {
+    return snippet.slice(0, sentenceEnd + 1);
+  }
+
+  const words = snippet.trim().split(WHITESPACE_RE);
+  const preview = words.slice(0, PREVIEW_WORD_LIMIT).join(' ');
+  return words.length > PREVIEW_WORD_LIMIT ? `${preview}…` : preview;
+};
+
 const SourceKindLabel = ({ source }: { source: RetrievedSource }) => (
   <span className="rounded-full border border-border/70 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
     {source.kind === 'faq' ? t('sources.faq') : t('sources.chunk')}
@@ -15,9 +30,11 @@ const SourceKindLabel = ({ source }: { source: RetrievedSource }) => (
 
 const SourceCard = ({ source }: { source: RetrievedSource }) => {
   const [expanded, setExpanded] = useState(false);
-  const hasSnippet = Boolean(source.snippet);
+  const snippet = source.snippet ?? '';
+  const hasSnippet = snippet.length > 0;
   const links = source.links ?? [];
   const snippetId = useId();
+  const visibleSnippet = expanded ? snippet : snippetPreview(snippet);
   const title = source.section
     ? `${source.title} · ${source.section}`
     : source.title;
@@ -45,7 +62,7 @@ const SourceCard = ({ source }: { source: RetrievedSource }) => {
           className={`mt-2 text-xs leading-relaxed text-muted-foreground ${expanded ? 'whitespace-pre-wrap' : 'line-clamp-2'}`}
           id={snippetId}
         >
-          {source.snippet}
+          {visibleSnippet}
         </p>
       ) : null}
     </>

--- a/web/components/chat/source-cards.tsx
+++ b/web/components/chat/source-cards.tsx
@@ -60,7 +60,7 @@ const SourceCard = ({ source }: { source: RetrievedSource }) => {
             aria-expanded={expanded}
             className="min-w-0 flex-1 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             onClick={() => {
-              setExpanded(!expanded);
+              setExpanded((current) => !current);
             }}
             type="button"
           >
@@ -117,7 +117,7 @@ export const SourceCards = ({
         aria-label={open ? t('sources.hide') : t('sources.show')}
         className="inline-flex items-center gap-1.5 rounded-md text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         onClick={() => {
-          setOpen(!open);
+          setOpen((current) => !current);
         }}
         type="button"
       >

--- a/web/components/chat/source-cards.tsx
+++ b/web/components/chat/source-cards.tsx
@@ -14,27 +14,61 @@ const SourceKindLabel = ({ source }: { source: RetrievedSource }) => (
 );
 
 const SourceCard = ({ source }: { source: RetrievedSource }) => {
+  const [expanded, setExpanded] = useState(false);
+  const hasSnippet = Boolean(source.snippet);
   const links = source.links ?? [];
+  const snippetId = useId();
   const title = source.section
     ? `${source.title} · ${source.section}`
     : source.title;
+  const content = (
+    <>
+      <div className="flex flex-wrap items-center gap-2">
+        <SourceKindLabel source={source} />
+        {typeof source.chunkIndex === 'number' ? (
+          <span className="text-[10px] text-muted-foreground/70">
+            #{source.chunkIndex + 1}
+          </span>
+        ) : null}
+        {hasSnippet ? (
+          <ChevronRight
+            aria-hidden="true"
+            className={`size-3 text-muted-foreground/70 transition-transform ${expanded ? 'rotate-90' : ''}`}
+          />
+        ) : null}
+      </div>
+      <p className="line-clamp-2 text-sm font-medium leading-snug text-foreground">
+        {title}
+      </p>
+      {hasSnippet ? (
+        <p
+          className={`mt-2 text-xs leading-relaxed text-muted-foreground ${expanded ? 'whitespace-pre-wrap' : 'line-clamp-2'}`}
+          id={snippetId}
+        >
+          {source.snippet}
+        </p>
+      ) : null}
+    </>
+  );
 
   return (
     <li className="min-w-0 rounded-lg border border-border/70 bg-muted/20 p-3 transition-colors hover:bg-muted/35">
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 space-y-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <SourceKindLabel source={source} />
-            {typeof source.chunkIndex === 'number' ? (
-              <span className="text-[10px] text-muted-foreground/70">
-                #{source.chunkIndex + 1}
-              </span>
-            ) : null}
-          </div>
-          <p className="line-clamp-2 text-sm font-medium leading-snug text-foreground">
-            {title}
-          </p>
-        </div>
+        {hasSnippet ? (
+          <button
+            aria-controls={snippetId}
+            aria-expanded={expanded}
+            className="min-w-0 flex-1 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => {
+              setExpanded(!expanded);
+            }}
+            type="button"
+          >
+            {content}
+          </button>
+        ) : (
+          <div className="min-w-0 flex-1 space-y-1">{content}</div>
+        )}
         {links.length > 0 ? (
           <div className="flex shrink-0 flex-wrap justify-end gap-1">
             {links.map((link) => (
@@ -55,11 +89,6 @@ const SourceCard = ({ source }: { source: RetrievedSource }) => {
           </div>
         ) : null}
       </div>
-      {source.snippet ? (
-        <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
-          {source.snippet}
-        </p>
-      ) : null}
     </li>
   );
 };

--- a/web/components/chat/source-cards.tsx
+++ b/web/components/chat/source-cards.tsx
@@ -13,11 +13,9 @@ const WHITESPACE_RE = /\s+/u;
 
 const snippetPreview = (snippet: string): string => {
   const sentenceEnd = snippet.search(SENTENCE_END_RE);
-  if (sentenceEnd >= 0) {
-    return snippet.slice(0, sentenceEnd + 1);
-  }
-
-  const words = snippet.trim().split(WHITESPACE_RE);
+  const sentencePreview =
+    sentenceEnd >= 0 ? snippet.slice(0, sentenceEnd + 1) : snippet;
+  const words = sentencePreview.trim().split(WHITESPACE_RE);
   const preview = words.slice(0, PREVIEW_WORD_LIMIT).join(' ');
   return words.length > PREVIEW_WORD_LIMIT ? `${preview}…` : preview;
 };

--- a/web/test/thread.test.tsx
+++ b/web/test/thread.test.tsx
@@ -20,6 +20,7 @@ const ARIA_EXPANDED = 'aria-expanded';
 const ANSWER_TEXT_TESTID = 'answer-text';
 const CHUNK_SOURCE_TITLE = 'Статут на ФИНКИ · Член 12';
 const CHUNK_SOURCE_TITLE_RE = /Статут на ФИНКИ · Член 12/u;
+const COLLAPSED_CHUNK_TEXT = 'Правилата се наведени во членот.';
 const EXPANDED_CHUNK_TEXT_RE = /Вториот став/u;
 const TIMING_TESTID = 'message-timing';
 
@@ -387,16 +388,19 @@ describe('AssistantMessage', () => {
     const chunkButton = screen.getByRole('button', {
       name: CHUNK_SOURCE_TITLE_RE,
     });
-    const chunkText = screen.getByText(EXPANDED_CHUNK_TEXT_RE);
+    const chunkText = screen.getByText(COLLAPSED_CHUNK_TEXT);
 
     expect(chunkButton).toHaveAttribute(ARIA_EXPANDED, 'false');
     expect(chunkText).toHaveClass('line-clamp-2');
+    expect(screen.queryByText(EXPANDED_CHUNK_TEXT_RE)).toBeNull();
 
     await user.click(chunkButton);
 
+    const expandedChunkText = screen.getByText(EXPANDED_CHUNK_TEXT_RE);
+
     expect(chunkButton).toHaveAttribute(ARIA_EXPANDED, 'true');
-    expect(chunkText).not.toHaveClass('line-clamp-2');
-    expect(chunkText).toHaveClass('whitespace-pre-wrap');
+    expect(expandedChunkText).not.toHaveClass('line-clamp-2');
+    expect(expandedChunkText).toHaveClass('whitespace-pre-wrap');
 
     expect(screen.getByRole('link', { name: 'Врска: iKnow' })).toHaveAttribute(
       'href',

--- a/web/test/thread.test.tsx
+++ b/web/test/thread.test.tsx
@@ -20,7 +20,8 @@ const ARIA_EXPANDED = 'aria-expanded';
 const ANSWER_TEXT_TESTID = 'answer-text';
 const CHUNK_SOURCE_TITLE = 'Статут на ФИНКИ · Член 12';
 const CHUNK_SOURCE_TITLE_RE = /Статут на ФИНКИ · Член 12/u;
-const COLLAPSED_CHUNK_TEXT = 'Правилата се наведени во членот.';
+const COLLAPSED_CHUNK_TEXT =
+  'Правилата за запишување и заверка на семестарот се наведени во овој член…';
 const EXPANDED_CHUNK_TEXT_RE = /Вториот став/u;
 const TIMING_TESTID = 'message-timing';
 
@@ -339,7 +340,7 @@ describe('AssistantMessage', () => {
   it('keeps source cards collapsed until the user expands them', async () => {
     const user = userEvent.setup();
     const chunkSnippet =
-      'Правилата се наведени во членот. Вториот став содржи дополнителни детали што треба да се прикажат кога картичката е отворена.';
+      'Правилата за запишување и заверка на семестарот се наведени во овој член со повеќе детали. Вториот став содржи дополнителни детали што треба да се прикажат кога картичката е отворена.';
     const msg: MyUIMessage = {
       id: 'a1',
       metadata: {

--- a/web/test/thread.test.tsx
+++ b/web/test/thread.test.tsx
@@ -16,7 +16,11 @@ beforeAll(() => {
 const SEARCHING = '🔍 Пребарувам…';
 const PREAMBLE = 'Дозволете да проверам во базата…';
 const ANSWER = 'Испитите се во јануари.';
+const ARIA_EXPANDED = 'aria-expanded';
 const ANSWER_TEXT_TESTID = 'answer-text';
+const CHUNK_SOURCE_TITLE = 'Статут на ФИНКИ · Член 12';
+const CHUNK_SOURCE_TITLE_RE = /Статут на ФИНКИ · Член 12/u;
+const EXPANDED_CHUNK_TEXT_RE = /Вториот став/u;
 const TIMING_TESTID = 'message-timing';
 
 const assistantWithParts = (parts: MyUIMessage['parts']): MyUIMessage => ({
@@ -333,6 +337,8 @@ describe('AssistantMessage', () => {
 
   it('keeps source cards collapsed until the user expands them', async () => {
     const user = userEvent.setup();
+    const chunkSnippet =
+      'Правилата се наведени во членот. Вториот став содржи дополнителни детали што треба да се прикажат кога картичката е отворена.';
     const msg: MyUIMessage = {
       id: 'a1',
       metadata: {
@@ -352,7 +358,7 @@ describe('AssistantMessage', () => {
             id: 'c1',
             kind: 'chunk',
             section: 'Член 12',
-            snippet: 'Правилата се наведени во членот.',
+            snippet: chunkSnippet,
             title: 'Статут на ФИНКИ',
           },
         ],
@@ -368,15 +374,30 @@ describe('AssistantMessage', () => {
 
     expect(sources).toHaveTextContent('Извори');
     expect(sources).toHaveTextContent('2');
-    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle).toHaveAttribute(ARIA_EXPANDED, 'false');
     expect(screen.queryByText('Упис')).toBeNull();
-    expect(screen.queryByText('Статут на ФИНКИ · Член 12')).toBeNull();
+    expect(screen.queryByText(CHUNK_SOURCE_TITLE)).toBeNull();
 
     await user.click(toggle);
 
-    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(toggle).toHaveAttribute(ARIA_EXPANDED, 'true');
     expect(screen.getByText('Упис')).toBeInTheDocument();
-    expect(screen.getByText('Статут на ФИНКИ · Член 12')).toBeInTheDocument();
+    expect(screen.getByText(CHUNK_SOURCE_TITLE)).toBeInTheDocument();
+
+    const chunkButton = screen.getByRole('button', {
+      name: CHUNK_SOURCE_TITLE_RE,
+    });
+    const chunkText = screen.getByText(EXPANDED_CHUNK_TEXT_RE);
+
+    expect(chunkButton).toHaveAttribute(ARIA_EXPANDED, 'false');
+    expect(chunkText).toHaveClass('line-clamp-2');
+
+    await user.click(chunkButton);
+
+    expect(chunkButton).toHaveAttribute(ARIA_EXPANDED, 'true');
+    expect(chunkText).not.toHaveClass('line-clamp-2');
+    expect(chunkText).toHaveClass('whitespace-pre-wrap');
+
     expect(screen.getByRole('link', { name: 'Врска: iKnow' })).toHaveAttribute(
       'href',
       'https://iknow.ukim.mk/',
@@ -390,7 +411,7 @@ describe('AssistantMessage', () => {
 
     expect(
       screen.getByRole('button', { name: 'Прикажи извори' }),
-    ).toHaveAttribute('aria-expanded', 'false');
+    ).toHaveAttribute(ARIA_EXPANDED, 'false');
     expect(screen.queryByText('Упис')).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- make source card bodies clickable when they have snippet text
- expand source snippets from clamped preview to full chunk text
- keep existing external source links separate from the card toggle

## Verification
- npm test -- thread.test.tsx
- npm run typecheck
- npm run lint (warnings only: pre-existing max-lines warnings)
- API_BASE_URL=http://localhost:8880 CHAT_API_KEY=dummy npm run build
- Browser QA on production build with mocked chat sources