### PR TITLE
fix(chat): gate auth and delete server state

### DIFF
--- a/.github/workflows/e2e-web.yaml
+++ b/.github/workflows/e2e-web.yaml
@@ -22,4 +22,5 @@ jobs:
         AUTH_SECRET=test-auth-secret
         AUTH_URL=http://localhost:3000
         CHAT_API_KEY=test-key
+        PLAYWRIGHT_AUTH_BYPASS=1
         RESUMABLE_STREAM_REDIS_URL=redis://localhost:6379

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,8 +7,8 @@ The chat UI is an operational product surface: fast, quiet, and readable for stu
 ## 2. Tokens
 
 - Color uses the existing Tailwind semantic tokens: `background`, `foreground`, `muted`, `muted-foreground`, `border`, `card`, `primary`, `destructive`, and `ring`.
-- Spacing follows the existing 4px Tailwind scale. Sidebar row controls use `gap-1`, `px-2.5`, `py-1.5`, and icon padding `p-1`.
-- Radius follows existing rounded surfaces: `rounded-md` for icon controls, `rounded-lg` for sidebar rows, and `rounded-xl` for larger sidebar buttons.
+- Spacing follows the existing 4px Tailwind scale. Sidebar row controls use `gap-1`, `px-2.5`, `py-1.5`, and icon padding `p-1`. Auth cards use `p-6` on mobile and `p-8` on wider screens.
+- Radius follows existing rounded surfaces: `rounded-md` for icon controls, `rounded-lg` for sidebar rows, `rounded-xl` for larger sidebar buttons, `rounded-2xl` for auth CTAs, and `rounded-3xl` for the auth panel.
 
 ## 3. Typography
 
@@ -25,6 +25,7 @@ The chat UI is an operational product surface: fast, quiet, and readable for stu
 - Sidebar conversation row: selectable title button plus compact row-action icon buttons that reveal on hover/focus for desktop and stay visible on mobile.
 - Row action button: Lucide icon, `size-3.5`, semantic aria label, focus-visible ring, muted default color, stronger hover color matching the action intent.
 - Destructive row action: use destructive hover color only for delete.
+- Auth sign-in panel: card surface using `card`, `border`, `background`, `primary`, and `muted-foreground` tokens, with provider buttons that visibly change border/background on hover and use `focus-visible:ring-ring`.
 
 ## 6. Accessibility
 

--- a/api/app/api/chat_state.py
+++ b/api/app/api/chat_state.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
+from app.data.chat_conversation_delete import delete_conversation
 from app.data.chat_persistence import (
     ChatMessageConflictError,
     ChatPersistenceDatabase,
@@ -113,6 +114,26 @@ async def load_conversation_state(
     if loaded is None:
         raise _not_found()
     return loaded
+
+
+@router.delete(
+    "/conversations/{conversation_id}",
+    status_code=status.HTTP_200_OK,
+    operation_id="deleteChatStateConversation",
+)
+async def delete_conversation_state(
+    conversation_id: UUID,
+    user_id: UserIdQuery,
+    db: ChatPersistenceDatabase = db_dep,
+) -> ChatConversation:
+    deleted = await delete_conversation(
+        db,
+        conversation_id=conversation_id,
+        user_id=user_id,
+    )
+    if deleted is None:
+        raise _not_found()
+    return deleted
 
 
 @router.post(

--- a/api/app/data/chat_conversation_delete.py
+++ b/api/app/data/chat_conversation_delete.py
@@ -1,0 +1,23 @@
+from uuid import UUID
+
+from app.data.chat_persistence import ChatPersistenceDatabase
+from app.data.chat_rows import conversation_from_row
+from app.schemas.chat_persistence import ChatConversation
+
+
+async def delete_conversation(
+    db: ChatPersistenceDatabase,
+    *,
+    conversation_id: UUID,
+    user_id: UUID,
+) -> ChatConversation | None:
+    row = await db.fetchrow(
+        """
+        DELETE FROM chat_conversation
+        WHERE id = $1 AND user_id = $2
+        RETURNING *
+        """,
+        conversation_id,
+        user_id,
+    )
+    return None if row is None else conversation_from_row(row)

--- a/api/tests/chat_persistence_fake.py
+++ b/api/tests/chat_persistence_fake.py
@@ -179,6 +179,21 @@ class FakeChatDatabase:
             conversation_id, user_id = args
             return self._owned_conversation(conversation_id, user_id)
 
+        if "DELETE FROM chat_conversation" in query:
+            conversation_id, user_id = args
+            current = self._owned_conversation(conversation_id, user_id)
+            if current is None:
+                return None
+            deleted = self.conversations.pop(conversation_id)
+            stale_message_ids = [
+                message_id
+                for message_id, message in self.messages.items()
+                if message["conversation_id"] == conversation_id
+            ]
+            for message_id in stale_message_ids:
+                del self.messages[message_id]
+            return deleted
+
         if "ON CONFLICT (conversation_id, response_id)" in query:
             conversation_id, response_id, message_id, content, metadata_json = args
             for existing in self.messages.values():

--- a/api/tests/test_chat_state_api.py
+++ b/api/tests/test_chat_state_api.py
@@ -193,6 +193,67 @@ def test_chat_state_wrong_user_cannot_load_or_mutate_state() -> None:
     assert all(row["content"] != "steal" for row in db.messages.values())
 
 
+def test_chat_state_delete_removes_owned_conversation_and_messages() -> None:
+    # Given: an authenticated owner has persisted conversation state.
+    db = FakeChatDatabase()
+    client = _client(db)
+    conversation_id = uuid4()
+    message_id = uuid4()
+    client.post(
+        "/chat/state/conversations",
+        headers=_auth_headers(),
+        json={"id": str(conversation_id), "user_id": OWNER_ID},
+    )
+    client.post(
+        f"/chat/state/conversations/{conversation_id}/messages/user",
+        headers=_auth_headers(),
+        json={"content": "delete me", "id": str(message_id), "user_id": OWNER_ID},
+    )
+
+    # When: the owner deletes the conversation through the state API.
+    deleted = client.delete(
+        f"/chat/state/conversations/{conversation_id}",
+        headers=_auth_headers(),
+        params={"user_id": OWNER_ID},
+    )
+    loaded = client.get(
+        f"/chat/state/conversations/{conversation_id}",
+        headers=_auth_headers(),
+        params={"user_id": OWNER_ID},
+    )
+
+    # Then: the conversation and its messages are no longer visible.
+    assert deleted.status_code == 200
+    assert deleted.json()["id"] == str(conversation_id)
+    assert loaded.status_code == 404
+    assert conversation_id not in db.conversations
+    assert message_id not in db.messages
+
+
+def test_chat_state_wrong_user_cannot_delete_conversation() -> None:
+    # Given: a conversation owned by one user.
+    db = FakeChatDatabase()
+    client = _client(db)
+    conversation_id = uuid4()
+    create_response = client.post(
+        "/chat/state/conversations",
+        headers=_auth_headers(),
+        json={"id": str(conversation_id), "user_id": OWNER_ID},
+    )
+
+    # When: another user attempts to delete it.
+    deleted = client.delete(
+        f"/chat/state/conversations/{conversation_id}",
+        headers=_auth_headers(),
+        params={"user_id": INTRUDER_ID},
+    )
+
+    # Then: ownership failures look like missing state and the row remains.
+    assert create_response.status_code == 200
+    assert deleted.status_code == 404
+    assert conversation_id in db.conversations
+
+
 def test_chat_state_message_id_collision_is_not_cross_tenant_write() -> None:
     # Given: a victim conversation already has a user message id.
     db = FakeChatDatabase()

--- a/web/app/api/chat/[id]/route.ts
+++ b/web/app/api/chat/[id]/route.ts
@@ -1,0 +1,39 @@
+import {
+  AuthenticationRequiredError,
+  getAuthenticatedChatUserId,
+} from '@/lib/authenticated-chat-user';
+import {
+  ChatStateRequestError,
+  createChatStateClient,
+} from '@/lib/chat-state-client';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  readonly params: Promise<{ readonly id: string }>;
+};
+
+export const DELETE = async (
+  _request: Request,
+  { params }: RouteContext,
+): Promise<Response> => {
+  const { id: conversationId } = await params;
+  const chatState = createChatStateClient();
+
+  try {
+    const userId = await getAuthenticatedChatUserId();
+    await chatState.deleteConversation({ conversationId, userId });
+
+    return new Response(null, { status: 204 });
+  } catch (error) {
+    if (error instanceof AuthenticationRequiredError) {
+      return new Response(null, { status: 401 });
+    }
+    if (error instanceof ChatStateRequestError) {
+      return new Response(null, { status: error.status });
+    }
+
+    throw error;
+  }
+};

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,9 +1,13 @@
 import { redirect } from 'next/navigation';
 
-import { auth, isAuthConfigured } from '@/auth';
+import { auth, isAuthConfigured, isPlaywrightAuthBypassEnabled } from '@/auth';
 import { ChatScreen } from '@/components/chat/chat-screen';
 
 const HomePage = async () => {
+  if (isPlaywrightAuthBypassEnabled()) {
+    return <ChatScreen />;
+  }
+
   const session = isAuthConfigured() ? await auth() : null;
 
   if (session === null) {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,137 +1,16 @@
-'use client';
+import { redirect } from 'next/navigation';
 
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { auth, isAuthConfigured } from '@/auth';
+import { ChatScreen } from '@/components/chat/chat-screen';
 
-import { Composer } from '@/components/chat/composer';
-import { ServiceBanner } from '@/components/chat/service-banner';
-import { Thread } from '@/components/chat/thread';
-import { Header } from '@/components/shell/header';
-import { Sidebar } from '@/components/shell/sidebar';
-import { isReasoningCapableModel } from '@/lib/reasoning';
-import { useUiStore } from '@/lib/ui-store';
-import { useConversations } from '@/lib/use-conversations';
-import { useHealth } from '@/lib/use-health';
-import { useModels } from '@/lib/use-models';
+const HomePage = async () => {
+  const session = isAuthConfigured() ? await auth() : null;
 
-const DESKTOP_SIDEBAR_QUERY = '(min-width: 768px)';
-const useIsomorphicLayoutEffect =
-  typeof window === 'undefined' ? useEffect : useLayoutEffect;
+  if (session === null) {
+    redirect('/signin?callbackUrl=/');
+  }
 
-const noop = () => {};
-
-const subscribeToMediaQuery = (
-  media: MediaQueryList,
-  onChange: (event: MediaQueryListEvent) => void,
-) => {
-  media.addEventListener('change', onChange);
-
-  return () => {
-    media.removeEventListener('change', onChange);
-  };
+  return <ChatScreen />;
 };
 
-const ChatScreen = () => {
-  const model = useUiStore((s) => s.model);
-  const setModel = useUiStore((s) => s.setModel);
-  const reasoning = useUiStore((s) => s.reasoning);
-  const setReasoning = useUiStore((s) => s.setReasoning);
-  const sidebarOpen = useUiStore((s) => s.sidebarOpen);
-  const reasoningActive = reasoning && isReasoningCapableModel(model);
-  const toggleSidebar = useUiStore((s) => s.toggleSidebar);
-  const setSidebarOpen = useUiStore((s) => s.setSidebarOpen);
-  const [sidebarSynced, setSidebarSynced] = useState(false);
-
-  const { unavailable } = useHealth();
-
-  useIsomorphicLayoutEffect(() => {
-    if (typeof matchMedia !== 'function') {
-      return noop;
-    }
-
-    const media = matchMedia(DESKTOP_SIDEBAR_QUERY);
-    const syncSidebarWithViewport = (event: MediaQueryListEvent) => {
-      setSidebarOpen(event.matches);
-    };
-
-    setSidebarOpen(media.matches);
-    setSidebarSynced(true);
-
-    return subscribeToMediaQuery(media, syncSidebarWithViewport);
-  }, [setSidebarOpen]);
-
-  const {
-    data: modelList,
-    isError: modelsError,
-    isLoading: modelsLoading,
-  } = useModels();
-  const {
-    activeError,
-    activeId,
-    activeStatus,
-    conversations,
-    generatingTitleId,
-    messages,
-    onClearAll,
-    onDelete,
-    onGenerateTitle,
-    onNewChat,
-    onRename,
-    onSelect,
-    onStop,
-    renderActions,
-    retry,
-    status,
-    submitMessage,
-  } = useConversations(model, unavailable, reasoningActive);
-
-  return (
-    <div className="flex h-dvh w-full flex-col">
-      <Header onToggleSidebar={toggleSidebar} />
-      {unavailable ? <ServiceBanner /> : null}
-      <div className="flex min-h-0 flex-1">
-        <Sidebar
-          activeId={activeId}
-          conversations={conversations}
-          generatingTitleId={generatingTitleId}
-          onClearAll={onClearAll}
-          onClose={() => {
-            setSidebarOpen(false);
-          }}
-          onDelete={onDelete}
-          onGenerateTitle={onGenerateTitle}
-          onNewChat={onNewChat}
-          onRename={onRename}
-          onSelect={onSelect}
-          open={sidebarOpen}
-          synced={sidebarSynced}
-        />
-        <main className="flex min-w-0 flex-1 flex-col">
-          <Thread
-            activeError={activeError}
-            activeStatus={activeStatus}
-            messages={messages}
-            onPickSuggestion={unavailable ? undefined : submitMessage}
-            onRetry={unavailable ? undefined : retry}
-            renderActions={renderActions}
-            status={status}
-          />
-          <Composer
-            disabled={unavailable}
-            model={model}
-            models={modelList ?? []}
-            modelsError={modelsError}
-            modelsLoading={modelsLoading}
-            onModelChange={setModel}
-            onReasoningChange={setReasoning}
-            onStop={onStop}
-            onSubmit={submitMessage}
-            reasoning={reasoningActive}
-            status={status}
-          />
-        </main>
-      </div>
-    </div>
-  );
-};
-
-export default ChatScreen;
+export default HomePage;

--- a/web/app/signin/page.tsx
+++ b/web/app/signin/page.tsx
@@ -3,6 +3,7 @@ import { AuthError } from 'next-auth';
 import { redirect } from 'next/navigation';
 
 import { auth, isAuthConfigured, providerMap, signIn } from '@/auth';
+import { getSafeCallbackUrl } from '@/lib/callback-url';
 
 type SignInPageProps = {
   readonly searchParams: Promise<{
@@ -10,8 +11,6 @@ type SignInPageProps = {
     readonly error?: string;
   }>;
 };
-
-const fallbackCallbackUrl = '/';
 
 const featureItems = [
   'Историјата е врзана со твојата најава, не со уредот.',
@@ -24,9 +23,10 @@ const SignInPage = async ({ searchParams }: SignInPageProps) => {
     searchParams,
     isAuthConfigured() ? auth() : null,
   ]);
+  const safeCallbackUrl = getSafeCallbackUrl(callbackUrl);
 
   if (session !== null) {
-    redirect(callbackUrl ?? fallbackCallbackUrl);
+    redirect(safeCallbackUrl);
   }
 
   return (
@@ -104,7 +104,7 @@ const SignInPage = async ({ searchParams }: SignInPageProps) => {
 
                     try {
                       await signIn(provider.id, {
-                        redirectTo: callbackUrl ?? fallbackCallbackUrl,
+                        redirectTo: safeCallbackUrl,
                       });
                     } catch (signInError) {
                       if (signInError instanceof AuthError) {

--- a/web/app/signin/page.tsx
+++ b/web/app/signin/page.tsx
@@ -1,0 +1,138 @@
+import { ArrowRight, Bot, GraduationCap, ShieldCheck } from 'lucide-react';
+import { AuthError } from 'next-auth';
+import { redirect } from 'next/navigation';
+
+import { auth, isAuthConfigured, providerMap, signIn } from '@/auth';
+
+type SignInPageProps = {
+  readonly searchParams: Promise<{
+    readonly callbackUrl?: string;
+    readonly error?: string;
+  }>;
+};
+
+const fallbackCallbackUrl = '/';
+
+const featureItems = [
+  'Историјата е врзана со твојата најава, не со уредот.',
+  'Разговорите се чуваат безбедно за да можеш да продолжиш подоцна.',
+  'ФИНКИ Хаб асистентот останува фокусиран на студиски прашања.',
+] as const;
+
+const SignInPage = async ({ searchParams }: SignInPageProps) => {
+  const [{ callbackUrl, error }, session] = await Promise.all([
+    searchParams,
+    isAuthConfigured() ? auth() : null,
+  ]);
+
+  if (session !== null) {
+    redirect(callbackUrl ?? fallbackCallbackUrl);
+  }
+
+  return (
+    <main className="relative min-h-dvh overflow-hidden bg-background text-foreground">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,hsl(var(--primary)/0.24),transparent_34rem),linear-gradient(135deg,hsl(var(--background)),hsl(var(--muted)/0.72))]" />
+      <div className="mx-auto grid min-h-dvh w-full max-w-6xl gap-10 px-6 py-10 md:grid-cols-[1.05fr_0.95fr] md:items-center lg:px-8">
+        <section className="space-y-8">
+          <div className="inline-flex items-center gap-2 rounded-full border border-border bg-card/80 px-3 py-1.5 text-sm text-muted-foreground shadow-sm backdrop-blur">
+            <GraduationCap
+              aria-hidden="true"
+              className="h-4 w-4 text-primary"
+            />
+            ФИНКИ Хаб / Чат
+          </div>
+
+          <div className="max-w-2xl space-y-5">
+            <h1 className="text-balance text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+              Најави се за да разговараш со{' '}
+              <span className="whitespace-nowrap">ФИНКИ Хаб</span> асистентот.
+            </h1>
+            <p className="max-w-xl text-pretty text-lg leading-8 text-muted-foreground">
+              Чатот е достапен само за најавени корисници за да ја зачува
+              твојата историја и да спречи неовластена употреба.
+            </p>
+          </div>
+
+          <div className="grid gap-3 text-sm text-muted-foreground">
+            {featureItems.map((item) => (
+              <div
+                className="flex items-start gap-3"
+                key={item}
+              >
+                <ShieldCheck
+                  aria-hidden="true"
+                  className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+                />
+                <span>{item}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-3xl border border-border bg-card/86 p-6 shadow-2xl shadow-primary/10 backdrop-blur md:p-8">
+          <div className="mb-8 flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-lg shadow-primary/25">
+              <Bot
+                aria-hidden="true"
+                className="h-6 w-6"
+              />
+            </div>
+            <div>
+              <h2 className="text-xl font-semibold">Продолжи со најава</h2>
+              <p className="text-sm text-muted-foreground">
+                Избери еден од достапните провајдери.
+              </p>
+            </div>
+          </div>
+
+          {error === undefined ? null : (
+            <p className="mb-4 rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              Најавата не успеа. Обиди се повторно.
+            </p>
+          )}
+
+          {providerMap.length === 0 ? (
+            <p className="rounded-xl border border-border bg-muted/60 px-4 py-3 text-sm text-muted-foreground">
+              Најавата не е конфигурирана на овој сервер.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {providerMap.map((provider) => (
+                <form
+                  action={async () => {
+                    'use server';
+
+                    try {
+                      await signIn(provider.id, {
+                        redirectTo: callbackUrl ?? fallbackCallbackUrl,
+                      });
+                    } catch (signInError) {
+                      if (signInError instanceof AuthError) {
+                        redirect('/signin?error=OAuthSignin');
+                      }
+                      throw signInError;
+                    }
+                  }}
+                  key={provider.id}
+                >
+                  <button
+                    className="group flex w-full items-center justify-between rounded-2xl border border-border bg-background px-4 py-3 text-left text-sm font-medium transition hover:border-primary/60 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    type="submit"
+                  >
+                    <span>Најави се со {provider.name}</span>
+                    <ArrowRight
+                      aria-hidden="true"
+                      className="h-4 w-4 text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-primary"
+                    />
+                  </button>
+                </form>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+};
+
+export default SignInPage;

--- a/web/auth.ts
+++ b/web/auth.ts
@@ -6,6 +6,10 @@ import MicrosoftEntraID from 'next-auth/providers/microsoft-entra-id';
 
 const authEnv = (name: string): string => process.env[name] ?? '';
 
+export const isPlaywrightAuthBypassEnabled = (): boolean =>
+  process.env.NODE_ENV !== 'production' &&
+  authEnv('PLAYWRIGHT_AUTH_BYPASS') === '1';
+
 const isGoogleConfigured = (): boolean =>
   authEnv('AUTH_GOOGLE_ID').length > 0 &&
   authEnv('AUTH_GOOGLE_SECRET').length > 0;
@@ -50,9 +54,11 @@ const authProviderDefinitions: readonly AuthProviderDefinition[] = [
   },
 ];
 
-export const providerMap = authProviderDefinitions
-  .filter((provider) => provider.enabled())
-  .map(({ id, name }) => ({ id, name }));
+export const providerMap = isAuthConfigured()
+  ? authProviderDefinitions
+      .filter((provider) => provider.enabled())
+      .map(({ id, name }) => ({ id, name }))
+  : [];
 
 const authProviders = authProviderDefinitions
   .filter((provider) => provider.enabled())

--- a/web/auth.ts
+++ b/web/auth.ts
@@ -1,3 +1,5 @@
+import type { Provider } from 'next-auth/providers';
+
 import NextAuth from 'next-auth';
 import Google from 'next-auth/providers/google';
 import MicrosoftEntraID from 'next-auth/providers/microsoft-entra-id';
@@ -17,25 +19,44 @@ export const isAuthConfigured = (): boolean =>
   (isGoogleConfigured() || isMicrosoftConfigured()) &&
   authEnv('AUTH_SECRET').length > 0;
 
-const authProviders = [
-  ...(isGoogleConfigured()
-    ? [
-        Google({
-          clientId: authEnv('AUTH_GOOGLE_ID'),
-          clientSecret: authEnv('AUTH_GOOGLE_SECRET'),
-        }),
-      ]
-    : []),
-  ...(isMicrosoftConfigured()
-    ? [
-        MicrosoftEntraID({
-          clientId: authEnv('AUTH_MICROSOFT_ENTRA_ID_ID'),
-          clientSecret: authEnv('AUTH_MICROSOFT_ENTRA_ID_SECRET'),
-          issuer: authEnv('AUTH_MICROSOFT_ENTRA_ID_ISSUER'),
-        }),
-      ]
-    : []),
+type AuthProviderDefinition = {
+  readonly create: () => Provider;
+  readonly enabled: () => boolean;
+  readonly id: string;
+  readonly name: string;
+};
+
+const authProviderDefinitions: readonly AuthProviderDefinition[] = [
+  {
+    create: () =>
+      Google({
+        clientId: authEnv('AUTH_GOOGLE_ID'),
+        clientSecret: authEnv('AUTH_GOOGLE_SECRET'),
+      }),
+    enabled: isGoogleConfigured,
+    id: 'google',
+    name: 'Google',
+  },
+  {
+    create: () =>
+      MicrosoftEntraID({
+        clientId: authEnv('AUTH_MICROSOFT_ENTRA_ID_ID'),
+        clientSecret: authEnv('AUTH_MICROSOFT_ENTRA_ID_SECRET'),
+        issuer: authEnv('AUTH_MICROSOFT_ENTRA_ID_ISSUER'),
+      }),
+    enabled: isMicrosoftConfigured,
+    id: 'microsoft-entra-id',
+    name: 'Microsoft Entra ID',
+  },
 ];
+
+export const providerMap = authProviderDefinitions
+  .filter((provider) => provider.enabled())
+  .map(({ id, name }) => ({ id, name }));
+
+const authProviders = authProviderDefinitions
+  .filter((provider) => provider.enabled())
+  .map((provider) => provider.create());
 
 export const { auth, handlers, signIn, signOut } = NextAuth({
   callbacks: {
@@ -57,6 +78,7 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
       return session;
     },
   },
+  pages: { signIn: '/signin' },
   providers: authProviders,
   secret: authEnv('AUTH_SECRET'),
   session: { maxAge: 30 * 24 * 60 * 60, strategy: 'jwt' },

--- a/web/components/chat/chat-screen.tsx
+++ b/web/components/chat/chat-screen.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect, useLayoutEffect, useState } from 'react';
+
+import { Composer } from '@/components/chat/composer';
+import { ServiceBanner } from '@/components/chat/service-banner';
+import { Thread } from '@/components/chat/thread';
+import { Header } from '@/components/shell/header';
+import { Sidebar } from '@/components/shell/sidebar';
+import { isReasoningCapableModel } from '@/lib/reasoning';
+import { useUiStore } from '@/lib/ui-store';
+import { useConversations } from '@/lib/use-conversations';
+import { useHealth } from '@/lib/use-health';
+import { useModels } from '@/lib/use-models';
+
+const DESKTOP_SIDEBAR_QUERY = '(min-width: 768px)';
+const useIsomorphicLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+const noop = () => {};
+
+const subscribeToMediaQuery = (
+  media: MediaQueryList,
+  onChange: (event: MediaQueryListEvent) => void,
+) => {
+  media.addEventListener('change', onChange);
+
+  return () => {
+    media.removeEventListener('change', onChange);
+  };
+};
+
+export const ChatScreen = () => {
+  const model = useUiStore((s) => s.model);
+  const setModel = useUiStore((s) => s.setModel);
+  const reasoning = useUiStore((s) => s.reasoning);
+  const setReasoning = useUiStore((s) => s.setReasoning);
+  const sidebarOpen = useUiStore((s) => s.sidebarOpen);
+  const reasoningActive = reasoning && isReasoningCapableModel(model);
+  const toggleSidebar = useUiStore((s) => s.toggleSidebar);
+  const setSidebarOpen = useUiStore((s) => s.setSidebarOpen);
+  const [sidebarSynced, setSidebarSynced] = useState(false);
+
+  const { unavailable } = useHealth();
+
+  useIsomorphicLayoutEffect(() => {
+    if (typeof matchMedia !== 'function') {
+      return noop;
+    }
+
+    const media = matchMedia(DESKTOP_SIDEBAR_QUERY);
+    const syncSidebarWithViewport = (event: MediaQueryListEvent) => {
+      setSidebarOpen(event.matches);
+    };
+
+    setSidebarOpen(media.matches);
+    setSidebarSynced(true);
+
+    return subscribeToMediaQuery(media, syncSidebarWithViewport);
+  }, [setSidebarOpen]);
+
+  const {
+    data: modelList,
+    isError: modelsError,
+    isLoading: modelsLoading,
+  } = useModels();
+  const {
+    activeError,
+    activeId,
+    activeStatus,
+    conversations,
+    generatingTitleId,
+    messages,
+    onClearAll,
+    onDelete,
+    onGenerateTitle,
+    onNewChat,
+    onRename,
+    onSelect,
+    onStop,
+    renderActions,
+    retry,
+    status,
+    submitMessage,
+  } = useConversations(model, unavailable, reasoningActive);
+
+  return (
+    <div className="flex h-dvh w-full flex-col">
+      <Header onToggleSidebar={toggleSidebar} />
+      {unavailable ? <ServiceBanner /> : null}
+      <div className="flex min-h-0 flex-1">
+        <Sidebar
+          activeId={activeId}
+          conversations={conversations}
+          generatingTitleId={generatingTitleId}
+          onClearAll={onClearAll}
+          onClose={() => {
+            setSidebarOpen(false);
+          }}
+          onDelete={onDelete}
+          onGenerateTitle={onGenerateTitle}
+          onNewChat={onNewChat}
+          onRename={onRename}
+          onSelect={onSelect}
+          open={sidebarOpen}
+          synced={sidebarSynced}
+        />
+        <main className="flex min-w-0 flex-1 flex-col">
+          <Thread
+            activeError={activeError}
+            activeStatus={activeStatus}
+            messages={messages}
+            onPickSuggestion={unavailable ? undefined : submitMessage}
+            onRetry={unavailable ? undefined : retry}
+            renderActions={renderActions}
+            status={status}
+          />
+          <Composer
+            disabled={unavailable}
+            model={model}
+            models={modelList ?? []}
+            modelsError={modelsError}
+            modelsLoading={modelsLoading}
+            onModelChange={setModel}
+            onReasoningChange={setReasoning}
+            onStop={onStop}
+            onSubmit={submitMessage}
+            reasoning={reasoningActive}
+            status={status}
+          />
+        </main>
+      </div>
+    </div>
+  );
+};

--- a/web/lib/callback-url.ts
+++ b/web/lib/callback-url.ts
@@ -1,0 +1,14 @@
+const fallbackCallbackUrl = '/';
+
+export const getSafeCallbackUrl = (callbackUrl: string | undefined): string => {
+  if (callbackUrl === undefined) {
+    return fallbackCallbackUrl;
+  }
+
+  const isSameOriginRelative =
+    callbackUrl.startsWith('/') &&
+    !callbackUrl.startsWith('//') &&
+    !callbackUrl.startsWith('/\\');
+
+  return isSameOriginRelative ? callbackUrl : fallbackCallbackUrl;
+};

--- a/web/lib/chat-state-client.ts
+++ b/web/lib/chat-state-client.ts
@@ -8,6 +8,7 @@ export type ChatStateClient = {
   readonly clearActiveStreamIfCurrent: (
     input: ClearActiveStreamInput,
   ) => Promise<void>;
+  readonly deleteConversation: (input: LoadConversationInput) => Promise<void>;
   readonly loadConversation: (
     input: LoadConversationInput,
   ) => Promise<ChatStateConversationWithMessages>;
@@ -175,6 +176,12 @@ export const createChatStateClient = (): ChatStateClient => ({
   clearActiveStreamIfCurrent: async ({ conversationId, streamId, userId }) => {
     await sendStateRequest(
       `/conversations/${conversationId}/active-stream/${streamId}?user_id=${encodeURIComponent(userId)}`,
+      { method: 'DELETE' },
+    );
+  },
+  deleteConversation: async ({ conversationId, userId }) => {
+    await sendStateRequest(
+      `/conversations/${conversationId}?user_id=${encodeURIComponent(userId)}`,
       { method: 'DELETE' },
     );
   },

--- a/web/lib/transport.ts
+++ b/web/lib/transport.ts
@@ -39,6 +39,16 @@ export const buildChatTransport = (
     }),
   });
 
+export class DeleteChatConversationError extends Error {
+  readonly status: number;
+
+  constructor(status: number, options?: ErrorOptions) {
+    super('Delete chat conversation failed', options);
+    this.name = 'DeleteChatConversationError';
+    this.status = status;
+  }
+}
+
 export class StopChatStreamError extends Error {
   readonly status: number;
 
@@ -48,6 +58,21 @@ export class StopChatStreamError extends Error {
     this.status = status;
   }
 }
+
+export const deleteChatConversation = async (
+  conversationId: string,
+): Promise<void> => {
+  const response = await fetch(
+    `/api/chat/${encodeURIComponent(conversationId)}`,
+    {
+      method: 'DELETE',
+    },
+  );
+
+  if (!response.ok) {
+    throw new DeleteChatConversationError(response.status);
+  }
+};
 
 export const stopChatStream = async (
   conversationId: string,

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -20,7 +20,10 @@ import {
   setMessageFeedback,
 } from '@/lib/db';
 import { deriveTitle } from '@/lib/messages';
-import { deleteChatConversation } from '@/lib/transport';
+import {
+  deleteChatConversation,
+  DeleteChatConversationError,
+} from '@/lib/transport';
 import { useUiStore } from '@/lib/ui-store';
 import { useConversationChatRuntime } from '@/lib/use-conversation-chat-runtime';
 import { useConversationList } from '@/lib/use-conversation-list';
@@ -154,7 +157,16 @@ export const useConversations = (
 
   const handleDelete = useCallback(
     async (id: string) => {
-      await deleteChatConversation(id);
+      try {
+        await deleteChatConversation(id);
+      } catch (error) {
+        const serverConversationAlreadyDeleted =
+          error instanceof DeleteChatConversationError && error.status === 404;
+
+        if (!serverConversationAlreadyDeleted) {
+          throw error;
+        }
+      }
       await deleteConversation(id);
       if (convoIdRef.current === id) {
         handleNewChat();

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -145,11 +145,13 @@ export const useConversations = (
         fireAndForget(
           (async () => {
             await handleStop('local-first');
+            convoIdRef.current = id;
             setActiveId(id);
           })(),
         );
         return;
       }
+      convoIdRef.current = id;
       setActiveId(id);
     },
     [convoIdRef, handleStop, setActiveId, status],
@@ -173,11 +175,10 @@ export const useConversations = (
         }
       }
       await deleteConversation(id);
-      if (deletingActiveConversation) {
+      if (deletingActiveConversation && convoIdRef.current === id) {
         setActiveId(null);
         setMessages([]);
         setActiveError(undefined);
-        // eslint-disable-next-line require-atomic-updates -- the active id is intentionally cleared after the delete succeeds
         convoIdRef.current = null;
       }
       await refreshConversations();

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -155,8 +155,13 @@ export const useConversations = (
     [convoIdRef, handleStop, setActiveId, status],
   );
 
-  const handleDelete = useCallback(
+  const deleteConversationEverywhere = useCallback(
     async (id: string) => {
+      const deletingActiveConversation = convoIdRef.current === id;
+      if (deletingActiveConversation && status !== 'ready') {
+        await handleStop();
+      }
+
       try {
         await deleteChatConversation(id);
       } catch (error) {
@@ -168,12 +173,31 @@ export const useConversations = (
         }
       }
       await deleteConversation(id);
-      if (convoIdRef.current === id) {
-        handleNewChat();
+      if (deletingActiveConversation) {
+        setActiveId(null);
+        setMessages([]);
+        setActiveError(undefined);
+        // eslint-disable-next-line require-atomic-updates -- the active id is intentionally cleared after the delete succeeds
+        convoIdRef.current = null;
       }
       await refreshConversations();
     },
-    [convoIdRef, handleNewChat, refreshConversations],
+    [
+      convoIdRef,
+      handleStop,
+      refreshConversations,
+      setActiveError,
+      setActiveId,
+      setMessages,
+      status,
+    ],
+  );
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      fireAndForget(deleteConversationEverywhere(id));
+    },
+    [deleteConversationEverywhere],
   );
 
   const handleClearAll = useCallback(async () => {

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -20,6 +20,7 @@ import {
   setMessageFeedback,
 } from '@/lib/db';
 import { deriveTitle } from '@/lib/messages';
+import { deleteChatConversation } from '@/lib/transport';
 import { useUiStore } from '@/lib/ui-store';
 import { useConversationChatRuntime } from '@/lib/use-conversation-chat-runtime';
 import { useConversationList } from '@/lib/use-conversation-list';
@@ -153,6 +154,7 @@ export const useConversations = (
 
   const handleDelete = useCallback(
     async (id: string) => {
+      await deleteChatConversation(id);
       await deleteConversation(id);
       if (convoIdRef.current === id) {
         handleNewChat();

--- a/web/test/api-chat-route-support.ts
+++ b/web/test/api-chat-route-support.ts
@@ -107,6 +107,7 @@ export const routeMocks = {
   },
   stateClient: {
     clearActiveStreamIfCurrent: vi.fn(async (_input: StateClientInput) => {}),
+    deleteConversation: vi.fn(async (_input: StateClientInput) => {}),
     loadConversation: vi.fn(
       async (_input: StateClientInput): Promise<LoadedConversation> => ({
         conversation: {

--- a/web/test/app-page.test.tsx
+++ b/web/test/app-page.test.tsx
@@ -1,0 +1,40 @@
+import { isValidElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+const { authMock, redirectMock } = vi.hoisted(() => ({
+  authMock: vi.fn<() => Promise<unknown>>(),
+  redirectMock: vi.fn<(url: string) => never>((url) => {
+    throw new Error(`redirect:${url}`);
+  }),
+}));
+
+vi.mock('@/auth', () => ({
+  auth: authMock,
+  isAuthConfigured: () => true,
+}));
+
+vi.mock('@/components/chat/chat-screen', () => ({
+  ChatScreen: () => 'chat-screen',
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+describe('HomePage auth gate', () => {
+  it('redirects unauthenticated users to the custom sign-in page', async () => {
+    authMock.mockResolvedValueOnce(null);
+    const { default: HomePage } = await import('@/app/page');
+
+    await expect(HomePage()).rejects.toThrow('redirect:/signin?callbackUrl=/');
+    expect(redirectMock).toHaveBeenCalledWith('/signin?callbackUrl=/');
+  });
+
+  it('renders the chat screen for authenticated users', async () => {
+    authMock.mockResolvedValueOnce({ user: { email: 'student@example.com' } });
+    const { default: HomePage } = await import('@/app/page');
+    const result = await HomePage();
+
+    expect(isValidElement(result)).toBe(true);
+  });
+});

--- a/web/test/app-page.test.tsx
+++ b/web/test/app-page.test.tsx
@@ -1,16 +1,19 @@
 import { isValidElement } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { authMock, redirectMock } = vi.hoisted(() => ({
-  authMock: vi.fn<() => Promise<unknown>>(),
-  redirectMock: vi.fn<(url: string) => never>((url) => {
-    throw new Error(`redirect:${url}`);
-  }),
-}));
+const { authMock, isPlaywrightAuthBypassEnabledMock, redirectMock } =
+  vi.hoisted(() => ({
+    authMock: vi.fn<() => Promise<unknown>>(),
+    isPlaywrightAuthBypassEnabledMock: vi.fn<() => boolean>(() => false),
+    redirectMock: vi.fn<(url: string) => never>((url) => {
+      throw new Error(`redirect:${url}`);
+    }),
+  }));
 
 vi.mock('@/auth', () => ({
   auth: authMock,
   isAuthConfigured: () => true,
+  isPlaywrightAuthBypassEnabled: isPlaywrightAuthBypassEnabledMock,
 }));
 
 vi.mock('@/components/chat/chat-screen', () => ({
@@ -22,6 +25,13 @@ vi.mock('next/navigation', () => ({
 }));
 
 describe('HomePage auth gate', () => {
+  beforeEach(() => {
+    authMock.mockReset();
+    isPlaywrightAuthBypassEnabledMock.mockReset();
+    isPlaywrightAuthBypassEnabledMock.mockReturnValue(false);
+    redirectMock.mockClear();
+  });
+
   it('redirects unauthenticated users to the custom sign-in page', async () => {
     authMock.mockResolvedValueOnce(null);
     const { default: HomePage } = await import('@/app/page');
@@ -36,5 +46,14 @@ describe('HomePage auth gate', () => {
     const result = await HomePage();
 
     expect(isValidElement(result)).toBe(true);
+  });
+
+  it('renders the chat screen when the Playwright auth bypass is enabled', async () => {
+    isPlaywrightAuthBypassEnabledMock.mockReturnValue(true);
+    const { default: HomePage } = await import('@/app/page');
+    const result = await HomePage();
+
+    expect(isValidElement(result)).toBe(true);
+    expect(authMock).not.toHaveBeenCalled();
   });
 });

--- a/web/test/auth-route.test.ts
+++ b/web/test/auth-route.test.ts
@@ -50,6 +50,7 @@ describe('Auth.js route handler', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     process.env = { ...ORIGINAL };
   });
 
@@ -86,5 +87,25 @@ describe('Auth.js route handler', () => {
     const { isAuthConfigured } = await import('@/auth');
 
     expect(isAuthConfigured()).toBe(false);
+  });
+
+  it('hides sign-in providers when the Auth.js secret is missing', async () => {
+    process.env['AUTH_SECRET'] = '';
+
+    const { providerMap } = await import('@/auth');
+
+    expect(providerMap).toStrictEqual([]);
+  });
+
+  it('allows the Playwright auth bypass outside production only', async () => {
+    process.env['PLAYWRIGHT_AUTH_BYPASS'] = '1';
+    vi.stubEnv('NODE_ENV', 'test');
+    const { isPlaywrightAuthBypassEnabled } = await import('@/auth');
+
+    expect(isPlaywrightAuthBypassEnabled()).toBe(true);
+
+    vi.stubEnv('NODE_ENV', 'production');
+
+    expect(isPlaywrightAuthBypassEnabled()).toBe(false);
   });
 });

--- a/web/test/callback-url.test.ts
+++ b/web/test/callback-url.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSafeCallbackUrl } from '@/lib/callback-url';
+
+describe('getSafeCallbackUrl', () => {
+  it('keeps same-origin relative callback URLs', () => {
+    expect(getSafeCallbackUrl('/chat/abc?source=signin')).toBe(
+      '/chat/abc?source=signin',
+    );
+  });
+
+  it('falls back for missing callback URLs', () => {
+    expect(getSafeCallbackUrl(undefined)).toBe('/');
+  });
+
+  it('falls back for absolute external callback URLs', () => {
+    expect(getSafeCallbackUrl('https://evil.example/phish')).toBe('/');
+  });
+
+  it('falls back for protocol-relative callback URLs', () => {
+    expect(getSafeCallbackUrl('//evil.example/phish')).toBe('/');
+  });
+});

--- a/web/test/chat-delete.route.test.ts
+++ b/web/test/chat-delete.route.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CONVERSATION_ID,
+  installRouteMocks,
+  resetRouteMocks,
+  routeMocks,
+  USER_ID,
+} from './api-chat-route-support';
+
+const importDelete = async (): Promise<
+  (
+    req: Request,
+    ctx: { readonly params: Promise<{ readonly id: string }> },
+  ) => Promise<Response>
+> => {
+  const { DELETE } = await import('@/app/api/chat/[id]/route');
+
+  return DELETE;
+};
+
+const deleteRequest = (): Request =>
+  new Request(`http://localhost/api/chat/${CONVERSATION_ID}`, {
+    method: 'DELETE',
+  });
+
+const routeContext = () => ({
+  params: Promise.resolve({ id: CONVERSATION_ID }),
+});
+
+describe('DELETE /api/chat/[id]', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetRouteMocks();
+    installRouteMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('deletes persisted conversation state for the authenticated owner', async () => {
+    const res = await (await importDelete())(deleteRequest(), routeContext());
+
+    expect(res.status).toBe(204);
+    expect(routeMocks.stateClient.deleteConversation).toHaveBeenCalledWith({
+      conversationId: CONVERSATION_ID,
+      userId: USER_ID,
+    });
+  });
+
+  it('returns 401 when there is no authenticated session', async () => {
+    const { AuthenticationRequiredError } =
+      await import('@/lib/authenticated-chat-user');
+    routeMocks.getAuthenticatedChatUserId.mockRejectedValueOnce(
+      new AuthenticationRequiredError(),
+    );
+
+    const res = await (await importDelete())(deleteRequest(), routeContext());
+
+    expect(res.status).toBe(401);
+    expect(routeMocks.stateClient.deleteConversation).not.toHaveBeenCalled();
+  });
+
+  it('preserves upstream ownership failures', async () => {
+    const { ChatStateRequestError } = await import('@/lib/chat-state-client');
+    routeMocks.stateClient.deleteConversation.mockRejectedValueOnce(
+      new ChatStateRequestError(404),
+    );
+
+    const res = await (await importDelete())(deleteRequest(), routeContext());
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/web/test/chat-state-client.test.ts
+++ b/web/test/chat-state-client.test.ts
@@ -55,4 +55,27 @@ describe('createChatStateClient', () => {
     );
     expect(user.id).toBe('00000000-0000-4000-8000-000000000001');
   });
+
+  it('deletes a user-owned conversation with the server API key', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { createChatStateClient } = await import('@/lib/chat-state-client');
+    await createChatStateClient().deleteConversation({
+      conversationId: 'conv-delete',
+      userId: '00000000-0000-4000-8000-000000000001',
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe(
+      'https://api:8880/chat/state/conversations/conv-delete?user_id=00000000-0000-4000-8000-000000000001',
+    );
+    expect(init.method).toBe('DELETE');
+    expect(new Headers(init.headers).get('x-api-key')).toBe('test-key');
+  });
 });

--- a/web/test/shell.test.tsx
+++ b/web/test/shell.test.tsx
@@ -20,7 +20,7 @@ import {
   vi,
 } from 'vitest';
 
-import ChatPage from '@/app/page';
+import { ChatScreen } from '@/components/chat/chat-screen';
 import { ConversationList } from '@/components/shell/conversation-list';
 import { Sidebar } from '@/components/shell/sidebar';
 import { type ConversationRow, db } from '@/lib/db';
@@ -467,7 +467,7 @@ const renderChatPage = (): ReturnType<typeof rtlRender> => {
   return rtlRender(
     <SessionProvider>
       <QueryClientProvider client={queryClient}>
-        <ChatPage />
+        <ChatScreen />
       </QueryClientProvider>
     </SessionProvider>,
   );

--- a/web/test/transport.test.ts
+++ b/web/test/transport.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { MyUIMessage } from '@/lib/api-types';
 
@@ -19,6 +19,10 @@ vi.mock('posthog-js', () => ({
     get_session_id: () => 'session-test-id',
   },
 }));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 const SUBMIT = 'submit-message' as const;
 const ACTIVE_STREAM_ID = '018f0f36-2b1d-7cc0-a50b-5f2d90c91d22';

--- a/web/test/transport.test.ts
+++ b/web/test/transport.test.ts
@@ -5,6 +5,8 @@ import type { MyUIMessage } from '@/lib/api-types';
 import {
   buildChatTransport,
   type ChatExtras,
+  deleteChatConversation,
+  DeleteChatConversationError,
   stopChatStream,
   StopChatStreamError,
 } from '@/lib/transport';
@@ -171,6 +173,35 @@ describe('buildChatTransport', () => {
     );
     await expect(stopChatStream('conv-7')).rejects.toMatchObject({
       status: 500,
+    });
+  });
+
+  it('calls the conversation delete endpoint without client ownership headers', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await deleteChatConversation('conv-7');
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/chat/conv-7', {
+      method: 'DELETE',
+    });
+  });
+
+  it('throws when the conversation delete endpoint rejects the request', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(null, { status: 403 })),
+    );
+
+    await expect(deleteChatConversation('conv-7')).rejects.toBeInstanceOf(
+      DeleteChatConversationError,
+    );
+    await expect(deleteChatConversation('conv-7')).rejects.toMatchObject({
+      status: 403,
     });
   });
 });

--- a/web/test/use-conversations.test.tsx
+++ b/web/test/use-conversations.test.tsx
@@ -223,13 +223,55 @@ describe('useConversations resumable streaming', () => {
     });
     const { result } = renderHook(() => useConversations('model-a'));
 
-    await act(async () => {
-      await result.current.onDelete('conv-delete');
+    act(() => {
+      result.current.onDelete('conv-delete');
+    });
+
+    await waitFor(() => {
+      expect(deleteConversation).toHaveBeenCalledWith('conv-delete');
     });
 
     expect(deleteChatConversation).toHaveBeenCalledWith('conv-delete');
-    expect(deleteConversation).toHaveBeenCalledWith('conv-delete');
     expect(calls).toStrictEqual(['server', 'local']);
+  });
+
+  it('stops the active stream before deleting the active conversation', async () => {
+    const { deleteConversation } = await import('@/lib/db');
+    const activeConversationId = 'conv-active';
+    useUiStore.setState({ activeConversationId });
+    chatState.status = 'streaming';
+    const calls: string[] = [];
+    stopChatStream.mockImplementation(() => {
+      calls.push('stop-server');
+      return Promise.resolve();
+    });
+    localStop.mockImplementation(() => {
+      calls.push('stop-local');
+    });
+    deleteChatConversation.mockImplementation(() => {
+      calls.push('delete-server');
+      return Promise.resolve();
+    });
+    vi.mocked(deleteConversation).mockImplementation(() => {
+      calls.push('delete-local');
+      return Promise.resolve();
+    });
+    const { result } = renderHook(() => useConversations('model-a'));
+
+    act(() => {
+      result.current.onDelete(activeConversationId);
+    });
+
+    await waitFor(() => {
+      expect(deleteConversation).toHaveBeenCalledWith(activeConversationId);
+    });
+
+    expect(calls).toStrictEqual([
+      'stop-local',
+      'stop-server',
+      'delete-server',
+      'delete-local',
+    ]);
   });
 
   it('removes the local conversation when the server conversation is already gone', async () => {
@@ -239,10 +281,12 @@ describe('useConversations resumable streaming', () => {
     );
     const { result } = renderHook(() => useConversations('model-a'));
 
-    await act(async () => {
-      await result.current.onDelete('conv-local-only');
+    act(() => {
+      result.current.onDelete('conv-local-only');
     });
 
-    expect(deleteConversation).toHaveBeenCalledWith('conv-local-only');
+    await waitFor(() => {
+      expect(deleteConversation).toHaveBeenCalledWith('conv-local-only');
+    });
   });
 });

--- a/web/test/use-conversations.test.tsx
+++ b/web/test/use-conversations.test.tsx
@@ -14,6 +14,7 @@ type UseChatOptions = {
 const chatState = { status: 'ready' };
 
 const localStop = vi.fn<() => Promise<void> | void>();
+const deleteChatConversation = vi.fn<(id: string) => Promise<void>>();
 const stopChatStream =
   vi.fn<(id: string, snapshot?: unknown) => Promise<void>>();
 const chatMessages: MyUIMessage[] = [];
@@ -42,6 +43,7 @@ vi.mock('@/lib/transport', () => ({
   buildChatTransport: vi.fn<() => { readonly kind: 'transport' }>(() => ({
     kind: 'transport',
   })),
+  deleteChatConversation: (id: string) => deleteChatConversation(id),
   stopChatStream: (id: string, snapshot?: unknown) =>
     stopChatStream(id, snapshot),
 }));
@@ -75,6 +77,8 @@ vi.mock('@/lib/db', () => ({
 
 describe('useConversations resumable streaming', () => {
   beforeEach(() => {
+    deleteChatConversation.mockReset();
+    deleteChatConversation.mockResolvedValue();
     localStop.mockClear();
     chatMessages.length = 0;
     stopChatStream.mockReset();
@@ -191,5 +195,27 @@ describe('useConversations resumable streaming', () => {
         activeStreamId: '018f0f36-2b1d-7cc0-a50b-5f2d90c91d22',
       });
     });
+  });
+
+  it('deletes server state before removing the local conversation', async () => {
+    const { deleteConversation } = await import('@/lib/db');
+    const calls: string[] = [];
+    deleteChatConversation.mockImplementation(() => {
+      calls.push('server');
+      return Promise.resolve();
+    });
+    vi.mocked(deleteConversation).mockImplementation(() => {
+      calls.push('local');
+      return Promise.resolve();
+    });
+    const { result } = renderHook(() => useConversations('model-a'));
+
+    await act(async () => {
+      await result.current.onDelete('conv-delete');
+    });
+
+    expect(deleteChatConversation).toHaveBeenCalledWith('conv-delete');
+    expect(deleteConversation).toHaveBeenCalledWith('conv-delete');
+    expect(calls).toStrictEqual(['server', 'local']);
   });
 });

--- a/web/test/use-conversations.test.tsx
+++ b/web/test/use-conversations.test.tsx
@@ -274,6 +274,47 @@ describe('useConversations resumable streaming', () => {
     ]);
   });
 
+  it('keeps a newly selected conversation when active delete finishes later', async () => {
+    const { deleteConversation } = await import('@/lib/db');
+    const activeConversationId = 'conv-active';
+    useUiStore.setState({ activeConversationId });
+    let resolveServerDelete: (() => void) | undefined;
+    const serverDeleteReleased = new Promise<void>((resolve) => {
+      resolveServerDelete = resolve;
+    });
+    deleteChatConversation.mockImplementation(async () => {
+      await serverDeleteReleased;
+    });
+    const { result } = renderHook(() => useConversations('model-a'));
+
+    act(() => {
+      result.current.onDelete(activeConversationId);
+    });
+
+    await waitFor(() => {
+      expect(deleteChatConversation).toHaveBeenCalledWith(activeConversationId);
+    });
+
+    act(() => {
+      result.current.onSelect('conv-next');
+    });
+
+    await waitFor(() => {
+      expect(useUiStore.getState().activeConversationId).toBe('conv-next');
+    });
+
+    if (resolveServerDelete === undefined) {
+      throw new Error('Server delete resolver was not captured');
+    }
+    resolveServerDelete();
+
+    await waitFor(() => {
+      expect(deleteConversation).toHaveBeenCalledWith(activeConversationId);
+    });
+
+    expect(useUiStore.getState().activeConversationId).toBe('conv-next');
+  });
+
   it('removes the local conversation when the server conversation is already gone', async () => {
     const { deleteConversation } = await import('@/lib/db');
     deleteChatConversation.mockRejectedValueOnce(

--- a/web/test/use-conversations.test.tsx
+++ b/web/test/use-conversations.test.tsx
@@ -11,6 +11,18 @@ type UseChatOptions = {
   readonly resume?: boolean;
 };
 
+const { DeleteChatConversationError } = vi.hoisted(() => ({
+  DeleteChatConversationError: class MockDeleteChatConversationError extends Error {
+    readonly status: number;
+
+    constructor(status: number) {
+      super('Delete chat conversation failed');
+      this.name = 'DeleteChatConversationError';
+      this.status = status;
+    }
+  },
+}));
+
 const chatState = { status: 'ready' };
 
 const localStop = vi.fn<() => Promise<void> | void>();
@@ -44,6 +56,7 @@ vi.mock('@/lib/transport', () => ({
     kind: 'transport',
   })),
   deleteChatConversation: (id: string) => deleteChatConversation(id),
+  DeleteChatConversationError,
   stopChatStream: (id: string, snapshot?: unknown) =>
     stopChatStream(id, snapshot),
 }));
@@ -217,5 +230,19 @@ describe('useConversations resumable streaming', () => {
     expect(deleteChatConversation).toHaveBeenCalledWith('conv-delete');
     expect(deleteConversation).toHaveBeenCalledWith('conv-delete');
     expect(calls).toStrictEqual(['server', 'local']);
+  });
+
+  it('removes the local conversation when the server conversation is already gone', async () => {
+    const { deleteConversation } = await import('@/lib/db');
+    deleteChatConversation.mockRejectedValueOnce(
+      new DeleteChatConversationError(404),
+    );
+    const { result } = renderHook(() => useConversations('model-a'));
+
+    await act(async () => {
+      await result.current.onDelete('conv-local-only');
+    });
+
+    expect(deleteConversation).toHaveBeenCalledWith('conv-local-only');
   });
 });


### PR DESCRIPTION
## Summary
- gate the chat UI behind Auth.js and add a themed sign-in page
- add server-side chat state conversation deletion through API, BFF, transport, and sidebar hook
- document the sign-in card tokens

## Verification
- npm run check
- npm run build with local auth/API env
- npm run test
- uv run pytest
- uv run ruff check app/api/chat_state.py app/data/chat_persistence.py app/data/chat_conversation_delete.py tests/test_chat_state_api.py tests/chat_persistence_fake.py
- local browser QA for unauthenticated redirect/sign-in and unauthenticated DELETE 401