### PR TITLE
refactor(web): extract conversation management hook

### DIFF
--- a/web/lib/use-conversation-management.ts
+++ b/web/lib/use-conversation-management.ts
@@ -9,6 +9,7 @@ import {
 import { flushSync } from 'react-dom';
 
 import type { ErrorNotice, MyUIMessage } from '@/lib/api-types';
+import type { StopOrder } from '@/lib/use-stop-chat';
 
 import { fireAndForget } from '@/lib/async';
 import { deriveTitle } from '@/lib/messages';
@@ -18,8 +19,6 @@ import {
   DeleteChatConversationError,
   saveChatConversation,
 } from '@/lib/transport';
-
-type StopOrder = 'local-first' | 'server-first';
 
 type UseConversationManagementOptions = {
   readonly applyGeneratedTitle: (

--- a/web/lib/use-conversation-management.ts
+++ b/web/lib/use-conversation-management.ts
@@ -1,0 +1,210 @@
+'use client';
+
+import {
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+  useCallback,
+} from 'react';
+import { flushSync } from 'react-dom';
+
+import type { ErrorNotice, MyUIMessage } from '@/lib/api-types';
+
+import { fireAndForget } from '@/lib/async';
+import { deriveTitle } from '@/lib/messages';
+import {
+  clearChatConversations,
+  deleteChatConversation,
+  DeleteChatConversationError,
+  saveChatConversation,
+} from '@/lib/transport';
+
+type StopOrder = 'local-first' | 'server-first';
+
+type UseConversationManagementOptions = {
+  readonly applyGeneratedTitle: (
+    id: string,
+    messages: readonly MyUIMessage[],
+    expectedTitle: string,
+  ) => Promise<void>;
+  readonly convoIdRef: RefObject<null | string>;
+  readonly handleStop: (order?: StopOrder) => Promise<void>;
+  readonly model: string;
+  readonly refreshConversations: () => Promise<void>;
+  readonly sendMessageRef: RefObject<(message: MyUIMessage) => Promise<void>>;
+  readonly setActiveError: Dispatch<SetStateAction<ErrorNotice | undefined>>;
+  readonly setActiveId: (id: null | string) => void;
+  readonly setMessages: Dispatch<SetStateAction<MyUIMessage[]>>;
+  readonly status: string;
+};
+
+export const useConversationManagement = ({
+  applyGeneratedTitle,
+  convoIdRef,
+  handleStop,
+  model,
+  refreshConversations,
+  sendMessageRef,
+  setActiveError,
+  setActiveId,
+  setMessages,
+  status,
+}: UseConversationManagementOptions) => {
+  const resetActiveConversation = useCallback(() => {
+    setActiveId(null);
+    setMessages([]);
+    setActiveError(undefined);
+    convoIdRef.current = null;
+  }, [convoIdRef, setActiveError, setActiveId, setMessages]);
+
+  const handleNewChat = useCallback(() => {
+    if (status !== 'ready') {
+      fireAndForget(
+        (async () => {
+          await handleStop('local-first');
+          resetActiveConversation();
+        })(),
+      );
+      return;
+    }
+
+    resetActiveConversation();
+  }, [handleStop, resetActiveConversation, status]);
+
+  const handleSubmit = useCallback(
+    async (text: string) => {
+      setActiveError(undefined);
+      const existing = convoIdRef.current;
+      let cid = existing;
+      let expectedTitle: null | string = null;
+      if (!existing) {
+        expectedTitle = deriveTitle(text);
+        cid = crypto.randomUUID();
+        await saveChatConversation({
+          id: cid,
+          model,
+          title: expectedTitle,
+        });
+        // eslint-disable-next-line require-atomic-updates -- fresh id, not a read-modify-write race
+        convoIdRef.current = cid;
+        flushSync(() => {
+          setActiveId(cid);
+        });
+        await refreshConversations();
+      }
+      if (!cid) {
+        return;
+      }
+      const userMessage: MyUIMessage = {
+        id: crypto.randomUUID(),
+        metadata: {},
+        parts: [{ text, type: 'text' }],
+        role: 'user',
+      };
+      if (expectedTitle !== null) {
+        fireAndForget(applyGeneratedTitle(cid, [userMessage], expectedTitle));
+      }
+      fireAndForget(sendMessageRef.current(userMessage));
+    },
+    [
+      applyGeneratedTitle,
+      convoIdRef,
+      model,
+      refreshConversations,
+      sendMessageRef,
+      setActiveError,
+      setActiveId,
+    ],
+  );
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      if (id !== convoIdRef.current && status !== 'ready') {
+        fireAndForget(
+          (async () => {
+            await handleStop('local-first');
+            convoIdRef.current = id;
+            setMessages([]);
+            setActiveId(id);
+          })(),
+        );
+        return;
+      }
+      convoIdRef.current = id;
+      setMessages([]);
+      setActiveId(id);
+    },
+    [convoIdRef, handleStop, setActiveId, setMessages, status],
+  );
+
+  const deleteConversationEverywhere = useCallback(
+    async (id: string) => {
+      const deletingActiveConversation = convoIdRef.current === id;
+      if (deletingActiveConversation && status !== 'ready') {
+        await handleStop();
+      }
+
+      try {
+        await deleteChatConversation(id);
+      } catch (error) {
+        const serverConversationAlreadyDeleted =
+          error instanceof DeleteChatConversationError && error.status === 404;
+
+        if (!serverConversationAlreadyDeleted) {
+          throw error;
+        }
+      }
+      if (deletingActiveConversation && convoIdRef.current === id) {
+        resetActiveConversation();
+      }
+      await refreshConversations();
+    },
+    [
+      convoIdRef,
+      handleStop,
+      refreshConversations,
+      resetActiveConversation,
+      status,
+    ],
+  );
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      fireAndForget(deleteConversationEverywhere(id));
+    },
+    [deleteConversationEverywhere],
+  );
+
+  const handleClearAll = useCallback(async () => {
+    if (status !== 'ready') {
+      await handleStop();
+    }
+    await clearChatConversations();
+    resetActiveConversation();
+    await refreshConversations();
+  }, [handleStop, refreshConversations, resetActiveConversation, status]);
+
+  const submitMessage = useCallback(
+    (text: string) => {
+      fireAndForget(handleSubmit(text));
+    },
+    [handleSubmit],
+  );
+
+  const handleRename = useCallback(
+    async (id: string, title: string) => {
+      await saveChatConversation({ id, title });
+      await refreshConversations();
+    },
+    [refreshConversations],
+  );
+
+  return {
+    handleClearAll,
+    handleDelete,
+    handleNewChat,
+    handleRename,
+    handleSelect,
+    submitMessage,
+  };
+};

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { useCallback } from 'react';
-import { flushSync } from 'react-dom';
 
-import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
+import type { FeedbackType } from '@/lib/api-types';
 
 import { fireAndForget } from '@/lib/async';
 import { renderAnswerActions } from '@/lib/conversation-actions';
@@ -11,16 +10,10 @@ import {
   applyFeedback,
   previewRegeneration,
 } from '@/lib/conversation-message-state';
-import { deriveTitle } from '@/lib/messages';
-import {
-  clearChatConversations,
-  deleteChatConversation,
-  DeleteChatConversationError,
-  saveChatConversation,
-} from '@/lib/transport';
 import { useUiStore } from '@/lib/ui-store';
 import { useConversationChatRuntime } from '@/lib/use-conversation-chat-runtime';
 import { useConversationList } from '@/lib/use-conversation-list';
+import { useConversationManagement } from '@/lib/use-conversation-management';
 import { useGeneratedTitle } from '@/lib/use-generated-title';
 import { useStopChat } from '@/lib/use-stop-chat';
 
@@ -59,169 +52,25 @@ export const useConversations = (
   const { applyGeneratedTitle, generatingTitleId, handleGenerateTitle } =
     useGeneratedTitle({ conversations, modelRef, refreshConversations });
   const handleStop = useStopChat({ convoIdRef, messages, model, stop });
-
-  const handleNewChat = useCallback(() => {
-    if (status !== 'ready') {
-      fireAndForget(
-        (async () => {
-          await handleStop('local-first');
-          setActiveId(null);
-          setMessages([]);
-          setActiveError(undefined);
-          convoIdRef.current = null;
-        })(),
-      );
-      return;
-    }
-    setActiveId(null);
-    setMessages([]);
-    setActiveError(undefined);
-    convoIdRef.current = null;
-  }, [
+  const {
+    handleClearAll,
+    handleDelete,
+    handleNewChat,
+    handleRename,
+    handleSelect,
+    submitMessage,
+  } = useConversationManagement({
+    applyGeneratedTitle,
     convoIdRef,
     handleStop,
-    setActiveError,
-    setActiveId,
-    setMessages,
-    status,
-  ]);
-
-  const handleSubmit = useCallback(
-    async (text: string) => {
-      setActiveError(undefined);
-      const existing = convoIdRef.current;
-      let cid = existing;
-      let expectedTitle: null | string = null;
-      if (!existing) {
-        expectedTitle = deriveTitle(text);
-        cid = crypto.randomUUID();
-        await saveChatConversation({
-          id: cid,
-          model,
-          title: expectedTitle,
-        });
-        // eslint-disable-next-line require-atomic-updates -- fresh id, not a read-modify-write race
-        convoIdRef.current = cid;
-        // eslint-disable-next-line @eslint-react/dom-no-flush-sync -- conversation id must be committed before useChat resumes the new stream
-        flushSync(() => {
-          setActiveId(cid);
-        });
-        await refreshConversations();
-      }
-      if (!cid) {
-        return;
-      }
-      const userMessage: MyUIMessage = {
-        id: crypto.randomUUID(),
-        metadata: {},
-        parts: [{ text, type: 'text' }],
-        role: 'user',
-      };
-      if (expectedTitle !== null) {
-        fireAndForget(applyGeneratedTitle(cid, [userMessage], expectedTitle));
-      }
-      fireAndForget(sendMessageRef.current(userMessage));
-    },
-    [
-      applyGeneratedTitle,
-      convoIdRef,
-      model,
-      refreshConversations,
-      sendMessageRef,
-      setActiveError,
-      setActiveId,
-    ],
-  );
-
-  const handleSelect = useCallback(
-    (id: string) => {
-      if (id !== convoIdRef.current && status !== 'ready') {
-        fireAndForget(
-          (async () => {
-            await handleStop('local-first');
-            convoIdRef.current = id;
-            setMessages([]);
-            setActiveId(id);
-          })(),
-        );
-        return;
-      }
-      convoIdRef.current = id;
-      setMessages([]);
-      setActiveId(id);
-    },
-    [convoIdRef, handleStop, setActiveId, setMessages, status],
-  );
-
-  const deleteConversationEverywhere = useCallback(
-    async (id: string) => {
-      const deletingActiveConversation = convoIdRef.current === id;
-      if (deletingActiveConversation && status !== 'ready') {
-        await handleStop();
-      }
-
-      try {
-        await deleteChatConversation(id);
-      } catch (error) {
-        const serverConversationAlreadyDeleted =
-          error instanceof DeleteChatConversationError && error.status === 404;
-
-        if (!serverConversationAlreadyDeleted) {
-          throw error;
-        }
-      }
-      if (deletingActiveConversation && convoIdRef.current === id) {
-        setActiveId(null);
-        setMessages([]);
-        setActiveError(undefined);
-        convoIdRef.current = null;
-      }
-      await refreshConversations();
-    },
-    [
-      convoIdRef,
-      handleStop,
-      refreshConversations,
-      setActiveError,
-      setActiveId,
-      setMessages,
-      status,
-    ],
-  );
-
-  const handleDelete = useCallback(
-    (id: string) => {
-      fireAndForget(deleteConversationEverywhere(id));
-    },
-    [deleteConversationEverywhere],
-  );
-
-  const handleClearAll = useCallback(async () => {
-    if (status !== 'ready') {
-      await handleStop();
-    }
-    await clearChatConversations();
-    setActiveId(null);
-    setMessages([]);
-    setActiveError(undefined);
-    convoIdRef.current = null;
-    await refreshConversations();
-  }, [
-    convoIdRef,
-    handleStop,
+    model,
     refreshConversations,
+    sendMessageRef,
     setActiveError,
     setActiveId,
     setMessages,
     status,
-  ]);
-
-  const submitMessage = useCallback(
-    (text: string) => {
-      fireAndForget(handleSubmit(text));
-    },
-    [handleSubmit],
-  );
+  });
 
   const retry = useCallback(() => {
     if (disabled) {
@@ -250,14 +99,6 @@ export const useConversations = (
       setActiveStatus,
       setRegeneratingMessageId,
     ],
-  );
-
-  const handleRename = useCallback(
-    async (id: string, title: string) => {
-      await saveChatConversation({ id, title });
-      await refreshConversations();
-    },
-    [refreshConversations],
   );
 
   const recordFeedback = useCallback(

--- a/web/lib/use-stop-chat.ts
+++ b/web/lib/use-stop-chat.ts
@@ -9,7 +9,7 @@ import { fireAndForget } from '@/lib/async';
 import { stopOptionsFrom } from '@/lib/stop-chat-snapshot';
 import { stopChatStream } from '@/lib/transport';
 
-type StopOrder = 'local-first' | 'server-first';
+export type StopOrder = 'local-first' | 'server-first';
 
 type UseStopChatOptions = {
   readonly convoIdRef: RefObject<null | string>;


### PR DESCRIPTION
## Summary
- extract conversation management actions from useConversations into useConversationManagement
- keep the public useConversations API unchanged
- preserve stop-before-clear/delete race handling and title-generation flow

## Verification
- npm run check
- npx eslint "lib/use-conversations.tsx" "lib/use-conversation-management.ts" --no-cache
- npm run lint -- --no-cache
- npm test -- use-conversations.test.tsx use-conversation-hydration.test.tsx shell.test.tsx chat-state-client.test.ts transport.test.ts
- npm test
- PLAYWRIGHT_AUTH_BYPASS=1 AUTH_SECRET=test-secret AUTH_URL=http://127.0.0.1:3000 API_BASE_URL=http://127.0.0.1:8880 CHAT_API_KEY=test-key RESUMABLE_STREAM_REDIS_URL=redis://127.0.0.1:6379 npx playwright test e2e/chat.spec.ts
- PLAYWRIGHT_AUTH_BYPASS=1 AUTH_SECRET=test-secret AUTH_URL=http://127.0.0.1:3000 API_BASE_URL=http://127.0.0.1:8880 CHAT_API_KEY=test-key RESUMABLE_STREAM_REDIS_URL=redis://127.0.0.1:6379 npm run build