### PR TITLE
fix: sanitize validation errors

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -31,9 +31,34 @@ from app.utils.settings import Settings
 
 logger = logging.getLogger(__name__)
 
+type ValidationErrorDetail = dict[str, "ValidationErrorValue"]
+type ValidationErrorValue = (
+    None
+    | bool
+    | int
+    | float
+    | str
+    | list["ValidationErrorValue"]
+    | ValidationErrorDetail
+)
+
 settings = Settings()
 
 setup_logging(level=settings.LOG_LEVEL)
+
+
+def _strip_validation_inputs(value: ValidationErrorValue) -> ValidationErrorValue:
+    match value:
+        case list():
+            return [_strip_validation_inputs(item) for item in value]
+        case dict():
+            return {
+                key: _strip_validation_inputs(item)
+                for key, item in value.items()
+                if key != "input"
+            }
+        case _:
+            return value
 
 
 def _warn_on_insecure_defaults(current: Settings) -> None:
@@ -136,9 +161,10 @@ def make_app(settings: Settings) -> FastAPI:
         exc: RequestValidationError,
     ) -> JSONResponse:
         # Don't echo the raw request body back (avoids reflecting arbitrary/oversized input).
+        detail = _strip_validation_inputs(jsonable_encoder(exc.errors()))
         return JSONResponse(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            content=jsonable_encoder({"detail": exc.errors()}),
+            content={"detail": detail},
         )
 
     @app.exception_handler(RetrievalError)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -31,34 +31,9 @@ from app.utils.settings import Settings
 
 logger = logging.getLogger(__name__)
 
-type ValidationErrorDetail = dict[str, "ValidationErrorValue"]
-type ValidationErrorValue = (
-    None
-    | bool
-    | int
-    | float
-    | str
-    | list["ValidationErrorValue"]
-    | ValidationErrorDetail
-)
-
 settings = Settings()
 
 setup_logging(level=settings.LOG_LEVEL)
-
-
-def _strip_validation_inputs(value: ValidationErrorValue) -> ValidationErrorValue:
-    match value:
-        case list():
-            return [_strip_validation_inputs(item) for item in value]
-        case dict():
-            return {
-                key: _strip_validation_inputs(item)
-                for key, item in value.items()
-                if key != "input"
-            }
-        case _:
-            return value
 
 
 def _warn_on_insecure_defaults(current: Settings) -> None:
@@ -161,10 +136,9 @@ def make_app(settings: Settings) -> FastAPI:
         exc: RequestValidationError,
     ) -> JSONResponse:
         # Don't echo the raw request body back (avoids reflecting arbitrary/oversized input).
-        detail = _strip_validation_inputs(jsonable_encoder(exc.errors()))
         return JSONResponse(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            content={"detail": detail},
+            content={"detail": jsonable_encoder(exc.errors(), exclude={"input"})},
         )
 
     @app.exception_handler(RetrievalError)

--- a/api/tests/test_api_endpoints.py
+++ b/api/tests/test_api_endpoints.py
@@ -63,3 +63,31 @@ def test_chat_stream_accepts_discord_without_api_key(monkeypatch):
         )
 
     assert response.status_code == 200
+
+
+def test_validation_errors_do_not_echo_raw_invalid_payload(monkeypatch):
+    monkeypatch.setattr("app.main.Database", HealthyDatabase)
+    app = make_app(
+        Settings(
+            API_KEY="test-api-key",
+            MCP_API_KEY="test-mcp-key",
+        ),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat/title",
+            json={
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": "private invalid title payload",
+                    },
+                ],
+            },
+        )
+
+    body = response.json()
+    assert response.status_code == 422
+    assert "private invalid title payload" not in response.text
+    assert "input" not in body["detail"][0]

--- a/gpu-api/app/main.py
+++ b/gpu-api/app/main.py
@@ -29,34 +29,9 @@ from app.utils.settings import Settings
 
 logger = logging.getLogger(__name__)
 
-type ValidationErrorDetail = dict[str, "ValidationErrorValue"]
-type ValidationErrorValue = (
-    None
-    | bool
-    | int
-    | float
-    | str
-    | list["ValidationErrorValue"]
-    | ValidationErrorDetail
-)
-
 settings = Settings()
 
 setup_logging(level=settings.LOG_LEVEL)
-
-
-def _strip_validation_inputs(value: ValidationErrorValue) -> ValidationErrorValue:
-    match value:
-        case list():
-            return [_strip_validation_inputs(item) for item in value]
-        case dict():
-            return {
-                key: _strip_validation_inputs(item)
-                for key, item in value.items()
-                if key != "input"
-            }
-        case _:
-            return value
 
 
 @asynccontextmanager
@@ -126,10 +101,9 @@ def make_app(settings: Settings) -> FastAPI:
         request: Request,
         exc: RequestValidationError,
     ) -> JSONResponse:
-        detail = _strip_validation_inputs(jsonable_encoder(exc.errors()))
         return JSONResponse(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            content={"detail": detail},
+            content={"detail": jsonable_encoder(exc.errors(), exclude={"input"})},
         )
 
     @app.exception_handler(ModelNotReadyError)

--- a/gpu-api/app/main.py
+++ b/gpu-api/app/main.py
@@ -29,9 +29,34 @@ from app.utils.settings import Settings
 
 logger = logging.getLogger(__name__)
 
+type ValidationErrorDetail = dict[str, "ValidationErrorValue"]
+type ValidationErrorValue = (
+    None
+    | bool
+    | int
+    | float
+    | str
+    | list["ValidationErrorValue"]
+    | ValidationErrorDetail
+)
+
 settings = Settings()
 
 setup_logging(level=settings.LOG_LEVEL)
+
+
+def _strip_validation_inputs(value: ValidationErrorValue) -> ValidationErrorValue:
+    match value:
+        case list():
+            return [_strip_validation_inputs(item) for item in value]
+        case dict():
+            return {
+                key: _strip_validation_inputs(item)
+                for key, item in value.items()
+                if key != "input"
+            }
+        case _:
+            return value
 
 
 @asynccontextmanager
@@ -101,19 +126,10 @@ def make_app(settings: Settings) -> FastAPI:
         request: Request,
         exc: RequestValidationError,
     ) -> JSONResponse:
-        raw = exc.body
-        if isinstance(raw, bytes | bytearray):
-            try:
-                body_str = raw.decode("utf-8")
-            except Exception:
-                body_str = repr(raw)
-        else:
-            body_str = raw
-
-        content = {"detail": exc.errors(), "body": body_str}
+        detail = _strip_validation_inputs(jsonable_encoder(exc.errors()))
         return JSONResponse(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            content=jsonable_encoder(content),
+            content={"detail": detail},
         )
 
     @app.exception_handler(ModelNotReadyError)

--- a/gpu-api/tests/test_gpu_api_endpoints.py
+++ b/gpu-api/tests/test_gpu_api_endpoints.py
@@ -197,3 +197,24 @@ def test_embeddings_route_returns_embedding_batch(monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == {"embeddings": [[0.1, 0.2], [0.3, 0.4]]}
+
+
+def test_validation_errors_do_not_echo_raw_invalid_payload():
+    client = make_test_client()
+
+    response = client.post(
+        "/stream/",
+        json={
+            "prompt": "private invalid stream prompt",
+            "inference_model": Model.QWEN2_5_7B_INSTRUCT.value,
+            "temperature": 2,
+            "top_p": 0.9,
+            "max_tokens": 64,
+        },
+    )
+
+    body = response.json()
+    assert response.status_code == 422
+    assert "private invalid stream prompt" not in response.text
+    assert "body" not in body
+    assert "input" not in body["detail"][0]


### PR DESCRIPTION
## Summary
- Strip raw input values from API validation error details
- Stop GPU API validation errors from echoing the raw request body
- Add API and GPU API regression tests for private invalid payloads

## Verification
- API: uv run pytest (97 passed)
- API: uv run ruff check .
- API: uv run mypy .
- GPU API: uv run pytest (10 passed)
- GPU API: uv run ruff check .
- GPU API: uv run mypy .
- Manual TestClient checks confirmed 422 responses do not echo private invalid payload text