### PR TITLE
feat: add magic chat title generation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,36 @@
+# FINKI Hub Chat Design System
+
+## 1. Purpose
+
+The chat UI is an operational product surface: fast, quiet, and readable for students asking factual questions. New controls should preserve the existing sidebar rhythm rather than introduce a new visual language.
+
+## 2. Tokens
+
+- Color uses the existing Tailwind semantic tokens: `background`, `foreground`, `muted`, `muted-foreground`, `border`, `card`, `primary`, `destructive`, and `ring`.
+- Spacing follows the existing 4px Tailwind scale. Sidebar row controls use `gap-1`, `px-2.5`, `py-1.5`, and icon padding `p-1`.
+- Radius follows existing rounded surfaces: `rounded-md` for icon controls, `rounded-lg` for sidebar rows, and `rounded-xl` for larger sidebar buttons.
+
+## 3. Typography
+
+- Sidebar rows use `text-sm`; section labels use `text-xs`, uppercase, and tracking-wide.
+- Conversation titles are single-line, truncated, and left-aligned.
+
+## 4. Motion
+
+- Motion is limited to opacity, color, and transform transitions already present in the sidebar.
+- Loading indicators may rotate, but only to communicate an in-progress action.
+
+## 5. Components
+
+- Sidebar conversation row: selectable title button plus compact row-action icon buttons that reveal on hover/focus for desktop and stay visible on mobile.
+- Row action button: Lucide icon, `size-3.5`, semantic aria label, focus-visible ring, muted default color, stronger hover color matching the action intent.
+- Destructive row action: use destructive hover color only for delete.
+
+## 6. Accessibility
+
+- Every icon-only action must have an `aria-label` from `web/lib/i18n.ts`.
+- Disabled async actions must expose `aria-busy` when work is pending.
+
+## 7. Accepted debt
+
+- The app currently has no richer brand reference document. This file captures the existing implicit system so small sidebar actions can remain consistent without a redesign.

--- a/api/app/api/chat_title.py
+++ b/api/app/api/chat_title.py
@@ -1,0 +1,60 @@
+from fastapi import APIRouter, status
+
+from app.llms.query_transform import transform_query
+from app.schemas.chat_title import ChatTitleResponse, ChatTitleSchema
+
+router = APIRouter(prefix="/chat", tags=["Chat"])
+
+_TITLE_MAX = 60
+_FALLBACK_TITLE = "Нов разговор"
+_TITLE_SYSTEM_PROMPT = """Generate a concise conversation title.
+
+Rules:
+- Use the same language as the user's first message.
+- Prefer Macedonian Cyrillic when the message is Macedonian.
+- Output only the title, with no quotes, punctuation wrapper, markdown, or explanation.
+- Keep it under 6 words and under 60 characters.
+- Describe the user's intent, not the assistant response."""
+
+
+def _first_line(text: str) -> str:
+    return text.split("\n", 1)[0].strip()
+
+
+def _clip_title(text: str) -> str:
+    if len(text) <= _TITLE_MAX:
+        return text
+    return f"{text[: _TITLE_MAX - 1].rstrip()}…"
+
+
+def _normalize_title(raw_title: str, fallback_text: str) -> str:
+    title = " ".join(_first_line(raw_title).strip("'\"`“”‘’ ").split())
+    if not title:
+        title = _first_line(fallback_text) or _FALLBACK_TITLE
+    return _clip_title(title)
+
+
+async def generate_chat_title(payload: ChatTitleSchema) -> ChatTitleResponse:
+    prompt = f"Conversation transcript:\n{payload.transcript}"
+    raw_title = await transform_query(
+        prompt,
+        payload.query_transform_model,
+        system_prompt=_TITLE_SYSTEM_PROMPT,
+        temperature=0.2,
+        top_p=1.0,
+        max_tokens=32,
+    )
+    return ChatTitleResponse(
+        title=_normalize_title(raw_title, payload.first_user_text),
+    )
+
+
+@router.post(
+    "/title",
+    summary="Generate a chat title",
+    description="Generate a short title from the first conversation turns.",
+    operation_id="generateChatTitle",
+    status_code=status.HTTP_200_OK,
+)
+async def chat_title(payload: ChatTitleSchema) -> ChatTitleResponse:
+    return await generate_chat_title(payload)

--- a/api/app/llms/query_transform.py
+++ b/api/app/llms/query_transform.py
@@ -26,8 +26,9 @@ async def transform_query(
     max_tokens: int,
 ) -> str:
     logger.info(
-        "Transforming query: '%s'",
-        query,
+        "Transforming query with model=%s query_length=%d",
+        model,
+        len(query),
     )
 
     match model:

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.cors import CORSMiddleware
 
 from app.api.chat import router as chat_router
+from app.api.chat_title import router as chat_title_router
 from app.api.diplomas import router as diplomas_router
 from app.api.documents import router as documents_router
 from app.api.feedback import router as feedback_router
@@ -120,6 +121,7 @@ def make_app(settings: Settings) -> FastAPI:
     app.include_router(groups_router)
     app.include_router(links_router)
     app.include_router(chat_router)
+    app.include_router(chat_title_router)
     app.include_router(feedback_router)
 
     @app.exception_handler(RequestValidationError)

--- a/api/app/schemas/chat_title.py
+++ b/api/app/schemas/chat_title.py
@@ -1,0 +1,56 @@
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.constants.defaults import DEFAULT_QUERY_TRANSFORM_MODEL
+from app.llms.models import QUERY_TRANSFORM_MODELS, Model
+from app.schemas.chat import ConversationTurn
+
+
+class ChatTitleSchema(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    messages: list[ConversationTurn] = Field(
+        min_length=1,
+        max_length=4,
+        description="The first conversation turns used to generate a concise title.",
+    )
+    query_transform_model: Model = Field(
+        DEFAULT_QUERY_TRANSFORM_MODEL,
+        description="Which chat-capable model to use for title generation.",
+    )
+
+    @field_validator("messages")
+    @classmethod
+    def _must_include_user_turn(
+        cls,
+        value: list[ConversationTurn],
+    ) -> list[ConversationTurn]:
+        if not any(turn.role == "user" for turn in value):
+            raise ValueError("messages must include at least one user turn")
+        return value
+
+    @field_validator("query_transform_model")
+    @classmethod
+    def _must_support_title_generation(cls, value: Model) -> Model:
+        if value not in QUERY_TRANSFORM_MODELS:
+            raise ValueError("query_transform_model must be a chat-capable model")
+        return value
+
+    @property
+    def first_user_text(self) -> str:
+        for turn in self.messages:
+            if turn.role == "user":
+                return turn.content
+        return ""
+
+    @property
+    def transcript(self) -> str:
+        return "\n".join(
+            f"{'User' if turn.role == 'user' else 'Assistant'}: {turn.content}"
+            for turn in self.messages
+        )
+
+
+class ChatTitleResponse(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    title: str = Field(min_length=1, max_length=60)

--- a/api/tests/test_chat_title.py
+++ b/api/tests/test_chat_title.py
@@ -1,6 +1,9 @@
+import logging
+
 import anyio
 
 from app.api import chat_title
+from app.llms import query_transform
 from app.llms.models import Model
 from app.schemas.chat_title import ChatTitleSchema
 
@@ -71,3 +74,38 @@ def test_chat_title_falls_back_to_first_user_message_when_model_returns_empty(
     response = anyio.run(chat_title.generate_chat_title, payload)
 
     assert response.title == "Како да пријавам испит?"
+
+
+def test_query_transform_logs_metadata_without_raw_query(monkeypatch, caplog):
+    async def fake_transform_query_with_openai(
+        query: str,
+        model: Model,
+        *,
+        system_prompt: str,
+        temperature: float,
+        top_p: float,
+        max_tokens: int,
+    ) -> str:
+        return "Испитен рок"
+
+    monkeypatch.setattr(
+        query_transform,
+        "transform_query_with_openai",
+        fake_transform_query_with_openai,
+    )
+    caplog.set_level(logging.INFO, logger=query_transform.__name__)
+
+    async def run_transform_query() -> None:
+        await query_transform.transform_query(
+            "Conversation transcript: private student question",
+            Model.GPT_5_4_MINI,
+            system_prompt="system",
+            temperature=0.2,
+            top_p=1.0,
+            max_tokens=32,
+        )
+
+    anyio.run(run_transform_query)
+
+    assert "private student question" not in caplog.text
+    assert "query_length" in caplog.text

--- a/api/tests/test_chat_title.py
+++ b/api/tests/test_chat_title.py
@@ -1,0 +1,73 @@
+import anyio
+
+from app.api import chat_title
+from app.llms.models import Model
+from app.schemas.chat_title import ChatTitleSchema
+
+
+def test_chat_title_uses_transform_prompt_and_normalizes_quotes(monkeypatch):
+    seen: dict[str, str | int | float | Model] = {}
+
+    async def fake_transform_query(
+        query: str,
+        model: Model,
+        *,
+        system_prompt: str,
+        temperature: float,
+        top_p: float,
+        max_tokens: int,
+    ) -> str:
+        seen.update(
+            {
+                "max_tokens": max_tokens,
+                "model": model,
+                "query": query,
+                "system_prompt": system_prompt,
+                "temperature": temperature,
+                "top_p": top_p,
+            },
+        )
+        return '"Испитна сесија"\n'
+
+    monkeypatch.setattr(chat_title, "transform_query", fake_transform_query)
+    payload = ChatTitleSchema(
+        messages=[{"role": "user", "content": "Кога е јунската сесија?"}],
+        query_transform_model=Model.CLAUDE_HAIKU_4_5,
+    )
+
+    response = anyio.run(chat_title.generate_chat_title, payload)
+
+    assert response.title == "Испитна сесија"
+    assert seen["model"] == Model.CLAUDE_HAIKU_4_5
+    assert seen["max_tokens"] == 32
+    assert "Кога е јунската сесија?" in str(seen["query"])
+    assert "conversation title" in str(seen["system_prompt"])
+
+
+def test_chat_title_falls_back_to_first_user_message_when_model_returns_empty(
+    monkeypatch,
+):
+    async def fake_transform_query(
+        query: str,
+        model: Model,
+        *,
+        system_prompt: str,
+        temperature: float,
+        top_p: float,
+        max_tokens: int,
+    ) -> str:
+        return "   "
+
+    monkeypatch.setattr(chat_title, "transform_query", fake_transform_query)
+    payload = ChatTitleSchema(
+        messages=[
+            {
+                "role": "user",
+                "content": "  Како да пријавам испит?\nИ кои се роковите?  ",
+            },
+        ],
+    )
+
+    response = anyio.run(chat_title.generate_chat_title, payload)
+
+    assert response.title == "Како да пријавам испит?"

--- a/web/app/api/chat/title/route.ts
+++ b/web/app/api/chat/title/route.ts
@@ -10,6 +10,14 @@ import { API_BASE_URL } from '@/lib/env';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
+const MAX_TITLE_CONTENT_LENGTH = 8_000;
+const MAX_TITLE_MESSAGES = 4;
+
+type ParsePayloadResult =
+  | { readonly kind: 'invalid' }
+  | { readonly kind: 'ok'; readonly payload: ChatTitleClientPayload }
+  | { readonly kind: 'tooLarge' };
+
 const isRole = (value: unknown): value is ConversationRole =>
   value === 'assistant' || value === 'user';
 
@@ -32,23 +40,37 @@ const parseTurn = (value: unknown): ConversationTurn | null => {
   return { content, role };
 };
 
-const parsePayload = (value: unknown): ChatTitleClientPayload | null => {
+const parsePayload = (value: unknown): ParsePayloadResult => {
   if (typeof value !== 'object' || value === null) {
-    return null;
+    return { kind: 'invalid' };
   }
 
   const candidate = value as Record<string, unknown>;
   const rawMessages = candidate['messages'];
 
   if (!Array.isArray(rawMessages) || rawMessages.length === 0) {
-    return null;
+    return { kind: 'invalid' };
+  }
+
+  if (rawMessages.length > MAX_TITLE_MESSAGES) {
+    return { kind: 'tooLarge' };
   }
 
   const messages: ConversationTurn[] = [];
   for (const rawMessage of rawMessages) {
+    if (typeof rawMessage === 'object' && rawMessage !== null) {
+      const { content } = rawMessage as Record<string, unknown>;
+      if (
+        typeof content === 'string' &&
+        content.length > MAX_TITLE_CONTENT_LENGTH
+      ) {
+        return { kind: 'tooLarge' };
+      }
+    }
+
     const turn = parseTurn(rawMessage);
     if (turn === null) {
-      return null;
+      return { kind: 'invalid' };
     }
     messages.push(turn);
   }
@@ -59,10 +81,13 @@ const parsePayload = (value: unknown): ChatTitleClientPayload | null => {
       : candidate['queryTransformModel'];
 
   return {
-    messages,
-    ...(typeof queryTransformModel === 'string' && {
-      queryTransformModel,
-    }),
+    kind: 'ok',
+    payload: {
+      messages,
+      ...(typeof queryTransformModel === 'string' && {
+        queryTransformModel,
+      }),
+    },
   };
 };
 
@@ -109,14 +134,20 @@ export const POST = async (req: Request): Promise<Response> => {
     return jsonError('Invalid JSON body', 400);
   }
 
-  const payload = parsePayload(raw);
+  const result = parsePayload(raw);
 
-  if (payload === null) {
+  if (result.kind === 'tooLarge') {
+    return jsonError('Title payload is too large.', 413);
+  }
+
+  if (result.kind === 'invalid') {
     return jsonError(
       'Invalid title payload: at least one message is required.',
       400,
     );
   }
+
+  const { payload } = result;
 
   let upstream: Response;
 

--- a/web/app/api/chat/title/route.ts
+++ b/web/app/api/chat/title/route.ts
@@ -1,0 +1,148 @@
+import type {
+  ChatTitleClientPayload,
+  ChatTitleResponse,
+  ConversationRole,
+  ConversationTurn,
+} from '@/lib/api-types';
+
+import { API_BASE_URL } from '@/lib/env';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const isRole = (value: unknown): value is ConversationRole =>
+  value === 'assistant' || value === 'user';
+
+const parseTurn = (value: unknown): ConversationTurn | null => {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const { content, role } = candidate;
+
+  if (typeof content !== 'string' || content.trim().length === 0) {
+    return null;
+  }
+
+  if (!isRole(role)) {
+    return null;
+  }
+
+  return { content, role };
+};
+
+const parsePayload = (value: unknown): ChatTitleClientPayload | null => {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const rawMessages = candidate['messages'];
+
+  if (!Array.isArray(rawMessages) || rawMessages.length === 0) {
+    return null;
+  }
+
+  const messages: ConversationTurn[] = [];
+  for (const rawMessage of rawMessages) {
+    const turn = parseTurn(rawMessage);
+    if (turn === null) {
+      return null;
+    }
+    messages.push(turn);
+  }
+
+  const queryTransformModel =
+    typeof candidate['query_transform_model'] === 'string'
+      ? candidate['query_transform_model']
+      : candidate['queryTransformModel'];
+
+  return {
+    messages,
+    ...(typeof queryTransformModel === 'string' && {
+      queryTransformModel,
+    }),
+  };
+};
+
+const jsonError = (message: string, status: number): Response =>
+  Response.json(
+    { error: message },
+    {
+      headers: { 'content-type': 'application/json' },
+      status,
+    },
+  );
+
+const toSchema = (payload: ChatTitleClientPayload) => ({
+  messages: payload.messages,
+  ...(payload.queryTransformModel !== undefined && {
+    // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+    query_transform_model: payload.queryTransformModel,
+  }),
+});
+
+const parseResponse = async (
+  response: Response,
+): Promise<ChatTitleResponse | null> => {
+  let body: Partial<ChatTitleResponse>;
+
+  try {
+    body = (await response.json()) as Partial<ChatTitleResponse>;
+  } catch {
+    return null;
+  }
+
+  if (typeof body.title !== 'string' || body.title.trim().length === 0) {
+    return null;
+  }
+  return { title: body.title };
+};
+
+export const POST = async (req: Request): Promise<Response> => {
+  let raw: unknown;
+
+  try {
+    raw = await req.json();
+  } catch {
+    return jsonError('Invalid JSON body', 400);
+  }
+
+  const payload = parsePayload(raw);
+
+  if (payload === null) {
+    return jsonError(
+      'Invalid title payload: at least one message is required.',
+      400,
+    );
+  }
+
+  let upstream: Response;
+
+  try {
+    upstream = await fetch(`${API_BASE_URL}/chat/title`, {
+      body: JSON.stringify(toSchema(payload)),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST',
+      signal: req.signal,
+    });
+  } catch {
+    return jsonError('Failed to reach the title service.', 502);
+  }
+
+  if (!upstream.ok) {
+    return jsonError('The title service rejected the request.', 502);
+  }
+
+  const title = await parseResponse(upstream);
+
+  if (title === null) {
+    return jsonError('The title service returned an invalid response.', 502);
+  }
+
+  return Response.json(title, {
+    headers: { 'content-type': 'application/json' },
+    status: 200,
+  });
+};

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -69,9 +69,11 @@ const ChatScreen = () => {
     activeId,
     activeStatus,
     conversations,
+    generatingTitleId,
     messages,
     onClearAll,
     onDelete,
+    onGenerateTitle,
     onNewChat,
     onRename,
     onSelect,
@@ -90,11 +92,13 @@ const ChatScreen = () => {
         <Sidebar
           activeId={activeId}
           conversations={conversations}
+          generatingTitleId={generatingTitleId}
           onClearAll={onClearAll}
           onClose={() => {
             setSidebarOpen(false);
           }}
           onDelete={onDelete}
+          onGenerateTitle={onGenerateTitle}
           onNewChat={onNewChat}
           onRename={onRename}
           onSelect={onSelect}

--- a/web/components/shell/conversation-list.tsx
+++ b/web/components/shell/conversation-list.tsx
@@ -41,6 +41,7 @@ export const ConversationList = ({
   const [pendingDelete, setPendingDelete] = useState<ConversationRow | null>(
     null,
   );
+  const isGeneratingAnyTitle = generatingTitleId !== null;
 
   const openRename = (conversation: ConversationRow) => {
     setRenameTarget(conversation);
@@ -95,7 +96,7 @@ export const ConversationList = ({
                     aria-busy={isGeneratingTitle || undefined}
                     aria-label={t('conversation.generateTitle')}
                     className="rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-background hover:text-primary focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-60"
-                    disabled={isGeneratingTitle}
+                    disabled={isGeneratingAnyTitle}
                     onClick={() => {
                       onGenerateTitle(c.id);
                     }}

--- a/web/components/shell/conversation-list.tsx
+++ b/web/components/shell/conversation-list.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Trash2 } from 'lucide-react';
+import { LoaderCircle, Pencil, Trash2, WandSparkles } from 'lucide-react';
 import { useState } from 'react';
 
 import type { ConversationRow } from '@/lib/db';
@@ -18,7 +18,9 @@ import { t } from '@/lib/i18n';
 export type ConversationListProps = {
   activeId: null | string;
   conversations: ConversationRow[];
+  generatingTitleId?: null | string;
   onDelete: (id: string) => void;
+  onGenerateTitle?: (id: string) => void;
   onRename: (id: string, title: string) => void;
   onSelect: (id: string) => void;
 };
@@ -26,7 +28,9 @@ export type ConversationListProps = {
 export const ConversationList = ({
   activeId,
   conversations,
+  generatingTitleId = null,
   onDelete,
+  onGenerateTitle,
   onRename,
   onSelect,
 }: ConversationListProps) => {
@@ -61,57 +65,85 @@ export const ConversationList = ({
   return (
     <>
       <ul className="flex flex-col gap-1">
-        {conversations.map((c) => (
-          <li
-            aria-current={c.id === activeId ? 'true' : undefined}
-            className={`group flex items-center justify-between gap-1 rounded-lg px-2.5 py-1.5 text-sm text-foreground/80 transition-colors duration-150 hover:bg-muted/70 ${
-              c.id === activeId ? 'bg-muted font-medium text-foreground' : ''
-            }`}
-            data-testid={`conversation-${c.id}`}
-            key={c.id}
-          >
-            <button
-              className="flex-1 truncate rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-              onClick={() => {
-                onSelect(c.id);
-              }}
-              type="button"
-            >
-              {c.title}
-            </button>
-            <span
-              className="flex items-center gap-1 opacity-100 transition-opacity duration-150 sm:opacity-0 sm:group-focus-within:opacity-100 sm:group-hover:opacity-100"
-              data-testid="row-actions"
+        {conversations.map((c) => {
+          const isGeneratingTitle = generatingTitleId === c.id;
+
+          return (
+            <li
+              aria-current={c.id === activeId ? 'true' : undefined}
+              className={`group flex items-center justify-between gap-1 rounded-lg px-2.5 py-1.5 text-sm text-foreground/80 transition-colors duration-150 hover:bg-muted/70 ${
+                c.id === activeId ? 'bg-muted font-medium text-foreground' : ''
+              }`}
+              data-testid={`conversation-${c.id}`}
+              key={c.id}
             >
               <button
-                aria-label={t('conversation.rename')}
-                className="rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-background hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+                className="flex-1 truncate rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                 onClick={() => {
-                  openRename(c);
+                  onSelect(c.id);
                 }}
                 type="button"
               >
-                <Pencil
-                  aria-hidden="true"
-                  className="size-3.5"
-                />
+                {c.title}
               </button>
-              <button
-                aria-label={t('conversation.delete')}
-                className="rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-background hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring/50"
-                onClick={() => {
-                  setPendingDelete(c);
-                }}
-                type="button"
+              <span
+                className="flex items-center gap-1 opacity-100 transition-opacity duration-150 sm:opacity-0 sm:group-focus-within:opacity-100 sm:group-hover:opacity-100"
+                data-testid="row-actions"
               >
-                <Trash2
-                  aria-hidden="true"
-                  className="size-3.5"
-                />
-              </button>
-            </span>
-          </li>
-        ))}
+                {onGenerateTitle ? (
+                  <button
+                    aria-busy={isGeneratingTitle || undefined}
+                    aria-label={t('conversation.generateTitle')}
+                    className="rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-background hover:text-primary focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-60"
+                    disabled={isGeneratingTitle}
+                    onClick={() => {
+                      onGenerateTitle(c.id);
+                    }}
+                    type="button"
+                  >
+                    {isGeneratingTitle ? (
+                      <LoaderCircle
+                        aria-hidden="true"
+                        className="size-3.5 animate-spin"
+                      />
+                    ) : (
+                      <WandSparkles
+                        aria-hidden="true"
+                        className="size-3.5"
+                      />
+                    )}
+                  </button>
+                ) : null}
+                <button
+                  aria-label={t('conversation.rename')}
+                  className="rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-background hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+                  onClick={() => {
+                    openRename(c);
+                  }}
+                  type="button"
+                >
+                  <Pencil
+                    aria-hidden="true"
+                    className="size-3.5"
+                  />
+                </button>
+                <button
+                  aria-label={t('conversation.delete')}
+                  className="rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-background hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring/50"
+                  onClick={() => {
+                    setPendingDelete(c);
+                  }}
+                  type="button"
+                >
+                  <Trash2
+                    aria-hidden="true"
+                    className="size-3.5"
+                  />
+                </button>
+              </span>
+            </li>
+          );
+        })}
       </ul>
 
       <Dialog

--- a/web/components/shell/sidebar.tsx
+++ b/web/components/shell/sidebar.tsx
@@ -17,9 +17,11 @@ import { cn } from '@/lib/utils';
 export type SidebarProps = {
   activeId: null | string;
   conversations: ConversationRow[];
+  generatingTitleId?: null | string;
   onClearAll: () => void;
   onClose: () => void;
   onDelete: (id: string) => void;
+  onGenerateTitle?: (id: string) => void;
   onNewChat: () => void;
   onRename: (id: string, title: string) => void;
   onSelect: (id: string) => void;
@@ -39,9 +41,11 @@ const closeIfMobile = (onClose: () => void) => {
 export const Sidebar = ({
   activeId,
   conversations,
+  generatingTitleId,
   onClearAll,
   onClose,
   onDelete,
+  onGenerateTitle,
   onNewChat,
   onRename,
   onSelect,
@@ -154,7 +158,9 @@ export const Sidebar = ({
               <ConversationList
                 activeId={activeId}
                 conversations={filtered}
+                generatingTitleId={generatingTitleId}
                 onDelete={onDelete}
+                onGenerateTitle={onGenerateTitle}
                 onRename={onRename}
                 onSelect={handleSelect}
               />

--- a/web/lib/api-types.ts
+++ b/web/lib/api-types.ts
@@ -15,6 +15,20 @@ export type ChatRequestBody = {
   top_p?: number;
 };
 
+export type ChatTitleClientPayload = {
+  readonly messages: readonly ConversationTurn[];
+  readonly queryTransformModel?: ModelId;
+};
+
+export type ChatTitleRequestBody = {
+  readonly messages: readonly ConversationTurn[];
+  readonly query_transform_model?: ModelId;
+};
+
+export type ChatTitleResponse = {
+  readonly title: string;
+};
+
 export type ConversationRole = 'assistant' | 'user';
 
 export type ConversationTurn = {

--- a/web/lib/chat-title-translate.ts
+++ b/web/lib/chat-title-translate.ts
@@ -1,0 +1,33 @@
+import type {
+  ChatTitleRequestBody,
+  ConversationTurn,
+  ModelId,
+  MyUIMessage,
+} from '@/lib/api-types';
+
+import { joinText, lastText } from '@/lib/message-parts';
+
+const TITLE_CONTEXT_TURNS = 4;
+
+type ChatTitleTranslateInput = {
+  readonly messages: readonly MyUIMessage[];
+  readonly queryTransformModel?: ModelId;
+};
+
+const toTurn = (message: MyUIMessage): ConversationTurn => {
+  const role = message.role === 'assistant' ? 'assistant' : 'user';
+  const content =
+    (role === 'assistant' ? lastText(message) : joinText(message)) ?? '';
+
+  return { content, role };
+};
+
+export const toChatTitleRequestBody = (
+  body: ChatTitleTranslateInput,
+): ChatTitleRequestBody => ({
+  messages: body.messages.slice(0, TITLE_CONTEXT_TURNS).map(toTurn),
+  ...(body.queryTransformModel !== undefined && {
+    // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+    query_transform_model: body.queryTransformModel,
+  }),
+});

--- a/web/lib/chat-title.ts
+++ b/web/lib/chat-title.ts
@@ -1,0 +1,30 @@
+import type { ChatTitleResponse, ModelId, MyUIMessage } from '@/lib/api-types';
+
+import { toChatTitleRequestBody } from '@/lib/chat-title-translate';
+
+type GenerateTitleInput = {
+  readonly messages: readonly MyUIMessage[];
+  readonly queryTransformModel: ModelId;
+};
+
+export const generateChatTitle = async ({
+  messages,
+  queryTransformModel,
+}: GenerateTitleInput): Promise<null | string> => {
+  const response = await fetch('/api/chat/title', {
+    body: JSON.stringify(
+      toChatTitleRequestBody({ messages, queryTransformModel }),
+    ),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const body = (await response.json()) as ChatTitleResponse;
+  const title = body.title.trim();
+
+  return title.length > 0 ? title : null;
+};

--- a/web/lib/chat-title.ts
+++ b/web/lib/chat-title.ts
@@ -1,10 +1,30 @@
-import type { ChatTitleResponse, ModelId, MyUIMessage } from '@/lib/api-types';
+import type { ModelId, MyUIMessage } from '@/lib/api-types';
 
 import { toChatTitleRequestBody } from '@/lib/chat-title-translate';
 
 type GenerateTitleInput = {
   readonly messages: readonly MyUIMessage[];
   readonly queryTransformModel: ModelId;
+};
+
+const parseTitle = (value: unknown): null | string => {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+
+  if (!('title' in value)) {
+    return null;
+  }
+
+  const { title } = value;
+
+  if (typeof title !== 'string') {
+    return null;
+  }
+
+  const trimmed = title.trim();
+
+  return trimmed.length > 0 ? trimmed : null;
 };
 
 export const generateChatTitle = async ({
@@ -23,8 +43,16 @@ export const generateChatTitle = async ({
     return null;
   }
 
-  const body = (await response.json()) as ChatTitleResponse;
-  const title = body.title.trim();
+  let body: unknown;
 
-  return title.length > 0 ? title : null;
+  try {
+    body = await response.json();
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return null;
+    }
+    throw error;
+  }
+
+  return parseTitle(body);
 };

--- a/web/lib/db.ts
+++ b/web/lib/db.ts
@@ -80,6 +80,20 @@ export const renameConversation = async (
   await db.conversations.update(id, { title, updatedAt: nextNow() });
 };
 
+export const renameConversationIfTitle = async (
+  id: string,
+  expectedTitle: string,
+  title: string,
+): Promise<boolean> =>
+  db.transaction('rw', db.conversations, async () => {
+    const row = await db.conversations.get(id);
+    if (row?.title !== expectedTitle) {
+      return false;
+    }
+    await db.conversations.update(id, { title, updatedAt: nextNow() });
+    return true;
+  });
+
 export const deleteConversation = async (id: string): Promise<void> => {
   await db.transaction('rw', db.conversations, db.messages, async () => {
     await db.messages.where('conversationId').equals(id).delete();

--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -23,6 +23,7 @@ export const messages = {
   'conversation.deleteDescription':
     'Ова дејство е трајно и не може да се врати.',
   'conversation.deleteTitle': 'Избриши разговор?',
+  'conversation.generateTitle': 'Генерирај име',
   'conversation.rename': 'Преименувај',
   'conversation.renamePrompt': 'Ново име на разговорот',
   'conversation.renameTitle': 'Преименувај разговор',

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -12,6 +12,7 @@ import type {
 } from '@/lib/api-types';
 
 import { fireAndForget } from '@/lib/async';
+import { generateChatTitle } from '@/lib/chat-title';
 import { renderAnswerActions } from '@/lib/conversation-actions';
 import {
   applyFeedback,
@@ -23,7 +24,10 @@ import {
   clearAllConversations,
   createConversation,
   deleteConversation,
+  loadMessages,
+  type MessageRow,
   renameConversation,
+  renameConversationIfTitle,
   replaceConversationMessages,
   saveMessages,
   setMessageFeedback,
@@ -35,6 +39,13 @@ import { useUiStore } from '@/lib/ui-store';
 import { useConversationHydration } from '@/lib/use-conversation-hydration';
 import { useConversationList } from '@/lib/use-conversation-list';
 import { useStreamTiming } from '@/lib/use-stream-timing';
+
+const fromRow = (row: MessageRow): MyUIMessage => ({
+  id: row.id,
+  metadata: row.metadata,
+  parts: row.parts,
+  role: row.role,
+});
 
 export const useConversations = (
   model: string,
@@ -55,6 +66,9 @@ export const useConversations = (
   const [regeneratingMessageId, setRegeneratingMessageId] = useState<
     null | string
   >(null);
+  const [generatingTitleId, setGeneratingTitleId] = useState<null | string>(
+    null,
+  );
 
   const persistFinished = useCallback(
     async (allMessages: readonly MyUIMessage[]): Promise<void> => {
@@ -167,6 +181,32 @@ export const useConversations = (
     setMessages,
   });
 
+  const applyGeneratedTitle = useCallback(
+    async (
+      id: string,
+      titleMessages: readonly MyUIMessage[],
+      expectedTitle: string,
+    ): Promise<void> => {
+      setGeneratingTitleId(id);
+      try {
+        const title = await generateChatTitle({
+          messages: titleMessages,
+          queryTransformModel: modelRef.current,
+        });
+
+        if (title === null) {
+          return;
+        }
+
+        await renameConversationIfTitle(id, expectedTitle, title);
+        await refreshConversations();
+      } finally {
+        setGeneratingTitleId((current) => (current === id ? null : current));
+      }
+    },
+    [refreshConversations],
+  );
+
   const handleNewChat = useCallback(() => {
     // The Chat instance is shared across conversations; stop before leaving.
     void stop();
@@ -181,10 +221,12 @@ export const useConversations = (
       setActiveError(undefined);
       const existing = convoIdRef.current;
       let cid = existing;
+      let expectedTitle: null | string = null;
       if (!existing) {
+        expectedTitle = deriveTitle(text);
         const convo = await createConversation({
           model,
-          title: deriveTitle(text),
+          title: expectedTitle,
         });
         cid = convo.id;
         // eslint-disable-next-line require-atomic-updates -- fresh id, not a read-modify-write race
@@ -202,9 +244,18 @@ export const useConversations = (
         role: 'user',
       };
       await saveMessages(cid, [userMessage]);
+      if (expectedTitle !== null) {
+        fireAndForget(applyGeneratedTitle(cid, [userMessage], expectedTitle));
+      }
       fireAndForget(sendMessage(userMessage));
     },
-    [model, refreshConversations, sendMessage, setActiveId],
+    [
+      applyGeneratedTitle,
+      model,
+      refreshConversations,
+      sendMessage,
+      setActiveId,
+    ],
   );
 
   const handleSelect = useCallback(
@@ -272,6 +323,26 @@ export const useConversations = (
     [refreshConversations],
   );
 
+  const handleGenerateTitle = useCallback(
+    (id: string) => {
+      const expectedTitle = conversations.find((c) => c.id === id)?.title;
+      if (expectedTitle === undefined) {
+        return;
+      }
+
+      const run = async (): Promise<void> => {
+        const rows = await loadMessages(id);
+        if (rows.length === 0) {
+          return;
+        }
+        await applyGeneratedTitle(id, rows.map(fromRow), expectedTitle);
+      };
+
+      fireAndForget(run());
+    },
+    [applyGeneratedTitle, conversations],
+  );
+
   const recordFeedback = useCallback(
     (messageId: string, vote: FeedbackType) => {
       setMessages(applyFeedback(messageId, vote));
@@ -303,9 +374,11 @@ export const useConversations = (
     activeId,
     activeStatus,
     conversations,
+    generatingTitleId,
     messages: visibleMessages,
     onClearAll: handleClearAll,
     onDelete: handleDelete,
+    onGenerateTitle: handleGenerateTitle,
     onNewChat: handleNewChat,
     onRename: handleRename,
     onSelect: handleSelect,

--- a/web/test/chat-title-translate.test.ts
+++ b/web/test/chat-title-translate.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MyUIMessage } from '@/lib/api-types';
+
+import { toChatTitleRequestBody } from '@/lib/chat-title-translate';
+
+const msg = (role: MyUIMessage['role'], ...texts: string[]): MyUIMessage => ({
+  id: crypto.randomUUID(),
+  parts: texts.map((text) => ({ text, type: 'text' })),
+  role,
+});
+
+describe('toChatTitleRequestBody', () => {
+  it('keeps a short oldest-first transcript and forwards the title model', () => {
+    const messages = [
+      msg('user', 'Прашање?'),
+      msg('assistant', 'Одговор.'),
+      msg('user', 'Дополнително?'),
+      msg('assistant', 'Уште еден одговор.'),
+      msg('user', 'Ова не влегува.'),
+    ];
+
+    expect(
+      toChatTitleRequestBody({
+        messages,
+        queryTransformModel: 'claude-sonnet-4-6',
+      }),
+    ).toStrictEqual({
+      messages: [
+        { content: 'Прашање?', role: 'user' },
+        { content: 'Одговор.', role: 'assistant' },
+        { content: 'Дополнително?', role: 'user' },
+        { content: 'Уште еден одговор.', role: 'assistant' },
+      ],
+      // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+      query_transform_model: 'claude-sonnet-4-6',
+    });
+  });
+
+  it('uses the last assistant text part when a reset created multiple text parts', () => {
+    const out = toChatTitleRequestBody({
+      messages: [
+        msg('user', 'Прашање?'),
+        msg('assistant', 'премин', 'одговор'),
+      ],
+    });
+
+    expect(out.messages.at(-1)).toStrictEqual({
+      content: 'одговор',
+      role: 'assistant',
+    });
+  });
+});

--- a/web/test/chat-title.route.test.ts
+++ b/web/test/chat-title.route.test.ts
@@ -99,6 +99,42 @@ describe('POST /api/chat/title', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('returns 413 when the payload has too many messages', async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(
+      jsonRequest({
+        messages: [
+          { content: '1', role: 'user' },
+          { content: '2', role: 'assistant' },
+          { content: '3', role: 'user' },
+          { content: '4', role: 'assistant' },
+          { content: '5', role: 'user' },
+        ],
+      }),
+    );
+
+    expect(res.status).toBe(413);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 413 when a message content is too long', async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(
+      jsonRequest({
+        messages: [{ content: 'x'.repeat(8_001), role: 'user' }],
+      }),
+    );
+
+    expect(res.status).toBe(413);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('returns 502 when the title service returns an invalid body', async () => {
     const fetchMock = vi
       .fn<typeof fetch>()

--- a/web/test/chat-title.route.test.ts
+++ b/web/test/chat-title.route.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChatTitleClientPayload,
+  ChatTitleRequestBody,
+  ChatTitleResponse,
+} from '@/lib/api-types';
+
+import { POST } from '@/app/api/chat/title/route';
+
+vi.mock('@/lib/env', () => ({
+  API_BASE_URL: 'https://api:8880',
+  CHAT_API_KEY: 'test-key',
+  env: { API_BASE_URL: 'https://api:8880', CHAT_API_KEY: 'test-key' },
+}));
+
+const jsonRequest = (body: unknown): Request =>
+  new Request('https://localhost/api/chat/title', {
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+  });
+
+const okJson = (body: unknown): Response =>
+  Response.json(body, {
+    headers: { 'content-type': 'application/json' },
+    status: 200,
+  });
+
+describe('POST /api/chat/title', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('proxies a title request to the chat API and returns the generated title', async () => {
+    const payload: ChatTitleRequestBody = {
+      messages: [{ content: 'Кога е испитот?', role: 'user' }],
+      // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+      query_transform_model: 'claude-sonnet-4-6',
+    };
+    const upstream: ChatTitleResponse = { title: 'Испитен рок' };
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(okJson(upstream));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(jsonRequest(payload));
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe('https://api:8880/chat/title');
+    expect(init.method).toBe('POST');
+    expect(new Headers(init.headers).get('content-type')).toBe(
+      'application/json',
+    );
+    expect(JSON.parse(init.body as string)).toStrictEqual({
+      messages: [{ content: 'Кога е испитот?', role: 'user' }],
+      // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+      query_transform_model: 'claude-sonnet-4-6',
+    });
+    await expect(res.json()).resolves.toStrictEqual(upstream);
+  });
+
+  it('also accepts the legacy camelCase model field', async () => {
+    const payload: ChatTitleClientPayload = {
+      messages: [{ content: 'Кога е испитот?', role: 'user' }],
+      queryTransformModel: 'claude-sonnet-4-6',
+    };
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(okJson({ title: 'Испитен рок' }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(jsonRequest(payload));
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(res.status).toBe(200);
+    expect(JSON.parse(init.body as string)).toStrictEqual({
+      messages: [{ content: 'Кога е испитот?', role: 'user' }],
+      // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+      query_transform_model: 'claude-sonnet-4-6',
+    });
+  });
+
+  it('returns 400 when the payload has no messages', async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(jsonRequest({ messages: [] }));
+
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 502 when the title service returns an invalid body', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(okJson({ title: '' }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(
+      jsonRequest({ messages: [{ content: 'Прашање?', role: 'user' }] }),
+    );
+
+    expect(res.status).toBe(502);
+  });
+
+  it('returns 502 when the title service returns malformed JSON', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('not json', {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      }),
+    );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(
+      jsonRequest({ messages: [{ content: 'Прашање?', role: 'user' }] }),
+    );
+
+    expect(res.status).toBe(502);
+  });
+});

--- a/web/test/chat-title.test.ts
+++ b/web/test/chat-title.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { generateChatTitle } from '@/lib/chat-title';
+
+const titleInput = {
+  messages: [
+    {
+      id: 'm1',
+      parts: [{ text: 'Кога е испитот?', type: 'text' as const }],
+      role: 'user' as const,
+    },
+  ],
+  queryTransformModel: 'claude-sonnet-4-6',
+};
+
+describe('generateChatTitle', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null when the title response is malformed JSON', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response('not json', {
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        }),
+      ),
+    );
+
+    await expect(generateChatTitle(titleInput)).resolves.toBeNull();
+  });
+
+  it('returns null when the title response has no usable title', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockResolvedValue(
+        Response.json(
+          { title: ' '.repeat(3) },
+          {
+            headers: { 'content-type': 'application/json' },
+            status: 200,
+          },
+        ),
+      ),
+    );
+
+    await expect(generateChatTitle(titleInput)).resolves.toBeNull();
+  });
+});

--- a/web/test/conversation-list-a11y.test.tsx
+++ b/web/test/conversation-list-a11y.test.tsx
@@ -13,6 +13,13 @@ const conversations: ConversationRow[] = [
     title: 'Прв разговор',
     updatedAt: 2,
   },
+  {
+    createdAt: 3,
+    id: 'c2',
+    model: 'gpt-5.4-mini',
+    title: 'Втор разговор',
+    updatedAt: 4,
+  },
 ];
 
 const noop = vi.fn<() => void>;
@@ -33,5 +40,27 @@ describe('ConversationList accessibility', () => {
     const actions = within(item).getByTestId('row-actions');
 
     expect(actions).toHaveClass('sm:group-focus-within:opacity-100');
+  });
+
+  it('disables every title generation action while one title is generating', () => {
+    render(
+      <ConversationList
+        activeId={null}
+        conversations={conversations}
+        generatingTitleId="c1"
+        onDelete={noop()}
+        onGenerateTitle={noop()}
+        onRename={noop()}
+        onSelect={noop()}
+      />,
+    );
+
+    const buttons = screen.getAllByRole('button', { name: 'Генерирај име' });
+
+    expect(buttons).toHaveLength(2);
+
+    for (const button of buttons) {
+      expect(button).toBeDisabled();
+    }
   });
 });

--- a/web/test/db.test.ts
+++ b/web/test/db.test.ts
@@ -9,6 +9,7 @@ import {
   listConversations,
   loadMessages,
   renameConversation,
+  renameConversationIfTitle,
   saveMessages,
   setMessageFeedback,
 } from '@/lib/db';
@@ -73,6 +74,27 @@ describe('conversations', () => {
     expect(list[0]?.title).toBe('A2');
     expect(a.id).toBe('a');
     expect(b.id).toBe('b');
+  });
+
+  it('renames a conversation only when the current title still matches', async () => {
+    await createConversation({ id: 'guarded', model: 'm', title: 'Прашање?' });
+
+    const renamed = await renameConversationIfTitle(
+      'guarded',
+      'Прашање?',
+      'Испитен рок',
+    );
+    const skipped = await renameConversationIfTitle(
+      'guarded',
+      'Прашање?',
+      'Презапиши',
+    );
+
+    expect([renamed, skipped]).toStrictEqual([true, false]);
+
+    const list = await listConversations();
+
+    expect(list.find((c) => c.id === 'guarded')?.title).toBe('Испитен рок');
   });
 });
 

--- a/web/test/shell.test.tsx
+++ b/web/test/shell.test.tsx
@@ -226,6 +226,28 @@ describe('ConversationList', () => {
 
     expect(onRename).toHaveBeenCalledWith('c1', 'Ново име');
   });
+
+  it('generates a conversation title from the row actions', () => {
+    const onGenerateTitle = vi.fn<(id: string) => void>();
+
+    render(
+      <ConversationList
+        activeId={null}
+        conversations={rows}
+        onDelete={noop()}
+        onGenerateTitle={onGenerateTitle}
+        onRename={noop()}
+        onSelect={noop()}
+      />,
+    );
+
+    const item = screen.getByTestId('conversation-c1');
+    fireEvent.click(
+      within(item).getByRole('button', { name: 'Генерирај име' }),
+    );
+
+    expect(onGenerateTitle).toHaveBeenCalledWith('c1');
+  });
 });
 
 describe('Sidebar', () => {
@@ -416,6 +438,9 @@ const respondTo = (
   if (url.endsWith('/api/chat')) {
     return Promise.resolve(sseChatResponse(chat));
   }
+  if (url.endsWith('/api/chat/title')) {
+    return Promise.resolve(jsonOk({ title: 'Испитен рок' }));
+  }
 
   return Promise.resolve(jsonOk({}));
 };
@@ -514,6 +539,24 @@ describe('ChatPage persistence', () => {
     expect(roles).toContain('assistant');
     expect(msgs.find((m) => m.role === 'assistant')?.metadata?.responseId).toBe(
       RESPONSE_ID,
+    );
+  });
+
+  it('generates and persists a title after the first message is sent', async () => {
+    const user = userEvent.setup();
+
+    renderChatPage();
+
+    await user.type(screen.getByRole('textbox'), 'Кога е испитот?');
+    await user.keyboard('{Enter}');
+
+    await waitFor(
+      async () => {
+        const convos = await db.conversations.toArray();
+
+        expect(convos.at(0)?.title).toBe('Испитен рок');
+      },
+      { timeout: 5_000 },
     );
   });
 


### PR DESCRIPTION
## Summary
- add FastAPI and web BFF endpoints for chat title generation
- generate titles automatically after the first message and expose a sidebar manual action
- add guarded Dexie rename behavior so generated titles do not overwrite manual renames
- document sidebar action design patterns

## Verification
- npm run lint
- npm run check
- npm run test
- API_BASE_URL="http://localhost:8880" CHAT_API_KEY="build-time-placeholder" npm run build
- uv run pytest
- uv run ruff check .
- uv run mypy .
- git diff --check origin/main..HEAD
- Playwright live QA: seeded IndexedDB conversation, clicked Генерирај име, observed Испитен рок, one /api/chat/title request