### PR TITLE
fix: improve theme hover contrast

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -43,6 +43,8 @@
 
 @layer base {
   :root {
+    color-scheme: light;
+
     --background: 0 0% 100%;
     --foreground: 0 0% 5%;
     --card: 0 0% 99%;
@@ -50,13 +52,13 @@
     --popover: 0 0% 99%;
     --popover-foreground: 0 0% 5%;
     --primary: 142 70% 45%;
-    --primary-foreground: 0 0% 98%;
+    --primary-foreground: 0 0% 2%;
     --secondary: 0 0% 93%;
     --secondary-foreground: 0 0% 9%;
     --muted: 0 0% 94%;
     --muted-foreground: 0 0% 40%;
     --accent: 142 70% 45%;
-    --accent-foreground: 0 0% 98%;
+    --accent-foreground: 0 0% 2%;
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 88%;
@@ -66,6 +68,8 @@
   }
 
   [data-kb-theme='dark'] {
+    color-scheme: dark;
+
     --background: 0 0% 4%;
     --foreground: 0 0% 95%;
     --card: 0 0% 7%;

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -49,7 +49,10 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: LIGHT_THEME_COLOR,
+  themeColor: [
+    { color: LIGHT_THEME_COLOR, media: '(prefers-color-scheme: light)' },
+    { color: DARK_THEME_COLOR, media: '(prefers-color-scheme: dark)' },
+  ],
 };
 
 const noFlashTheme = `(() => {
@@ -66,8 +69,10 @@ const noFlashTheme = `(() => {
     root.dataset.kbTheme = theme;
     root.style.colorScheme = theme;
     document
-      .querySelector('meta[name="theme-color"]')
-      ?.setAttribute('content', themeColors[theme]);
+      .querySelectorAll('meta[name="theme-color"]')
+      .forEach((meta) => {
+        meta.setAttribute('content', themeColors[theme]);
+      });
   } catch {}
 })();`;
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -12,6 +12,8 @@ const DESCRIPTION =
   'Разговарај со ФИНКИ Хаб асистентот за прашања поврзани со студиите на ФИНКИ.';
 const SITE_URL = process.env['SITE_URL'] ?? 'https://chat.finki-hub.com';
 const OG_IMAGE = `${SITE_URL}/favicon-96x96.png`;
+const LIGHT_THEME_COLOR = '#ffffff';
+const DARK_THEME_COLOR = '#0a0a0a';
 
 export const metadata: Metadata = {
   alternates: {
@@ -47,22 +49,25 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: [
-    { color: '#ffffff', media: '(prefers-color-scheme: light)' },
-    { color: '#0a0a0a', media: '(prefers-color-scheme: dark)' },
-  ],
+  themeColor: LIGHT_THEME_COLOR,
 };
 
 const noFlashTheme = `(() => {
   try {
+    const themeColors = { dark: '${DARK_THEME_COLOR}', light: '${LIGHT_THEME_COLOR}' };
     const stored = localStorage.getItem('theme');
     const theme =
       stored === 'dark' || stored === 'light'
         ? stored
-        : matchMedia('(prefers-color-scheme: dark)').matches
+        : typeof matchMedia === 'function' && matchMedia('(prefers-color-scheme: dark)').matches
           ? 'dark'
           : 'light';
-    document.documentElement.dataset.kbTheme = theme;
+    const root = document.documentElement;
+    root.dataset.kbTheme = theme;
+    root.style.colorScheme = theme;
+    document
+      .querySelector('meta[name="theme-color"]')
+      ?.setAttribute('content', themeColors[theme]);
   } catch {}
 })();`;
 

--- a/web/components/shell/theme-toggle.tsx
+++ b/web/components/shell/theme-toggle.tsx
@@ -19,30 +19,51 @@ const prefersDark = (): boolean =>
   typeof matchMedia === 'function' &&
   matchMedia('(prefers-color-scheme: dark)').matches;
 
+const fallbackTheme = (): Theme => (prefersDark() ? 'dark' : 'light');
+
+const readStoredThemeValue = (): null | string => {
+  try {
+    return localStorage.getItem(storageKey);
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredTheme = (theme: Theme): boolean => {
+  try {
+    localStorage.setItem(storageKey, theme);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const readStoredTheme = (): Theme => {
   if (typeof localStorage === 'undefined') {
-    return 'light';
+    return fallbackTheme();
   }
 
-  const stored = localStorage.getItem(storageKey);
+  const stored = readStoredThemeValue();
   if (isTheme(stored)) {
     return stored;
   }
 
-  return prefersDark() ? 'dark' : 'light';
+  return fallbackTheme();
 };
 
 const syncThemeChrome = (theme: Theme) => {
   document.documentElement.style.colorScheme = theme;
   document
-    .querySelector<HTMLMetaElement>('meta[name="theme-color"]')
-    ?.setAttribute('content', themeColors[theme]);
+    .querySelectorAll<HTMLMetaElement>('meta[name="theme-color"]')
+    .forEach((meta) => {
+      meta.setAttribute('content', themeColors[theme]);
+    });
 };
 
 const applyTheme = (theme: Theme) => {
   document.documentElement.dataset['kbTheme'] = theme;
   syncThemeChrome(theme);
-  localStorage.setItem(storageKey, theme);
+  writeStoredTheme(theme);
 };
 
 export const ThemeToggle = () => {

--- a/web/components/shell/theme-toggle.tsx
+++ b/web/components/shell/theme-toggle.tsx
@@ -7,6 +7,10 @@ import { t } from '@/lib/i18n';
 type Theme = 'dark' | 'light';
 
 const storageKey = 'theme';
+const themeColors = {
+  dark: '#0a0a0a',
+  light: '#ffffff',
+} satisfies Record<Theme, string>;
 
 const isTheme = (value: null | string): value is Theme =>
   value === 'dark' || value === 'light';
@@ -16,6 +20,10 @@ const prefersDark = (): boolean =>
   matchMedia('(prefers-color-scheme: dark)').matches;
 
 const readStoredTheme = (): Theme => {
+  if (typeof localStorage === 'undefined') {
+    return 'light';
+  }
+
   const stored = localStorage.getItem(storageKey);
   if (isTheme(stored)) {
     return stored;
@@ -24,32 +32,48 @@ const readStoredTheme = (): Theme => {
   return prefersDark() ? 'dark' : 'light';
 };
 
+const syncThemeChrome = (theme: Theme) => {
+  document.documentElement.style.colorScheme = theme;
+  document
+    .querySelector<HTMLMetaElement>('meta[name="theme-color"]')
+    ?.setAttribute('content', themeColors[theme]);
+};
+
 const applyTheme = (theme: Theme) => {
   document.documentElement.dataset['kbTheme'] = theme;
+  syncThemeChrome(theme);
   localStorage.setItem(storageKey, theme);
 };
 
 export const ThemeToggle = () => {
-  const [theme, setTheme] = useState<Theme>('light');
+  const [theme, setTheme] = useState<null | Theme>(null);
 
   useEffect(() => {
     setTheme(readStoredTheme());
   }, []);
 
   useEffect(() => {
+    if (theme === null) {
+      return;
+    }
+
     applyTheme(theme);
   }, [theme]);
+
+  const displayedTheme = theme ?? 'light';
 
   return (
     <IconButton
       aria-label={t('header.theme')}
       onClick={() => {
-        setTheme((currentTheme) =>
-          currentTheme === 'dark' ? 'light' : 'dark',
-        );
+        setTheme((currentTheme) => {
+          const activeTheme = currentTheme ?? readStoredTheme();
+
+          return activeTheme === 'dark' ? 'light' : 'dark';
+        });
       }}
     >
-      {theme === 'dark' ? (
+      {displayedTheme === 'dark' ? (
         <SunIcon
           aria-hidden="true"
           className="h-4 w-4"


### PR DESCRIPTION
## Summary
- fix green theme foreground contrast in light mode
- sync manual theme selection with color-scheme and theme-color

## Checks
- npm run check
- npm run lint (pre-existing max-lines warnings only)
- npm run test
- npm run build
- Playwright hover/theme QA