### PR TITLE
fix(web): improve chat action focus states

### DIFF
--- a/web/components/chat/answer-actions.tsx
+++ b/web/components/chat/answer-actions.tsx
@@ -129,7 +129,7 @@ export const AnswerActions = ({
         className={cn(
           BTN,
           vote === 'like' &&
-            'bg-green-600/10 text-green-600 hover:bg-green-600/15 hover:text-green-600',
+            'bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground',
         )}
         data-testid="like-button"
         disabled={pending}
@@ -149,7 +149,7 @@ export const AnswerActions = ({
         className={cn(
           BTN,
           vote === 'dislike' &&
-            'bg-red-600/10 text-red-600 hover:bg-red-600/15 hover:text-red-600',
+            'bg-destructive text-destructive-foreground hover:bg-destructive/90 hover:text-destructive-foreground',
         )}
         data-testid="dislike-button"
         disabled={pending}

--- a/web/components/chat/message.tsx
+++ b/web/components/chat/message.tsx
@@ -243,7 +243,7 @@ const MessageTiming = ({
       <HoverCardTrigger asChild>
         <button
           aria-label={triggerLabel}
-          className={`${FOOTNOTE_CLASS} cursor-help hover:text-muted-foreground`}
+          className={`${FOOTNOTE_CLASS} cursor-help rounded-md hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`}
           data-testid="message-timing"
           type="button"
         >
@@ -282,7 +282,7 @@ const MessageError = ({
         <p className="text-destructive">{errorPart.message}</p>
         {onRetry ? (
           <button
-            className="self-start rounded-md border border-border px-3 py-1 text-sm hover:bg-muted"
+            className="self-start rounded-md border border-border px-3 py-1 text-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             onClick={onRetry}
             type="button"
           >

--- a/web/components/chat/reasoning-disclosure.tsx
+++ b/web/components/chat/reasoning-disclosure.tsx
@@ -29,7 +29,7 @@ export const ReasoningDisclosure = ({
       <button
         aria-controls={panelId}
         aria-expanded={open}
-        className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        className="inline-flex items-center gap-1 rounded-md text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         onClick={() => {
           setManualOpen(!open);
         }}

--- a/web/components/chat/source-cards.tsx
+++ b/web/components/chat/source-cards.tsx
@@ -89,7 +89,7 @@ const SourceCard = ({ source }: { source: RetrievedSource }) => {
             {links.map((link) => (
               <a
                 aria-label={`${t('sources.link')}: ${link.label}`}
-                className="rounded-md p-1 text-muted-foreground hover:bg-background hover:text-foreground"
+                className="rounded-md p-1 text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 href={link.url}
                 key={`${link.label}:${link.url}`}
                 rel="noreferrer"

--- a/web/test/answer-actions.test.tsx
+++ b/web/test/answer-actions.test.tsx
@@ -101,7 +101,7 @@ describe('AnswerActions feedback', () => {
     });
   });
 
-  it('paints the like button green once pressed', async () => {
+  it('marks the like button with selected action colors once pressed', async () => {
     render(<AnswerActions message={assistant('resp-9')} />);
     const like = screen.getByRole('button', { name: 'Допаѓа' });
     fireEvent.click(like);
@@ -110,7 +110,8 @@ describe('AnswerActions feedback', () => {
       expect(like).toHaveAttribute(PRESSED, 'true');
     });
 
-    expect(like.className).toContain('text-green-600');
+    expect(like.className).toContain('bg-primary');
+    expect(like.className).toContain('text-primary-foreground');
     expect(like.className).not.toContain('text-muted-foreground');
   });
 


### PR DESCRIPTION
## Summary
- use semantic theme tokens for selected chat feedback actions
- add visible focus rings to chat timing, retry, reasoning, and source-link controls
- update the feedback action test expectation for selected colors

## Verification
- npm run test -- answer-actions.test.tsx
- npm run check
- npm run lint
- browser sanity check on http://127.0.0.1:3310/