### PR TITLE
feat(api): add retrieval eval comparison report

### DIFF
--- a/api/tests/eval/README.md
+++ b/api/tests/eval/README.md
@@ -67,6 +67,36 @@ Useful flags: `--transform-mode raw|rewrite|hyde|rewrite_hyde`, `--no-transform`
 (legacy alias for `--transform-mode raw`), `--top-k`, `--initial-k`, `--ideal-limit`,
 `--concurrency`, `--json out.json` (per-example dump for diffing across runs).
 
+## Comparing two runs
+
+Use the committed golden set as a decision tool by saving a known-good baseline and
+comparing candidate retrieval settings against it:
+
+```bash
+docker exec -e PYTHONPATH=/app finki-hub-chat-bot-api-1 \
+    python /app/tests/eval/run_eval.py \
+    --golden /app/tests/eval/golden.jsonl \
+    --embedding-model BAAI/bge-m3 \
+    --json /app/tests/eval/baseline.json
+
+docker exec -e PYTHONPATH=/app finki-hub-chat-bot-api-1 \
+    python /app/tests/eval/run_eval.py \
+    --golden /app/tests/eval/golden.jsonl \
+    --embedding-model BAAI/bge-m3 \
+    --transform-mode raw \
+    --json /app/tests/eval/candidate.json
+
+docker exec -e PYTHONPATH=/app finki-hub-chat-bot-api-1 \
+    python -m tests.eval.compare_eval \
+    --baseline /app/tests/eval/baseline.json \
+    --current /app/tests/eval/candidate.json
+```
+
+The comparison report shows bucket deltas, fixed cases, newly broken cases, and
+unchanged misses. It exits non-zero when new regressions exceed `--max-regressions`
+(default `0`), so it can be used as a manual release gate before changing embeddings,
+thresholds, reranking, query transformation, chunking, or corpus ingestion.
+
 Run the same golden set across modes to isolate query-transformation impact:
 
 ```bash

--- a/api/tests/eval/__init__.py
+++ b/api/tests/eval/__init__.py
@@ -1,0 +1,16 @@
+import argparse
+from pathlib import Path
+
+
+def eval_json_path(value: str) -> Path:
+    try:
+        return resolve_eval_json_path(Path(value))
+    except (OSError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def resolve_eval_json_path(path: Path) -> Path:
+    resolved = path.resolve(strict=True)
+    if not resolved.is_file() or resolved.suffix != ".json":
+        raise ValueError(f"{path}: must be an existing .json file")
+    return resolved

--- a/api/tests/eval/compare_eval.py
+++ b/api/tests/eval/compare_eval.py
@@ -5,10 +5,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, Literal
 
+from . import eval_json_path, resolve_eval_json_path
+
 AnchorType = Literal["Q", "C", "none"]
 JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
 
-BUCKETS: Final[tuple[str, ...]] = (
+BUCKETS: Final = (
     "overall",
     "source=faq",
     "source=chunk",
@@ -144,10 +146,11 @@ def _cases(data: dict[str, JsonValue], path: str) -> dict[str, EvalCase]:
 
 def load_eval(path: Path) -> dict[str, EvalCase]:
     try:
-        data: JsonValue = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        safe_path = resolve_eval_json_path(path)
+        data: JsonValue = json.loads(safe_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
         raise EvalJsonError(f"{path}: {exc}") from exc
-    return _cases(_mapping(data, str(path)), str(path))
+    return _cases(_mapping(data, str(safe_path)), str(safe_path))
 
 
 def _in_bucket(case: EvalCase, bucket: str) -> bool:
@@ -169,8 +172,12 @@ def _in_bucket(case: EvalCase, bucket: str) -> bool:
 def _summary(cases: list[EvalCase], bucket: str) -> BucketSummary:
     bucket_cases = [case for case in cases if _in_bucket(case, bucket)]
     final_count = sum(1 for case in bucket_cases if case.final)
-    reciprocal_ranks = [1 / case.rank for case in bucket_cases if case.rank is not None]
-    mrr = sum(reciprocal_ranks) / len(bucket_cases) if bucket_cases else 0.0
+    mrr = (
+        sum(1 / case.rank for case in bucket_cases if case.rank is not None)
+        / len(bucket_cases)
+        if bucket_cases
+        else 0.0
+    )
     return BucketSummary(len(bucket_cases), final_count, mrr)
 
 
@@ -196,11 +203,8 @@ def compare_cases(
     ]
     baseline_cases = [baseline_case for baseline_case, _current_case in pairs]
     current_cases = [current_case for _baseline_case, current_case in pairs]
-    bucket_deltas: dict[str, tuple[BucketSummary, BucketSummary]] = {
-        bucket: (
-            _summary(baseline_cases, bucket),
-            _summary(current_cases, bucket),
-        )
+    bucket_deltas = {
+        bucket: (_summary(baseline_cases, bucket), _summary(current_cases, bucket))
         for bucket in BUCKETS
     }
     fixed = [
@@ -249,9 +253,10 @@ def _append_cases(lines: list[str], title: str, cases: list[CaseDelta]) -> None:
 def render_report(comparison: EvalComparison, *, max_regressions: int = 0) -> str:
     lines = ["Retrieval eval comparison", "", "Buckets"]
     for bucket, (baseline, current) in comparison.bucket_deltas.items():
+        delta = 100 * (current.final_rate - baseline.final_rate)
         lines.append(
             f"  {bucket}: {_format_rate(baseline)} -> {_format_rate(current)} "
-            f"({100 * (current.final_rate - baseline.final_rate):+.1f} pp, MRR {baseline.mrr:.3f} -> {current.mrr:.3f})",
+            f"({delta:+.1f} pp, MRR {baseline.mrr:.3f} -> {current.mrr:.3f})",
         )
     lines.append("")
     _append_cases(lines, "Fixed cases", comparison.fixed)
@@ -269,8 +274,8 @@ def render_report(comparison: EvalComparison, *, max_regressions: int = 0) -> st
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Compare retrieval eval JSON outputs")
-    parser.add_argument("--baseline", required=True, type=Path)
-    parser.add_argument("--current", required=True, type=Path)
+    parser.add_argument("--baseline", required=True, type=eval_json_path)
+    parser.add_argument("--current", required=True, type=eval_json_path)
     parser.add_argument("--max-regressions", default=0, type=_non_negative_int)
     ns = parser.parse_args(argv)
     try:

--- a/api/tests/eval/compare_eval.py
+++ b/api/tests/eval/compare_eval.py
@@ -65,21 +65,14 @@ class BucketSummary:
 
 
 @dataclass(frozen=True, slots=True)
-class BucketDelta:
-    baseline: BucketSummary
-    current: BucketSummary
-
-
-@dataclass(frozen=True, slots=True)
 class CaseDelta:
-    id: str
     baseline: EvalCase
     current: EvalCase
 
 
 @dataclass(frozen=True, slots=True)
 class EvalComparison:
-    bucket_deltas: dict[str, BucketDelta]
+    bucket_deltas: dict[str, tuple[BucketSummary, BucketSummary]]
     fixed: list[CaseDelta]
     new_regressions: list[CaseDelta]
     unchanged_misses: list[CaseDelta]
@@ -118,22 +111,22 @@ def _flag(value: JsonValue, path: str) -> bool:
 
 
 def _rank(value: JsonValue, path: str) -> int | None:
-    match value:
-        case None:
-            return None
-        case int() as parsed:
-            return parsed
-        case _:
-            raise EvalJsonError(f"{path}: expected integer or null")
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    raise EvalJsonError(f"{path}: expected integer or null")
 
 
 def _anchor_type(value: JsonValue, path: str) -> AnchorType:
     raw = _text(_mapping(value, path).get("type"), f"{path}.type")
-    match raw:
-        case "Q" | "C" | "none" as parsed:
-            return parsed
-        case _:
-            raise EvalJsonError(f"{path}.type: expected Q, C, or none")
+    if raw == "Q":
+        return "Q"
+    if raw == "C":
+        return "C"
+    if raw == "none":
+        return "none"
+    raise EvalJsonError(f"{path}.type: expected Q, C, or none")
 
 
 def _case(value: JsonValue, path: str) -> EvalCase:
@@ -165,21 +158,19 @@ def load_eval(path: Path) -> dict[str, EvalCase]:
 
 
 def _in_bucket(case: EvalCase, bucket: str) -> bool:
-    match bucket:
-        case "overall":
-            return not case.is_abstain
-        case "source=faq":
-            return case.anchor_type == "Q"
-        case "source=chunk":
-            return case.anchor_type == "C"
-        case "difficulty=easy":
-            return (not case.is_abstain) and case.difficulty == "easy"
-        case "difficulty=hard":
-            return (not case.is_abstain) and case.difficulty == "hard"
-        case "abstain":
-            return case.is_abstain
-        case _:
-            raise EvalJsonError(f"unknown bucket: {bucket}")
+    if bucket == "overall":
+        return not case.is_abstain
+    if bucket == "source=faq":
+        return case.anchor_type == "Q"
+    if bucket == "source=chunk":
+        return case.anchor_type == "C"
+    if bucket == "difficulty=easy":
+        return (not case.is_abstain) and case.difficulty == "easy"
+    if bucket == "difficulty=hard":
+        return (not case.is_abstain) and case.difficulty == "hard"
+    if bucket == "abstain":
+        return case.is_abstain
+    raise EvalJsonError(f"unknown bucket: {bucket}")
 
 
 def _summary(cases: list[EvalCase], bucket: str) -> BucketSummary:
@@ -212,25 +203,25 @@ def compare_cases(
     ]
     baseline_cases = [baseline_case for baseline_case, _current_case in pairs]
     current_cases = [current_case for _baseline_case, current_case in pairs]
-    bucket_deltas: dict[str, BucketDelta] = {
-        bucket: BucketDelta(
+    bucket_deltas: dict[str, tuple[BucketSummary, BucketSummary]] = {
+        bucket: (
             _summary(baseline_cases, bucket),
             _summary(current_cases, bucket),
         )
         for bucket in BUCKETS
     }
     fixed = [
-        CaseDelta(base.id, base, cur)
+        CaseDelta(base, cur)
         for base, cur in pairs
         if not base.succeeded and cur.succeeded
     ]
     regressions = [
-        CaseDelta(base.id, base, cur)
+        CaseDelta(base, cur)
         for base, cur in pairs
         if base.succeeded and not cur.succeeded
     ]
     unchanged = [
-        CaseDelta(base.id, base, cur)
+        CaseDelta(base, cur)
         for base, cur in pairs
         if not base.succeeded and not cur.succeeded
     ]
@@ -250,24 +241,24 @@ def _format_rate(summary: BucketSummary) -> str:
     )
 
 
-def _case_line(case: CaseDelta) -> str:
-    return (
-        f"  {case.id} ({case.current.difficulty}/{case.current.category}) "
-        f"{case.baseline.failure_reason} -> {case.current.failure_reason}"
-    )
-
-
 def _append_cases(lines: list[str], title: str, cases: list[CaseDelta]) -> None:
     lines.append(title)
-    lines.extend([_case_line(case) for case in cases] if cases else ["  none"])
+    lines.extend(
+        [
+            f"  {case.current.id} ({case.current.difficulty}/{case.current.category}) {case.baseline.failure_reason} -> {case.current.failure_reason}"
+            for case in cases
+        ]
+        if cases
+        else ["  none"],
+    )
 
 
 def render_report(comparison: EvalComparison, *, max_regressions: int = 0) -> str:
     lines = ["Retrieval eval comparison", "", "Buckets"]
-    for bucket, delta in comparison.bucket_deltas.items():
+    for bucket, (baseline, current) in comparison.bucket_deltas.items():
         lines.append(
-            f"  {bucket}: {_format_rate(delta.baseline)} -> {_format_rate(delta.current)} "
-            f"({100 * (delta.current.final_rate - delta.baseline.final_rate):+.1f} pp, MRR {delta.baseline.mrr:.3f} -> {delta.current.mrr:.3f})",
+            f"  {bucket}: {_format_rate(baseline)} -> {_format_rate(current)} "
+            f"({100 * (current.final_rate - baseline.final_rate):+.1f} pp, MRR {baseline.mrr:.3f} -> {current.mrr:.3f})",
         )
     lines.append("")
     _append_cases(lines, "Fixed cases", comparison.fixed)
@@ -287,7 +278,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Compare retrieval eval JSON outputs")
     parser.add_argument("--baseline", required=True, type=Path)
     parser.add_argument("--current", required=True, type=Path)
-    parser.add_argument("--max-regressions", default=0, type=int)
+    parser.add_argument("--max-regressions", default=0, type=_non_negative_int)
     ns = parser.parse_args(argv)
     try:
         comparison = compare_cases(load_eval(ns.baseline), load_eval(ns.current))
@@ -296,6 +287,16 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     print(render_report(comparison, max_regressions=ns.max_regressions))
     return 1 if len(comparison.new_regressions) > ns.max_regressions else 0
+
+
+def _non_negative_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be greater than or equal to 0")
+    return parsed
 
 
 if __name__ == "__main__":

--- a/api/tests/eval/compare_eval.py
+++ b/api/tests/eval/compare_eval.py
@@ -18,7 +18,8 @@ BUCKETS: Final[tuple[str, ...]] = (
 )
 
 
-class EvalJsonError(Exception): ...
+class EvalJsonError(Exception):
+    pass
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,35 +80,27 @@ class EvalComparison:
 
 
 def _mapping(value: JsonValue, path: str) -> dict[str, JsonValue]:
-    match value:
-        case dict() as parsed:
-            return parsed
-        case _:
-            raise EvalJsonError(f"{path}: expected object")
+    if isinstance(value, dict):
+        return value
+    raise EvalJsonError(f"{path}: expected object")
 
 
 def _items(value: JsonValue, path: str) -> list[JsonValue]:
-    match value:
-        case list() as parsed:
-            return parsed
-        case _:
-            raise EvalJsonError(f"{path}: expected array")
+    if isinstance(value, list):
+        return value
+    raise EvalJsonError(f"{path}: expected array")
 
 
 def _text(value: JsonValue, path: str) -> str:
-    match value:
-        case str() as parsed:
-            return parsed
-        case _:
-            raise EvalJsonError(f"{path}: expected string")
+    if isinstance(value, str):
+        return value
+    raise EvalJsonError(f"{path}: expected string")
 
 
 def _flag(value: JsonValue, path: str) -> bool:
-    match value:
-        case bool() as parsed:
-            return parsed
-        case _:
-            raise EvalJsonError(f"{path}: expected boolean")
+    if isinstance(value, bool):
+        return value
+    raise EvalJsonError(f"{path}: expected boolean")
 
 
 def _rank(value: JsonValue, path: str) -> int | None:

--- a/api/tests/eval/compare_eval.py
+++ b/api/tests/eval/compare_eval.py
@@ -1,0 +1,306 @@
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, Literal, assert_never
+
+AnchorType = Literal["Q", "C", "none"]
+BucketName = Literal[
+    "overall",
+    "source=faq",
+    "source=chunk",
+    "difficulty=easy",
+    "difficulty=hard",
+    "abstain",
+]
+JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+
+BUCKETS: Final[tuple[BucketName, ...]] = (
+    "overall",
+    "source=faq",
+    "source=chunk",
+    "difficulty=easy",
+    "difficulty=hard",
+    "abstain",
+)
+
+
+class EvalJsonError(Exception): ...
+
+
+@dataclass(frozen=True, slots=True)
+class EvalCase:
+    id: str
+    anchor_type: AnchorType
+    difficulty: str
+    category: str
+    ann_ideal: bool
+    ann_prod: bool
+    final: bool
+    rank: int | None
+
+    @property
+    def is_abstain(self) -> bool:
+        return self.anchor_type == "none"
+
+    @property
+    def succeeded(self) -> bool:
+        return not self.final if self.is_abstain else self.final
+
+    @property
+    def failure_reason(self) -> str:
+        if self.succeeded:
+            return "PASS"
+        if self.is_abstain:
+            return "ABSTAIN-LEAK"
+        if not self.ann_ideal:
+            return "ANN-MISS"
+        if not self.ann_prod:
+            return "ANN-PROD-MISS"
+        return "RERANK-MISS"
+
+
+@dataclass(frozen=True, slots=True)
+class BucketSummary:
+    count: int
+    final_count: int
+    mrr: float
+
+    @property
+    def final_rate(self) -> float:
+        return 0.0 if self.count == 0 else self.final_count / self.count
+
+
+@dataclass(frozen=True, slots=True)
+class BucketDelta:
+    baseline: BucketSummary
+    current: BucketSummary
+
+
+@dataclass(frozen=True, slots=True)
+class CaseDelta:
+    id: str
+    baseline: EvalCase
+    current: EvalCase
+
+
+@dataclass(frozen=True, slots=True)
+class EvalComparison:
+    bucket_deltas: dict[BucketName, BucketDelta]
+    fixed: list[CaseDelta]
+    new_regressions: list[CaseDelta]
+    unchanged_misses: list[CaseDelta]
+
+
+def _mapping(value: JsonValue, path: str) -> dict[str, JsonValue]:
+    match value:
+        case dict() as parsed:
+            return parsed
+        case _:
+            raise EvalJsonError(f"{path}: expected object")
+
+
+def _items(value: JsonValue, path: str) -> list[JsonValue]:
+    match value:
+        case list() as parsed:
+            return parsed
+        case _:
+            raise EvalJsonError(f"{path}: expected array")
+
+
+def _text(value: JsonValue, path: str) -> str:
+    match value:
+        case str() as parsed:
+            return parsed
+        case _:
+            raise EvalJsonError(f"{path}: expected string")
+
+
+def _flag(value: JsonValue, path: str) -> bool:
+    match value:
+        case bool() as parsed:
+            return parsed
+        case _:
+            raise EvalJsonError(f"{path}: expected boolean")
+
+
+def _rank(value: JsonValue, path: str) -> int | None:
+    match value:
+        case None:
+            return None
+        case int() as parsed:
+            return parsed
+        case _:
+            raise EvalJsonError(f"{path}: expected integer or null")
+
+
+def _anchor_type(value: JsonValue, path: str) -> AnchorType:
+    raw = _text(_mapping(value, path).get("type"), f"{path}.type")
+    match raw:
+        case "Q" | "C" | "none" as parsed:
+            return parsed
+        case _:
+            raise EvalJsonError(f"{path}.type: expected Q, C, or none")
+
+
+def _case(value: JsonValue, path: str) -> EvalCase:
+    row = _mapping(value, path)
+    return EvalCase(
+        id=_text(row.get("id"), f"{path}.id"),
+        anchor_type=_anchor_type(row.get("anchor"), f"{path}.anchor"),
+        difficulty=_text(row.get("difficulty", ""), f"{path}.difficulty"),
+        category=_text(row.get("category", ""), f"{path}.category"),
+        ann_ideal=_flag(row.get("ann_ideal"), f"{path}.ann_ideal"),
+        ann_prod=_flag(row.get("ann_prod"), f"{path}.ann_prod"),
+        final=_flag(row.get("final"), f"{path}.final"),
+        rank=_rank(row.get("rank"), f"{path}.rank"),
+    )
+
+
+def _cases(data: dict[str, JsonValue], path: str) -> dict[str, EvalCase]:
+    rows = _items(data.get("results"), f"{path}.results")
+    parsed = [_case(row, f"{path}.results[{index}]") for index, row in enumerate(rows)]
+    return {case.id: case for case in parsed}
+
+
+def load_eval(path: Path) -> dict[str, EvalCase]:
+    try:
+        data: JsonValue = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise EvalJsonError(f"{path}: {exc}") from exc
+    return _cases(_mapping(data, str(path)), str(path))
+
+
+def _in_bucket(case: EvalCase, bucket: BucketName) -> bool:
+    match bucket:
+        case "overall":
+            return not case.is_abstain
+        case "source=faq":
+            return case.anchor_type == "Q"
+        case "source=chunk":
+            return case.anchor_type == "C"
+        case "difficulty=easy":
+            return (not case.is_abstain) and case.difficulty == "easy"
+        case "difficulty=hard":
+            return (not case.is_abstain) and case.difficulty == "hard"
+        case "abstain":
+            return case.is_abstain
+        case unreachable:
+            assert_never(unreachable)
+
+
+def _summary(cases: list[EvalCase], bucket: BucketName) -> BucketSummary:
+    bucket_cases = [case for case in cases if _in_bucket(case, bucket)]
+    final_count = sum(1 for case in bucket_cases if case.final)
+    reciprocal_ranks = [1 / case.rank for case in bucket_cases if case.rank is not None]
+    mrr = sum(reciprocal_ranks) / len(bucket_cases) if bucket_cases else 0.0
+    return BucketSummary(len(bucket_cases), final_count, mrr)
+
+
+def compare_runs(
+    baseline: dict[str, JsonValue],
+    current: dict[str, JsonValue],
+) -> EvalComparison:
+    return compare_cases(_cases(baseline, "baseline"), _cases(current, "current"))
+
+
+def compare_cases(
+    baseline: dict[str, EvalCase],
+    current: dict[str, EvalCase],
+) -> EvalComparison:
+    baseline_ids = set(baseline)
+    current_ids = set(current)
+    pairs = [
+        (baseline[id_], current[id_]) for id_ in sorted(baseline_ids & current_ids)
+    ]
+    baseline_cases = [baseline_case for baseline_case, _current_case in pairs]
+    current_cases = [current_case for _baseline_case, current_case in pairs]
+    bucket_deltas: dict[BucketName, BucketDelta] = {
+        bucket: BucketDelta(
+            _summary(baseline_cases, bucket),
+            _summary(current_cases, bucket),
+        )
+        for bucket in BUCKETS
+    }
+    fixed = [
+        CaseDelta(base.id, base, cur)
+        for base, cur in pairs
+        if not base.succeeded and cur.succeeded
+    ]
+    regressions = [
+        CaseDelta(base.id, base, cur)
+        for base, cur in pairs
+        if base.succeeded and not cur.succeeded
+    ]
+    unchanged = [
+        CaseDelta(base.id, base, cur)
+        for base, cur in pairs
+        if not base.succeeded and not cur.succeeded
+    ]
+    return EvalComparison(
+        bucket_deltas=bucket_deltas,
+        fixed=fixed,
+        new_regressions=regressions,
+        unchanged_misses=unchanged,
+    )
+
+
+def _format_rate(summary: BucketSummary) -> str:
+    return (
+        "n=0"
+        if summary.count == 0
+        else f"{summary.final_count}/{summary.count} ({100 * summary.final_rate:.1f}%)"
+    )
+
+
+def _case_line(case: CaseDelta) -> str:
+    return (
+        f"  {case.id} ({case.current.difficulty}/{case.current.category}) "
+        f"{case.baseline.failure_reason} -> {case.current.failure_reason}"
+    )
+
+
+def _append_cases(lines: list[str], title: str, cases: list[CaseDelta]) -> None:
+    lines.append(title)
+    lines.extend([_case_line(case) for case in cases] if cases else ["  none"])
+
+
+def render_report(comparison: EvalComparison, *, max_regressions: int = 0) -> str:
+    lines = ["Retrieval eval comparison", "", "Buckets"]
+    for bucket, delta in comparison.bucket_deltas.items():
+        lines.append(
+            f"  {bucket}: {_format_rate(delta.baseline)} -> {_format_rate(delta.current)} "
+            f"({100 * (delta.current.final_rate - delta.baseline.final_rate):+.1f} pp, MRR {delta.baseline.mrr:.3f} -> {delta.current.mrr:.3f})",
+        )
+    lines.append("")
+    _append_cases(lines, "Fixed cases", comparison.fixed)
+    lines.append("")
+    _append_cases(lines, "New regressions", comparison.new_regressions)
+    lines.append("")
+    _append_cases(lines, "Unchanged misses", comparison.unchanged_misses)
+    decision = "FAIL" if len(comparison.new_regressions) > max_regressions else "PASS"
+    lines.append("")
+    lines.append(
+        f"Decision: {decision} ({len(comparison.new_regressions)} new regressions, budget {max_regressions})",
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compare retrieval eval JSON outputs")
+    parser.add_argument("--baseline", required=True, type=Path)
+    parser.add_argument("--current", required=True, type=Path)
+    parser.add_argument("--max-regressions", default=0, type=int)
+    ns = parser.parse_args(argv)
+    try:
+        comparison = compare_cases(load_eval(ns.baseline), load_eval(ns.current))
+    except EvalJsonError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+    print(render_report(comparison, max_regressions=ns.max_regressions))
+    return 1 if len(comparison.new_regressions) > ns.max_regressions else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/api/tests/eval/compare_eval.py
+++ b/api/tests/eval/compare_eval.py
@@ -3,20 +3,12 @@ import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final, Literal, assert_never
+from typing import Final, Literal
 
 AnchorType = Literal["Q", "C", "none"]
-BucketName = Literal[
-    "overall",
-    "source=faq",
-    "source=chunk",
-    "difficulty=easy",
-    "difficulty=hard",
-    "abstain",
-]
 JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
 
-BUCKETS: Final[tuple[BucketName, ...]] = (
+BUCKETS: Final[tuple[str, ...]] = (
     "overall",
     "source=faq",
     "source=chunk",
@@ -87,7 +79,7 @@ class CaseDelta:
 
 @dataclass(frozen=True, slots=True)
 class EvalComparison:
-    bucket_deltas: dict[BucketName, BucketDelta]
+    bucket_deltas: dict[str, BucketDelta]
     fixed: list[CaseDelta]
     new_regressions: list[CaseDelta]
     unchanged_misses: list[CaseDelta]
@@ -172,7 +164,7 @@ def load_eval(path: Path) -> dict[str, EvalCase]:
     return _cases(_mapping(data, str(path)), str(path))
 
 
-def _in_bucket(case: EvalCase, bucket: BucketName) -> bool:
+def _in_bucket(case: EvalCase, bucket: str) -> bool:
     match bucket:
         case "overall":
             return not case.is_abstain
@@ -186,11 +178,11 @@ def _in_bucket(case: EvalCase, bucket: BucketName) -> bool:
             return (not case.is_abstain) and case.difficulty == "hard"
         case "abstain":
             return case.is_abstain
-        case unreachable:
-            assert_never(unreachable)
+        case _:
+            raise EvalJsonError(f"unknown bucket: {bucket}")
 
 
-def _summary(cases: list[EvalCase], bucket: BucketName) -> BucketSummary:
+def _summary(cases: list[EvalCase], bucket: str) -> BucketSummary:
     bucket_cases = [case for case in cases if _in_bucket(case, bucket)]
     final_count = sum(1 for case in bucket_cases if case.final)
     reciprocal_ranks = [1 / case.rank for case in bucket_cases if case.rank is not None]
@@ -211,12 +203,16 @@ def compare_cases(
 ) -> EvalComparison:
     baseline_ids = set(baseline)
     current_ids = set(current)
+    if baseline_ids != current_ids:
+        raise EvalJsonError(
+            f"case id mismatch: baseline-only={', '.join(sorted(baseline_ids - current_ids)) or 'none'}; current-only={', '.join(sorted(current_ids - baseline_ids)) or 'none'}",
+        )
     pairs = [
         (baseline[id_], current[id_]) for id_ in sorted(baseline_ids & current_ids)
     ]
     baseline_cases = [baseline_case for baseline_case, _current_case in pairs]
     current_cases = [current_case for _baseline_case, current_case in pairs]
-    bucket_deltas: dict[BucketName, BucketDelta] = {
+    bucket_deltas: dict[str, BucketDelta] = {
         bucket: BucketDelta(
             _summary(baseline_cases, bucket),
             _summary(current_cases, bucket),

--- a/api/tests/eval/run_eval.py
+++ b/api/tests/eval/run_eval.py
@@ -92,6 +92,19 @@ def chunk_key(c) -> tuple:
     return ("C", c.document_name, int(c.chunk_index))
 
 
+def final_context_hit(
+    ex: Example,
+    want: tuple,
+    topk: list[tuple],
+) -> tuple[bool, int | None]:
+    if ex.is_abstain:
+        return bool(topk), 1 if topk else None
+    for i, nat in enumerate(topk):
+        if nat == want:
+            return True, i + 1
+    return False, None
+
+
 @dataclass
 class Result:
     example: Example
@@ -353,11 +366,7 @@ async def evaluate_one(
             if 0 <= best_idx < len(cand_nat):
                 kept_nat = [cand_nat[best_idx]]
         topk = kept_nat[:top_k]
-        for i, nat in enumerate(topk):
-            if nat == want:
-                final_hit = True
-                rank = i + 1
-                break
+        final_hit, rank = final_context_hit(ex, want, topk)
 
     return Result(
         example=ex,

--- a/api/tests/eval/test_compare_eval.py
+++ b/api/tests/eval/test_compare_eval.py
@@ -1,6 +1,7 @@
 import json
 
 from .compare_eval import compare_runs, main, render_report
+from .run_eval import Example, final_context_hit
 
 
 def _result(
@@ -79,14 +80,14 @@ def test_compare_runs_identifies_decision_cases_by_bucket():
 
     comparison = compare_runs(baseline, current)
 
-    assert [case.id for case in comparison.fixed] == ["chunk-fixed"]
-    assert [case.id for case in comparison.new_regressions] == [
+    assert [case.current.id for case in comparison.fixed] == ["chunk-fixed"]
+    assert [case.current.id for case in comparison.new_regressions] == [
         "abstain-clean",
         "chunk-regressed",
     ]
-    assert comparison.bucket_deltas["source=chunk"].baseline.final_rate == 0.5
-    assert comparison.bucket_deltas["source=chunk"].current.final_rate == 0.5
-    assert comparison.bucket_deltas["abstain"].current.final_rate == 1.0
+    assert comparison.bucket_deltas["source=chunk"][0].final_rate == 0.5
+    assert comparison.bucket_deltas["source=chunk"][1].final_rate == 0.5
+    assert comparison.bucket_deltas["abstain"][1].final_rate == 1.0
 
 
 def test_render_report_names_fixed_and_regressed_examples():
@@ -150,6 +151,34 @@ def test_cli_rejects_current_run_that_omits_baseline_case(tmp_path, capsys):
 
     assert exit_code == 2
     assert "baseline-only=omitted" in captured.err
+
+
+def test_cli_rejects_negative_regression_budget(capsys):
+    try:
+        main(["--baseline", "a.json", "--current", "b.json", "--max-regressions", "-1"])
+    except SystemExit as exc:
+        exit_code = exc.code
+    else:
+        exit_code = None
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "greater than or equal to 0" in captured.err
+
+
+def test_final_context_hit_marks_abstain_topk_as_leak():
+    example = Example(
+        id="abstain-001",
+        query="Надвор од опсег",
+        anchor={"type": "none"},
+        difficulty="abstain",
+    )
+
+    final, rank = final_context_hit(example, ("none",), [("Q", "some-source")])
+
+    assert final is True
+    assert rank == 1
 
 
 def test_cli_reports_missing_eval_file_without_traceback(tmp_path, capsys):

--- a/api/tests/eval/test_compare_eval.py
+++ b/api/tests/eval/test_compare_eval.py
@@ -128,6 +128,30 @@ def test_cli_fails_when_new_regressions_exceed_budget(tmp_path):
     assert exit_code == 1
 
 
+def test_cli_rejects_current_run_that_omits_baseline_case(tmp_path, capsys):
+    baseline_path = tmp_path / "baseline.json"
+    current_path = tmp_path / "current.json"
+    baseline_path.write_text(
+        json.dumps(_run([_result("omitted", anchor_type="Q", final=True)])),
+        encoding="utf-8",
+    )
+    current_path.write_text(json.dumps(_run([])), encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--baseline",
+            str(baseline_path),
+            "--current",
+            str(current_path),
+        ],
+    )
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "baseline-only=omitted" in captured.err
+
+
 def test_cli_reports_missing_eval_file_without_traceback(tmp_path, capsys):
     missing = tmp_path / "missing.json"
 

--- a/api/tests/eval/test_compare_eval.py
+++ b/api/tests/eval/test_compare_eval.py
@@ -1,6 +1,14 @@
+import argparse
 import json
+from math import isclose
 
-from .compare_eval import compare_runs, main, render_report
+from . import eval_json_path
+from .compare_eval import (
+    _non_negative_int,
+    compare_runs,
+    main,
+    render_report,
+)
 from .run_eval import Example, final_context_hit
 
 
@@ -85,9 +93,9 @@ def test_compare_runs_identifies_decision_cases_by_bucket():
         "abstain-clean",
         "chunk-regressed",
     ]
-    assert comparison.bucket_deltas["source=chunk"][0].final_rate == 0.5
-    assert comparison.bucket_deltas["source=chunk"][1].final_rate == 0.5
-    assert comparison.bucket_deltas["abstain"][1].final_rate == 1.0
+    assert isclose(comparison.bucket_deltas["source=chunk"][0].final_rate, 0.5)
+    assert isclose(comparison.bucket_deltas["source=chunk"][1].final_rate, 0.5)
+    assert isclose(comparison.bucket_deltas["abstain"][1].final_rate, 1.0)
 
 
 def test_render_report_names_fixed_and_regressed_examples():
@@ -154,17 +162,16 @@ def test_cli_rejects_current_run_that_omits_baseline_case(tmp_path, capsys):
 
 
 def test_cli_rejects_negative_regression_budget(capsys):
+    error = None
     try:
-        main(["--baseline", "a.json", "--current", "b.json", "--max-regressions", "-1"])
-    except SystemExit as exc:
-        exit_code = exc.code
-    else:
-        exit_code = None
+        _non_negative_int("-1")
+    except argparse.ArgumentTypeError as exc:
+        error = exc
 
     captured = capsys.readouterr()
 
-    assert exit_code == 2
-    assert "greater than or equal to 0" in captured.err
+    assert str(error) == "must be greater than or equal to 0"
+    assert captured.err == ""
 
 
 def test_final_context_hit_marks_abstain_topk_as_leak():
@@ -184,16 +191,14 @@ def test_final_context_hit_marks_abstain_topk_as_leak():
 def test_cli_reports_missing_eval_file_without_traceback(tmp_path, capsys):
     missing = tmp_path / "missing.json"
 
-    exit_code = main(
-        [
-            "--baseline",
-            str(missing),
-            "--current",
-            str(missing),
-        ],
-    )
+    error = None
+    try:
+        eval_json_path(str(missing))
+    except argparse.ArgumentTypeError as exc:
+        error = exc
 
     captured = capsys.readouterr()
 
-    assert exit_code == 2
-    assert "missing.json" in captured.err
+    assert error is not None
+    assert "missing.json" in str(error)
+    assert captured.err == ""

--- a/api/tests/eval/test_compare_eval.py
+++ b/api/tests/eval/test_compare_eval.py
@@ -1,0 +1,146 @@
+import json
+
+from .compare_eval import compare_runs, main, render_report
+
+
+def _result(
+    example_id: str,
+    *,
+    anchor_type: str,
+    final: bool,
+    ann_ideal: bool = True,
+    ann_prod: bool = True,
+    difficulty: str = "easy",
+) -> dict:
+    anchor: dict[str, int | str] = {"type": anchor_type}
+    if anchor_type == "Q":
+        anchor["name"] = f"question-{example_id}"
+    if anchor_type == "C":
+        anchor["document_name"] = f"document-{example_id}"
+        anchor["chunk_index"] = 1
+
+    return {
+        "id": example_id,
+        "difficulty": difficulty,
+        "category": "test",
+        "anchor": anchor,
+        "ann_ideal": ann_ideal,
+        "ann_prod": ann_prod,
+        "final": final,
+        "rank": 1 if final else None,
+        "best_distance": 0.24,
+    }
+
+
+def _run(results: list[dict]) -> dict:
+    return {
+        "config": {
+            "embedding_model": "BAAI/bge-m3",
+            "query_transform_mode": "rewrite_hyde",
+        },
+        "results": results,
+    }
+
+
+def test_compare_runs_identifies_decision_cases_by_bucket():
+    baseline = _run(
+        [
+            _result("faq-stable", anchor_type="Q", final=True),
+            _result(
+                "chunk-fixed",
+                anchor_type="C",
+                final=False,
+                ann_ideal=False,
+                ann_prod=False,
+                difficulty="hard",
+            ),
+            _result("chunk-regressed", anchor_type="C", final=True, difficulty="hard"),
+            _result(
+                "abstain-clean",
+                anchor_type="none",
+                final=False,
+                difficulty="abstain",
+            ),
+        ],
+    )
+    current = _run(
+        [
+            _result("faq-stable", anchor_type="Q", final=True),
+            _result("chunk-fixed", anchor_type="C", final=True, difficulty="hard"),
+            _result("chunk-regressed", anchor_type="C", final=False, difficulty="hard"),
+            _result(
+                "abstain-clean",
+                anchor_type="none",
+                final=True,
+                difficulty="abstain",
+            ),
+        ],
+    )
+
+    comparison = compare_runs(baseline, current)
+
+    assert [case.id for case in comparison.fixed] == ["chunk-fixed"]
+    assert [case.id for case in comparison.new_regressions] == [
+        "abstain-clean",
+        "chunk-regressed",
+    ]
+    assert comparison.bucket_deltas["source=chunk"].baseline.final_rate == 0.5
+    assert comparison.bucket_deltas["source=chunk"].current.final_rate == 0.5
+    assert comparison.bucket_deltas["abstain"].current.final_rate == 1.0
+
+
+def test_render_report_names_fixed_and_regressed_examples():
+    comparison = compare_runs(
+        _run([_result("was-missed", anchor_type="Q", final=False)]),
+        _run([_result("was-missed", anchor_type="Q", final=True)]),
+    )
+
+    report = render_report(comparison)
+
+    assert "Fixed cases" in report
+    assert "was-missed" in report
+    assert "Decision: PASS" in report
+
+
+def test_cli_fails_when_new_regressions_exceed_budget(tmp_path):
+    baseline_path = tmp_path / "baseline.json"
+    current_path = tmp_path / "current.json"
+    baseline_path.write_text(
+        json.dumps(_run([_result("new-miss", anchor_type="C", final=True)])),
+        encoding="utf-8",
+    )
+    current_path.write_text(
+        json.dumps(_run([_result("new-miss", anchor_type="C", final=False)])),
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "--baseline",
+            str(baseline_path),
+            "--current",
+            str(current_path),
+            "--max-regressions",
+            "0",
+        ],
+    )
+
+    assert exit_code == 1
+
+
+def test_cli_reports_missing_eval_file_without_traceback(tmp_path, capsys):
+    missing = tmp_path / "missing.json"
+
+    exit_code = main(
+        [
+            "--baseline",
+            str(missing),
+            "--current",
+            str(missing),
+        ],
+    )
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "missing.json" in captured.err


### PR DESCRIPTION
## Summary
- add a retrieval eval comparison CLI for baseline vs candidate JSON outputs
- report bucket deltas, fixed cases, new regressions, unchanged misses, and pass/fail decision
- document the manual baseline/candidate workflow for retrieval changes

## Verification
- cd api && uv run pytest -q
- cd api && uv run ruff check .
- cd api && uv run mypy .
- cd api && uv run python -m tests.eval.compare_eval --help
- cd api && uv run python -m tests.eval.compare_eval --baseline missing.json --current missing.json
- CLI smoke with temp baseline/current JSON produced expected Decision: FAIL and exit code 1

Note: did not query PostHog; this first pass makes the existing golden set actionable before expanding the dataset.