### PR TITLE
test: cover chat state regression paths

### DIFF
--- a/api/tests/test_chat_state_active_stream_api.py
+++ b/api/tests/test_chat_state_active_stream_api.py
@@ -1,0 +1,88 @@
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from app.data.db import get_db
+from app.main import make_app
+from app.utils.settings import Settings
+from tests.chat_persistence_fake import FakeChatDatabase
+
+
+def _client(db: FakeChatDatabase) -> TestClient:
+    app = make_app(Settings(API_KEY="test-api-key", MCP_API_KEY="test-mcp-key"))
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def _auth_headers() -> dict[str, str]:
+    return {"x-api-key": "test-api-key"}
+
+
+OWNER_ID = "00000000-0000-4000-8000-000000000001"
+INTRUDER_ID = "00000000-0000-4000-8000-000000000002"
+
+
+def test_chat_state_active_stream_set_rejects_wrong_user() -> None:
+    db = FakeChatDatabase()
+    client = _client(db)
+    conversation_id = uuid4()
+    stream_id = uuid4()
+    response_id = uuid4()
+    client.post(
+        "/chat/state/conversations",
+        headers=_auth_headers(),
+        json={"id": str(conversation_id), "user_id": OWNER_ID},
+    )
+
+    response = client.put(
+        f"/chat/state/conversations/{conversation_id}/active-stream",
+        headers=_auth_headers(),
+        json={
+            "active_response_id": str(response_id),
+            "active_status": "streaming",
+            "active_stream_id": str(stream_id),
+            "user_id": INTRUDER_ID,
+        },
+    )
+
+    assert response.status_code == 404
+    assert db.conversations[conversation_id]["active_stream_id"] is None
+
+
+def test_chat_state_active_stream_stop_and_clear_reject_wrong_user() -> None:
+    db = FakeChatDatabase()
+    client = _client(db)
+    conversation_id = uuid4()
+    stream_id = uuid4()
+    response_id = uuid4()
+    client.post(
+        "/chat/state/conversations",
+        headers=_auth_headers(),
+        json={"id": str(conversation_id), "user_id": OWNER_ID},
+    )
+    client.put(
+        f"/chat/state/conversations/{conversation_id}/active-stream",
+        headers=_auth_headers(),
+        json={
+            "active_response_id": str(response_id),
+            "active_status": "streaming",
+            "active_stream_id": str(stream_id),
+            "user_id": OWNER_ID,
+        },
+    )
+
+    stopped = client.post(
+        f"/chat/state/conversations/{conversation_id}/active-stream/{stream_id}/stop",
+        headers=_auth_headers(),
+        json={"user_id": INTRUDER_ID},
+    )
+    cleared = client.delete(
+        f"/chat/state/conversations/{conversation_id}/active-stream/{stream_id}",
+        headers=_auth_headers(),
+        params={"user_id": INTRUDER_ID},
+    )
+
+    assert stopped.status_code == 404
+    assert cleared.status_code == 404
+    assert db.conversations[conversation_id]["active_status"] == "streaming"
+    assert db.conversations[conversation_id]["active_stream_id"] == stream_id

--- a/gpu-api/tests/test_gpu_api_endpoints.py
+++ b/gpu-api/tests/test_gpu_api_endpoints.py
@@ -129,3 +129,71 @@ def test_embeddings_logs_input_metadata_without_raw_text(caplog, monkeypatch):
     assert "private embedding text" not in caplog.text
     assert "input_chars=" in caplog.text
     assert "model=" in caplog.text
+
+
+def test_embeddings_route_returns_single_embedding_and_logs_metadata(
+    caplog,
+    monkeypatch,
+):
+    async def fake_generate_embeddings(_input, _model):
+        return [0.1, 0.2]
+
+    captured_props = []
+
+    def fake_capture_chat_inference(_request, *, stage, ms, props):
+        captured_props.append({"ms": ms, "props": props, "stage": stage})
+
+    monkeypatch.setattr(
+        "app.api.embeddings.generate_embeddings",
+        fake_generate_embeddings,
+    )
+    monkeypatch.setattr(
+        "app.api.embeddings.capture_chat_inference",
+        fake_capture_chat_inference,
+    )
+    caplog.set_level(logging.INFO, logger="app.api.embeddings")
+    client = make_test_client()
+
+    response = client.post(
+        "/embeddings/embed",
+        json={
+            "embeddings_model": Model.BGE_M3.value,
+            "input": "private embedding text",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"embeddings": [0.1, 0.2]}
+    assert captured_props[0]["stage"] == "embed"
+    assert captured_props[0]["props"]["count"] == 1
+    assert captured_props[0]["props"]["input_chars"] == len(
+        "private embedding text",
+    )
+    assert "private embedding text" not in caplog.text
+    assert "gpu.embed" in caplog.text
+
+
+def test_embeddings_route_returns_embedding_batch(monkeypatch):
+    async def fake_generate_embeddings(_input, _model):
+        return [[0.1, 0.2], [0.3, 0.4]]
+
+    monkeypatch.setattr(
+        "app.api.embeddings.generate_embeddings",
+        fake_generate_embeddings,
+    )
+    monkeypatch.setattr(
+        "app.api.embeddings.capture_chat_inference",
+        lambda *_args, **_kwargs: None,
+    )
+    client = make_test_client()
+
+    response = client.post(
+        "/embeddings/embed",
+        json={
+            "embeddings_model": Model.BGE_M3.value,
+            "input": ["first", "second"],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"embeddings": [[0.1, 0.2], [0.3, 0.4]]}

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -225,14 +225,14 @@ export const POST = async (req: Request): Promise<Response> => {
           await createChatResumableStreamContext({
             waitUntil: after,
           }).createNewResumableStream(streamId, () => sseStream);
-        } catch (error) {
+        } catch {
+          upstreamController.abort();
           await chatState.clearActiveStreamIfCurrent({
             conversationId,
             streamId,
             userId,
           });
           activeChatProducers.unregister(streamId);
-          throw error;
         }
       },
       stream,

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -227,12 +227,17 @@ export const POST = async (req: Request): Promise<Response> => {
           }).createNewResumableStream(streamId, () => sseStream);
         } catch {
           upstreamController.abort();
-          await chatState.clearActiveStreamIfCurrent({
-            conversationId,
-            streamId,
-            userId,
-          });
-          activeChatProducers.unregister(streamId);
+          try {
+            await ignoreMissing(
+              chatState.clearActiveStreamIfCurrent({
+                conversationId,
+                streamId,
+                userId,
+              }),
+            );
+          } finally {
+            activeChatProducers.unregister(streamId);
+          }
         }
       },
       stream,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -47,6 +47,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
+        "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^10.6.0",
         "eslint-config-imperium": "^4.1.4",
         "fake-indexeddb": "^6.2.5",
@@ -541,6 +542,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -5699,6 +5710,37 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/eslint-plugin": {
       "version": "1.6.20",
       "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.20.tgz",
@@ -6077,6 +6119,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -9392,6 +9453,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -9806,6 +9877,13 @@
           "url": "https://patreon.com/mdevils"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/html-tags": {
@@ -10457,6 +10535,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -11103,6 +11220,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-table": {
@@ -14486,6 +14631,19 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
       "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
       "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/svelte": {
       "version": "5.56.4",

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,8 @@
     "lint": "eslint . --cache",
     "format": "eslint . --cache --fix",
     "test": "vitest run",
+    "test:all": "npm run check && npm run lint && npm run test",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "e2e": "playwright test",
     "e2e:install": "playwright install chromium"
@@ -59,6 +61,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.6.0",
     "eslint-config-imperium": "^4.1.4",
     "fake-indexeddb": "^6.2.5",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const isCI = Boolean(process.env['CI']);
+const port = process.env['PLAYWRIGHT_PORT'] ?? '3000';
+const baseURL =
+  process.env['PLAYWRIGHT_BASE_URL'] ?? `http://127.0.0.1:${port}`;
 
 export default defineConfig({
   forbidOnly: isCI,
@@ -9,13 +12,14 @@ export default defineConfig({
   retries: isCI ? 2 : 0,
   testDir: './e2e',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL,
     trace: 'on-first-retry',
   },
   webServer: {
-    command: 'npm run dev',
-    reuseExistingServer: !isCI,
+    command: `npm run dev -- --hostname 127.0.0.1 --port ${port}`,
+    reuseExistingServer:
+      !isCI && process.env['PLAYWRIGHT_REUSE_SERVER'] === '1',
     timeout: 120_000,
-    url: 'http://localhost:3000',
+    url: baseURL,
   },
 });

--- a/web/test/api-chat.route.test.ts
+++ b/web/test/api-chat.route.test.ts
@@ -266,6 +266,8 @@ describe('POST /api/chat', () => {
   });
 
   it('clears active state and unregisters the producer when resumable stream creation fails', async () => {
+    const { ChatStateRequestError } = await import('@/lib/chat-state-client');
+
     vi.stubGlobal(
       'fetch',
       vi
@@ -274,6 +276,9 @@ describe('POST /api/chat', () => {
     );
     routeMocks.resumableContext.createNewResumableStream.mockRejectedValueOnce(
       new Error('redis failed'),
+    );
+    routeMocks.stateClient.clearActiveStreamIfCurrent.mockRejectedValueOnce(
+      new ChatStateRequestError(404),
     );
 
     const res = await (await importPost())(chatRequest({ text: 'Hi' }));

--- a/web/test/api-chat.route.test.ts
+++ b/web/test/api-chat.route.test.ts
@@ -23,6 +23,8 @@ const okStreamResponse = (...frames: string[]): Response =>
     status: 200,
   });
 
+const helloTokenFrame = 'event: token\ndata: {"text":"Здраво"}\n\n';
+
 const importPost = async (): Promise<(req: Request) => Promise<Response>> => {
   const { POST } = await import('@/app/api/chat/route');
 
@@ -46,7 +48,7 @@ describe('POST /api/chat', () => {
       .mockResolvedValue(
         okStreamResponse(
           'event: sources\ndata: {"sources":[{"id":"c1","kind":"chunk","title":"Статут","section":"Член 12","snippet":"Правила."}]}\n\n',
-          'event: token\ndata: {"text":"Здраво"}\n\n',
+          helloTokenFrame,
           'event: token\ndata: {"text":"!"}\n\n',
           'event: done\ndata: {}\n\n',
         ),
@@ -160,10 +162,7 @@ describe('POST /api/chat', () => {
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValue(
-        okStreamResponse(
-          'event: token\ndata: {"text":"Здраво"}\n\n',
-          'event: done\ndata: {}\n\n',
-        ),
+        okStreamResponse(helloTokenFrame, 'event: done\ndata: {}\n\n'),
       );
     vi.stubGlobal('fetch', fetchMock);
 
@@ -208,7 +207,7 @@ describe('POST /api/chat', () => {
         .fn<typeof fetch>()
         .mockResolvedValue(
           okStreamResponse(
-            'event: token\ndata: {"text":"Здраво"}\n\n',
+            helloTokenFrame,
             'event: token\ndata: {"text":"!"}\n\n',
             'event: done\ndata: {}\n\n',
           ),
@@ -227,6 +226,59 @@ describe('POST /api/chat', () => {
       responseId: RESPONSE_ID,
       userId: USER_ID,
     });
+    expect(
+      routeMocks.stateClient.clearActiveStreamIfCurrent,
+    ).toHaveBeenCalledWith({
+      conversationId: CONVERSATION_ID,
+      streamId: RESPONSE_ID,
+      userId: USER_ID,
+    });
+    expect(routeMocks.activeChatProducers.unregister).toHaveBeenCalledWith(
+      RESPONSE_ID,
+    );
+  });
+
+  it('aborts upstream and unregisters the producer when setting active stream state fails', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(okStreamResponse(helloTokenFrame));
+    routeMocks.stateClient.setActiveStream.mockRejectedValueOnce(
+      new Error('state failed'),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await (await importPost())(chatRequest({ text: 'Hi' }));
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const signal = init.signal;
+    const abortSignal = signal instanceof AbortSignal ? signal : null;
+    const out = await res.text();
+
+    expect(out).toContain('data-error');
+
+    expect(abortSignal?.aborted).toBe(true);
+
+    expect(routeMocks.activeChatProducers.unregister).toHaveBeenCalledWith(
+      RESPONSE_ID,
+    );
+    expect(
+      routeMocks.resumableContext.createNewResumableStream,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('clears active state and unregisters the producer when resumable stream creation fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(okStreamResponse(helloTokenFrame)),
+    );
+    routeMocks.resumableContext.createNewResumableStream.mockRejectedValueOnce(
+      new Error('redis failed'),
+    );
+
+    const res = await (await importPost())(chatRequest({ text: 'Hi' }));
+    await res.text();
+
     expect(
       routeMocks.stateClient.clearActiveStreamIfCurrent,
     ).toHaveBeenCalledWith({

--- a/web/test/app-page.test.tsx
+++ b/web/test/app-page.test.tsx
@@ -1,5 +1,5 @@
-import { isValidElement } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { authMock, isPlaywrightAuthBypassEnabledMock, redirectMock } =
   vi.hoisted(() => ({
@@ -17,7 +17,7 @@ vi.mock('@/auth', () => ({
 }));
 
 vi.mock('@/components/chat/chat-screen', () => ({
-  ChatScreen: () => 'chat-screen',
+  ChatScreen: () => <div>chat-screen</div>,
 }));
 
 vi.mock('next/navigation', () => ({
@@ -30,6 +30,10 @@ describe('HomePage auth gate', () => {
     isPlaywrightAuthBypassEnabledMock.mockReset();
     isPlaywrightAuthBypassEnabledMock.mockReturnValue(false);
     redirectMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('redirects unauthenticated users to the custom sign-in page', async () => {
@@ -45,7 +49,9 @@ describe('HomePage auth gate', () => {
     const { default: HomePage } = await import('@/app/page');
     const result = await HomePage();
 
-    expect(isValidElement(result)).toBe(true);
+    render(result);
+
+    expect(screen.getByText('chat-screen')).toBeVisible();
   });
 
   it('renders the chat screen when the Playwright auth bypass is enabled', async () => {
@@ -53,7 +59,9 @@ describe('HomePage auth gate', () => {
     const { default: HomePage } = await import('@/app/page');
     const result = await HomePage();
 
-    expect(isValidElement(result)).toBe(true);
+    render(result);
+
+    expect(screen.getByText('chat-screen')).toBeVisible();
     expect(authMock).not.toHaveBeenCalled();
   });
 });

--- a/web/test/auth-route.test.ts
+++ b/web/test/auth-route.test.ts
@@ -1,9 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const ORIGINAL = { ...process.env };
-vi.mock('next-auth', () => ({
-  default: vi.fn<
-    () => {
+
+type AuthConfig = {
+  readonly callbacks: {
+    readonly jwt: (input: {
+      readonly account?: {
+        readonly provider: string;
+        readonly providerAccountId: string;
+      };
+      readonly token: Record<string, string>;
+    }) => Record<string, string>;
+    readonly session: (input: {
+      readonly session: { readonly user: Record<string, string> };
+      readonly token: Record<string, string>;
+    }) => { readonly user: Record<string, string> };
+  };
+};
+
+const { nextAuthMock } = vi.hoisted(() => ({
+  nextAuthMock: vi.fn<
+    (config: unknown) => {
       readonly auth: () => void;
       readonly handlers: {
         readonly GET: () => void;
@@ -18,6 +35,10 @@ vi.mock('next-auth', () => ({
     signIn: vi.fn<() => void>(),
     signOut: vi.fn<() => void>(),
   })),
+}));
+
+vi.mock('next-auth', () => ({
+  default: nextAuthMock,
 }));
 
 vi.mock('next-auth/providers/google', () => ({
@@ -45,6 +66,7 @@ const setAuthEnv = (): void => {
 describe('Auth.js route handler', () => {
   beforeEach(() => {
     vi.resetModules();
+    nextAuthMock.mockClear();
     process.env = { ...ORIGINAL };
     setAuthEnv();
   });
@@ -107,5 +129,39 @@ describe('Auth.js route handler', () => {
     vi.stubEnv('NODE_ENV', 'production');
 
     expect(isPlaywrightAuthBypassEnabled()).toBe(false);
+  });
+
+  it('exposes every configured provider on the sign-in provider map', async () => {
+    process.env['AUTH_MICROSOFT_ENTRA_ID_ID'] = 'microsoft-client-id';
+    process.env['AUTH_MICROSOFT_ENTRA_ID_SECRET'] = 'microsoft-client-secret';
+    process.env['AUTH_MICROSOFT_ENTRA_ID_ISSUER'] =
+      'https://login.microsoftonline.com/tenant-id/v2.0/';
+
+    const { providerMap } = await import('@/auth');
+
+    expect(providerMap).toStrictEqual([
+      { id: 'google', name: 'Google' },
+      { id: 'microsoft-entra-id', name: 'Microsoft Entra ID' },
+    ]);
+  });
+
+  it('copies provider account claims from JWT into the session user', async () => {
+    await import('@/auth');
+    const config = nextAuthMock.mock.calls[0]?.[0] as AuthConfig;
+
+    const token = config.callbacks.jwt({
+      account: { provider: 'google', providerAccountId: 'google-sub-1' },
+      token: {},
+    });
+    const session = config.callbacks.session({ session: { user: {} }, token });
+
+    expect(token).toStrictEqual({
+      provider: 'google',
+      providerSubject: 'google-sub-1',
+    });
+    expect(session.user).toStrictEqual({
+      provider: 'google',
+      providerSubject: 'google-sub-1',
+    });
   });
 });

--- a/web/test/authenticated-chat-user.test.ts
+++ b/web/test/authenticated-chat-user.test.ts
@@ -68,4 +68,25 @@ describe('getAuthenticatedChatUserId', () => {
     );
     expect(upsertChatUserMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ['missing provider subject', { provider: 'google', providerSubject: '' }],
+    [
+      'unsupported provider',
+      { provider: 'github', providerSubject: 'github-sub-1' },
+    ],
+  ] as const)(
+    'rejects an Auth.js identity with %s before touching the API',
+    async (_label, user) => {
+      authMock.mockResolvedValue({ user });
+
+      const { AuthenticationRequiredError, getAuthenticatedChatUserId } =
+        await import('@/lib/authenticated-chat-user');
+
+      await expect(getAuthenticatedChatUserId()).rejects.toBeInstanceOf(
+        AuthenticationRequiredError,
+      );
+      expect(upsertChatUserMock).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/web/test/chat-state-client.test.ts
+++ b/web/test/chat-state-client.test.ts
@@ -6,6 +6,8 @@ vi.mock('@/lib/env', () => ({
   env: { API_BASE_URL: 'https://api:8880', CHAT_API_KEY: 'test-key' },
 }));
 
+const CHAT_USER_ID = '00000000-0000-4000-8000-000000000001';
+
 describe('createChatStateClient', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -21,7 +23,7 @@ describe('createChatStateClient', () => {
         Object.fromEntries([
           ['avatar_url', 'https://example.com/a.png'],
           ['email', 'student@example.com'],
-          ['id', '00000000-0000-4000-8000-000000000001'],
+          ['id', CHAT_USER_ID],
           ['name', 'Student'],
           ['provider', 'microsoft-entra-id'],
           ['provider_subject', 'microsoft-sub-1'],
@@ -53,7 +55,7 @@ describe('createChatStateClient', () => {
         ['provider_subject', 'microsoft-sub-1'],
       ]),
     );
-    expect(user.id).toBe('00000000-0000-4000-8000-000000000001');
+    expect(user.id).toBe(CHAT_USER_ID);
   });
 
   it('deletes a user-owned conversation with the server API key', async () => {
@@ -67,15 +69,67 @@ describe('createChatStateClient', () => {
     const { createChatStateClient } = await import('@/lib/chat-state-client');
     await createChatStateClient().deleteConversation({
       conversationId: 'conv-delete',
-      userId: '00000000-0000-4000-8000-000000000001',
+      userId: CHAT_USER_ID,
     });
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
 
     expect(url).toBe(
-      'https://api:8880/chat/state/conversations/conv-delete?user_id=00000000-0000-4000-8000-000000000001',
+      `https://api:8880/chat/state/conversations/conv-delete?user_id=${CHAT_USER_ID}`,
     );
     expect(init.method).toBe('DELETE');
     expect(new Headers(init.headers).get('x-api-key')).toBe('test-key');
+  });
+
+  it('loads a user-owned conversation with the server API key', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      Response.json({
+        conversation: Object.fromEntries([
+          ['active_response_id', null],
+          ['active_status', null],
+          ['active_stream_id', null],
+          ['id', 'conv-load'],
+          ['user_id', CHAT_USER_ID],
+        ]),
+        messages: [],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { createChatStateClient } = await import('@/lib/chat-state-client');
+    const loaded = await createChatStateClient().loadConversation({
+      conversationId: 'conv-load',
+      userId: CHAT_USER_ID,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe(
+      `https://api:8880/chat/state/conversations/conv-load?user_id=${CHAT_USER_ID}`,
+    );
+    expect(init.method).toBe('GET');
+    expect(new Headers(init.headers).get('x-api-key')).toBe('test-key');
+    expect(loaded.conversation.id).toBe('conv-load');
+  });
+
+  it('throws a typed request error when state writes fail', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(null, { status: 404 })),
+    );
+
+    const { ChatStateRequestError, createChatStateClient } =
+      await import('@/lib/chat-state-client');
+
+    await expect(
+      createChatStateClient().setActiveStream({
+        activeResponseId: 'response-missing',
+        activeStreamId: 'stream-missing',
+        conversationId: 'conv-missing',
+        userId: CHAT_USER_ID,
+      }),
+    ).rejects.toMatchObject(new ChatStateRequestError(404));
   });
 });


### PR DESCRIPTION
## Summary
- Add regression coverage for chat-state ownership, auth claims, embeddings, and chat route cleanup paths.
- Fix chat stream cleanup when resumable stream creation fails.
- Add web aggregate/coverage test scripts and make Playwright server settings configurable.

## Verification
- `api`: `uv run pytest`; `uv run ruff check .`; `uv run mypy .`
- `gpu-api`: `uv run pytest`; `uv run ruff check .`; `uv run mypy .`
- `web`: `npm run test:all`
- `web`: `npm run test:coverage -- test/message-parts.test.ts`