### PR TITLE
fix(api): stop streaming reasoning traces

### DIFF
--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -243,8 +243,8 @@ async def _instrument_stream(
     distinct_id: str,
     observation: StreamObservation,
 ) -> AsyncGenerator[bytes | str | memoryview]:
-    """Pass the SSE body through untouched, stamping TTFT, thinking and total, then
-    log one chat.timing line and emit a trailing ``meta`` frame with the same breakdown.
+    """Stamp TTFT, thinking and total while filtering private thinking frames,
+    then log one chat.timing line and emit a trailing ``meta`` frame.
 
     Thinking time spans the first ``thinking`` frame to the first ``token`` frame, so it
     lands in the same ``meta`` diagnostics as TTFT and total.
@@ -261,8 +261,8 @@ async def _instrument_stream(
     try:
         async for chunk in body:
             timings.mark_ttft()
+            event_name = _sse_event_name(chunk)
             if marking or not answered:
-                event_name = _sse_event_name(chunk)
                 if marking:
                     if event_name == "thinking":
                         timings.mark_thinking()
@@ -274,6 +274,8 @@ async def _instrument_stream(
             sniffed = _sniff_tokens(chunk)
             if sniffed is not None:
                 usage = sniffed
+            if event_name == "thinking":
+                continue
             yield chunk
     except GeneratorExit:
         outcome = "client_disconnect"

--- a/api/app/schemas/chat.py
+++ b/api/app/schemas/chat.py
@@ -119,9 +119,9 @@ class ChatSchema(BaseModel):
         examples=[True],
         description=(
             "Enable the model's extended-thinking / reasoning mode. When true and the "
-            "selected model supports it, the model reasons before answering and the "
-            "reasoning is streamed on a separate `thinking` SSE channel. Models without "
-            "a reasoning mode ignore this flag."
+            "selected model supports it, the model reasons before answering. Private "
+            "reasoning traces are not streamed to public clients. Models without a "
+            "reasoning mode ignore this flag."
         ),
     )
 

--- a/api/tests/test_chat_cost_meta.py
+++ b/api/tests/test_chat_cost_meta.py
@@ -18,6 +18,12 @@ async def _body() -> AsyncIterator[str]:
     yield "event: done\ndata: {}\n\n"
 
 
+async def _body_with_thinking() -> AsyncIterator[str]:
+    yield 'event: thinking\ndata: {"text":"private chain of thought"}\n\n'
+    yield 'event: token\ndata: {"text":"answer"}\n\n'
+    yield "event: done\ndata: {}\n\n"
+
+
 def test_chat_stream_emits_cost_diagnostics_when_pricing_is_known(monkeypatch):
     captured: list[tuple[str, str, dict[str, object]]] = []
     monkeypatch.setattr(
@@ -52,3 +58,35 @@ def test_chat_stream_emits_cost_diagnostics_when_pricing_is_known(monkeypatch):
     assert meta["cost"]["total_usd"] == pytest.approx(0.006)
     assert len(captured) == 1
     assert captured[0][2]["$ai_total_cost_usd"] == pytest.approx(0.006)
+
+
+def test_chat_stream_does_not_forward_private_thinking_events(monkeypatch):
+    monkeypatch.setattr(chat_api, "capture", lambda *args: None)
+    payload = ChatSchema(
+        interface="web",
+        inference_model=Model.CLAUDE_HAIKU_4_5,
+        messages=[{"role": "user", "content": "Прашање?"}],
+        reasoning=True,
+    )
+    observation = StreamObservation(distinct_id="user-1", response_id="response-1")
+
+    async def collect() -> list[str]:
+        stream = chat_api._instrument_stream(  # noqa: SLF001
+            _body_with_thinking(),
+            payload=payload,
+            response_id=uuid4(),
+            timings=RequestTimings(),
+            retrieval_hit=True,
+            distinct_id="user-1",
+            observation=observation,
+        )
+        return [str(chunk) async for chunk in stream]
+
+    chunks = anyio.run(collect)
+    body = "".join(chunks)
+    meta = json.loads(chunks[-1].split("data:", 1)[1].strip())
+
+    assert "event: thinking" not in body
+    assert "private chain of thought" not in body
+    assert 'event: token\ndata: {"text":"answer"}' in body
+    assert meta["timing"]["thinking_ms"] is not None


### PR DESCRIPTION
## Summary
- filter private thinking SSE frames before they reach public clients
- keep server-side thinking timing in diagnostics
- update reasoning flag API description

## Checks
- uv run pytest tests/test_chat_cost_meta.py tests/test_chat_system_prompt.py -q
- uv run ruff check app/api/chat.py app/schemas/chat.py tests/test_chat_cost_meta.py
- manual _instrument_stream driver