### PR TITLE
fix(api): tolerate partial MCP outages

### DIFF
--- a/api/app/llms/mcp.py
+++ b/api/app/llms/mcp.py
@@ -127,26 +127,27 @@ async def get_mcp_tools() -> list[BaseTool]:
     with timed("agent.mcp_tools"):
         fetched: list[BaseTool] = []
         for server in servers:
+            server_label = server.name if server.name != server.url else "legacy_url"
             try:
                 server_tools = await client.get_tools(server_name=server.name)
             except get_cancelled_exc_class():
                 logger.warning(
                     "MCP server tool loading cancelled; propagating cancellation: %s",
-                    server.name,
+                    server_label,
                 )
                 raise
             except Exception as exc:
-                failed_server_names.append(server.name)
+                failed_server_names.append(server_label)
                 logger.warning(
                     "MCP server tool loading failed; skipping server: %s",
-                    server.name,
+                    server_label,
                     exc_info=True,
                 )
                 capture(
                     "server",
                     "mcp_server_tool_loading_failed",
                     {
-                        "server_name": server.name,
+                        "server_name": server_label,
                         "transport": server.transport,
                         "error_type": type(exc).__name__,
                     },

--- a/api/app/llms/mcp.py
+++ b/api/app/llms/mcp.py
@@ -11,6 +11,7 @@ from langchain_mcp_adapters.sessions import (
     StreamableHttpConnection,
 )
 
+from app.utils.posthog_client import capture
 from app.utils.settings import McpServerSettings, Settings
 from app.utils.timing import timed
 
@@ -124,7 +125,24 @@ async def get_mcp_tools() -> list[BaseTool]:
     with timed("agent.mcp_tools"):
         fetched: list[BaseTool] = []
         for server in servers:
-            server_tools = await client.get_tools(server_name=server.name)
+            try:
+                server_tools = await client.get_tools(server_name=server.name)
+            except Exception as exc:
+                logger.warning(
+                    "MCP server tool loading failed; skipping server: %s",
+                    server.name,
+                    exc_info=True,
+                )
+                capture(
+                    "server",
+                    "mcp_server_tool_loading_failed",
+                    {
+                        "server_name": server.name,
+                        "transport": server.transport,
+                        "error_type": type(exc).__name__,
+                    },
+                )
+                continue
             fetched_source_tool_count += len(server_tools)
             fetched.extend(_filter_tools(server_tools, server))
 

--- a/api/app/llms/mcp.py
+++ b/api/app/llms/mcp.py
@@ -122,7 +122,8 @@ async def get_mcp_tools() -> list[BaseTool]:
     client = build_mcp_client()
     # Timed only on an actual fetch (cache hits return above), so the span's presence on
     # a request flags a refresh — and a degraded MCP server, which refetches every time.
-    fetched_source_tool_count = 0
+    failed_server_names: list[str] = []
+    successful_server_count = 0
     with timed("agent.mcp_tools"):
         fetched: list[BaseTool] = []
         for server in servers:
@@ -135,6 +136,7 @@ async def get_mcp_tools() -> list[BaseTool]:
                 )
                 raise
             except Exception as exc:
+                failed_server_names.append(server.name)
                 logger.warning(
                     "MCP server tool loading failed; skipping server: %s",
                     server.name,
@@ -150,16 +152,25 @@ async def get_mcp_tools() -> list[BaseTool]:
                     },
                 )
                 continue
-            fetched_source_tool_count += len(server_tools)
+            successful_server_count += 1
             fetched.extend(_filter_tools(server_tools, server))
 
-    if not fetched and fetched_source_tool_count == 0:
-        # Empty usually means the MCP server is unreachable/degraded. Keep the last-good
-        # tools and leave the timestamp stale so the next request retries, instead of
-        # caching a tool-less agent for the whole TTL.
+    if failed_server_names:
+        if successful_server_count > 0:
+            logger.warning(
+                "Fetched %d MCP tools from %d/%d MCP servers; failed servers (%s) "
+                "will be retried on the next request instead of caching a degraded list",
+                len(fetched),
+                successful_server_count,
+                len(servers),
+                ", ".join(failed_server_names),
+            )
+            return fetched
+
         logger.warning(
-            "MCP returned an empty tool list; keeping previously cached tools (if any) "
-            "and retrying on the next request instead of caching the empty result",
+            "All MCP servers failed (%s); keeping previously cached tools (if any) "
+            "and retrying on the next request instead of caching the failed refresh",
+            ", ".join(failed_server_names),
         )
         return mcp_tools if mcp_tools is not None else []
 

--- a/api/app/llms/mcp.py
+++ b/api/app/llms/mcp.py
@@ -129,6 +129,10 @@ async def get_mcp_tools() -> list[BaseTool]:
             try:
                 server_tools = await client.get_tools(server_name=server.name)
             except get_cancelled_exc_class():
+                logger.warning(
+                    "MCP server tool loading cancelled; propagating cancellation: %s",
+                    server.name,
+                )
                 raise
             except Exception as exc:
                 logger.warning(

--- a/api/app/llms/mcp.py
+++ b/api/app/llms/mcp.py
@@ -3,6 +3,7 @@ import time
 from collections.abc import Sequence
 from typing import Protocol, assert_never
 
+from anyio import get_cancelled_exc_class
 from langchain_core.tools import BaseTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.sessions import (
@@ -127,6 +128,8 @@ async def get_mcp_tools() -> list[BaseTool]:
         for server in servers:
             try:
                 server_tools = await client.get_tools(server_name=server.name)
+            except get_cancelled_exc_class():
+                raise
             except Exception as exc:
                 logger.warning(
                     "MCP server tool loading failed; skipping server: %s",

--- a/api/tests/test_mcp_cache_failures.py
+++ b/api/tests/test_mcp_cache_failures.py
@@ -110,3 +110,53 @@ async def test_get_mcp_tools_caches_successful_empty_response(monkeypatch):
     assert tools == []
     assert mcp.mcp_tools == []
     assert mcp.mcp_tools_fetched_at > 0
+
+
+@pytest.mark.anyio
+async def test_mcp_failure_event_redacts_legacy_url_server_name(monkeypatch, caplog):
+    class FakeClient:
+        async def get_tools(self, *, server_name: str | None = None):
+            raise OSError("legacy MCP is unavailable")
+
+    def build_fake_client() -> FakeClient:
+        return FakeClient()
+
+    legacy_url = "https://user:secret@internal.example/mcp?token=sensitive"
+    captured_events = []
+    monkeypatch.setattr(mcp, "build_mcp_client", build_fake_client)
+    monkeypatch.setattr(
+        mcp,
+        "capture",
+        lambda distinct_id, event, props: captured_events.append(
+            (distinct_id, event, props),
+        ),
+    )
+    monkeypatch.setattr(
+        mcp,
+        "settings",
+        Settings(
+            MCP_SERVERS=[],
+            MCP_HTTP_URLS=legacy_url,
+            MCP_API_KEY="shared-key",
+        ),
+    )
+    monkeypatch.setattr(mcp, "mcp_tools", None)
+    monkeypatch.setattr(mcp, "mcp_tools_fetched_at", -10_000.0)
+
+    tools = await mcp.get_mcp_tools()
+
+    assert tools == []
+    assert captured_events == [
+        (
+            "server",
+            "mcp_server_tool_loading_failed",
+            {
+                "server_name": "legacy_url",
+                "transport": "streamable_http",
+                "error_type": "OSError",
+            },
+        ),
+    ]
+    assert legacy_url not in str(captured_events)
+    assert legacy_url not in caplog.text
+    assert "legacy_url" in caplog.text

--- a/api/tests/test_mcp_cache_failures.py
+++ b/api/tests/test_mcp_cache_failures.py
@@ -1,0 +1,112 @@
+from dataclasses import dataclass
+
+import pytest
+
+from app.llms import mcp
+from app.utils.settings import McpServerSettings, Settings
+
+
+@dataclass(frozen=True, slots=True)
+class ToolStub:
+    name: str
+
+
+def server(name: str) -> McpServerSettings:
+    return McpServerSettings(
+        name=name,
+        url=f"https://{name}-mcp:8808/mcp",
+        transport="streamable_http",
+    )
+
+
+@pytest.mark.anyio
+async def test_get_mcp_tools_retries_partial_refresh_instead_of_caching_it(
+    monkeypatch,
+):
+    class FakeClient:
+        def __init__(self) -> None:
+            self.calls = {"search": 0, "records": 0}
+
+        async def get_tools(self, *, server_name: str | None = None):
+            if server_name is None:
+                raise AssertionError("server_name is required")
+            self.calls[server_name] += 1
+            if server_name == "records" and self.calls[server_name] == 1:
+                raise OSError("records MCP is temporarily unavailable")
+            tool_name = "web_search" if server_name == "search" else "lookup"
+            return [ToolStub(tool_name)]
+
+    fake_client = FakeClient()
+    monkeypatch.setattr(mcp, "build_mcp_client", lambda: fake_client)
+    monkeypatch.setattr(mcp, "capture", lambda *args: None)
+    monkeypatch.setattr(
+        mcp,
+        "settings",
+        Settings(MCP_SERVERS=[server("search"), server("records")]),
+    )
+    monkeypatch.setattr(mcp, "mcp_tools", None)
+    monkeypatch.setattr(mcp, "mcp_tools_fetched_at", -10_000.0)
+
+    degraded_tools = await mcp.get_mcp_tools()
+    refreshed_tools = await mcp.get_mcp_tools()
+
+    assert [tool.name for tool in degraded_tools] == ["web_search"]
+    assert [tool.name for tool in refreshed_tools] == ["web_search", "lookup"]
+    assert fake_client.calls == {"search": 2, "records": 2}
+
+
+@pytest.mark.anyio
+async def test_get_mcp_tools_excludes_stale_tools_when_healthy_server_is_empty(
+    monkeypatch,
+):
+    class FakeClient:
+        async def get_tools(self, *, server_name: str | None = None):
+            if server_name == "broken":
+                raise OSError("broken MCP is unavailable")
+            return []
+
+    def build_fake_client() -> FakeClient:
+        return FakeClient()
+
+    stale_tools = [ToolStub("stale_broken_tool")]
+    monkeypatch.setattr(mcp, "build_mcp_client", build_fake_client)
+    monkeypatch.setattr(mcp, "capture", lambda *args: None)
+    monkeypatch.setattr(
+        mcp,
+        "settings",
+        Settings(MCP_SERVERS=[server("broken"), server("empty")]),
+    )
+    monkeypatch.setattr(mcp, "mcp_tools", stale_tools)
+    monkeypatch.setattr(mcp, "mcp_tools_fetched_at", -10_000.0)
+
+    tools = await mcp.get_mcp_tools()
+
+    assert tools == []
+    assert mcp.mcp_tools == stale_tools
+    assert mcp.mcp_tools_fetched_at == -10_000.0
+
+
+@pytest.mark.anyio
+async def test_get_mcp_tools_caches_successful_empty_response(monkeypatch):
+    class FakeClient:
+        async def get_tools(self, *, server_name: str | None = None):
+            return []
+
+    def build_fake_client() -> FakeClient:
+        return FakeClient()
+
+    stale_tools = [ToolStub("stale_tool")]
+    monkeypatch.setattr(mcp, "build_mcp_client", build_fake_client)
+    monkeypatch.setattr(
+        mcp,
+        "settings",
+        Settings(MCP_SERVERS=[server("empty")]),
+    )
+    monkeypatch.setattr(mcp, "mcp_tools", stale_tools)
+    monkeypatch.setattr(mcp, "mcp_tools_fetched_at", -10_000.0)
+
+    tools = await mcp.get_mcp_tools()
+
+    assert tools == []
+    assert mcp.mcp_tools == []
+    assert mcp.mcp_tools_fetched_at > 0

--- a/api/tests/test_mcp_cache_failures.py
+++ b/api/tests/test_mcp_cache_failures.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 import pytest
+from anyio import lowlevel
 
 from app.llms import mcp
 from app.utils.settings import McpServerSettings, Settings
@@ -28,6 +29,7 @@ async def test_get_mcp_tools_retries_partial_refresh_instead_of_caching_it(
             self.calls = {"search": 0, "records": 0}
 
         async def get_tools(self, *, server_name: str | None = None):
+            await lowlevel.checkpoint()
             if server_name is None:
                 raise AssertionError("server_name is required")
             self.calls[server_name] += 1
@@ -61,6 +63,7 @@ async def test_get_mcp_tools_excludes_stale_tools_when_healthy_server_is_empty(
 ):
     class FakeClient:
         async def get_tools(self, *, server_name: str | None = None):
+            await lowlevel.checkpoint()
             if server_name == "broken":
                 raise OSError("broken MCP is unavailable")
             return []
@@ -90,6 +93,7 @@ async def test_get_mcp_tools_excludes_stale_tools_when_healthy_server_is_empty(
 async def test_get_mcp_tools_caches_successful_empty_response(monkeypatch):
     class FakeClient:
         async def get_tools(self, *, server_name: str | None = None):
+            await lowlevel.checkpoint()
             return []
 
     def build_fake_client() -> FakeClient:
@@ -116,12 +120,13 @@ async def test_get_mcp_tools_caches_successful_empty_response(monkeypatch):
 async def test_mcp_failure_event_redacts_legacy_url_server_name(monkeypatch, caplog):
     class FakeClient:
         async def get_tools(self, *, server_name: str | None = None):
+            await lowlevel.checkpoint()
             raise OSError("legacy MCP is unavailable")
 
     def build_fake_client() -> FakeClient:
         return FakeClient()
 
-    legacy_url = "https://user:secret@internal.example/mcp?token=sensitive"
+    legacy_url = "https://internal.example/mcp?tenant=private"
     captured_events = []
     monkeypatch.setattr(mcp, "build_mcp_client", build_fake_client)
     monkeypatch.setattr(

--- a/api/tests/test_mcp_cancellation.py
+++ b/api/tests/test_mcp_cancellation.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from app.llms import mcp
@@ -9,7 +11,7 @@ class SimulatedCancellationError(Exception):
 
 
 @pytest.mark.anyio
-async def test_get_mcp_tools_propagates_backend_cancellation(monkeypatch):
+async def test_get_mcp_tools_propagates_backend_cancellation(monkeypatch, caplog):
     captured_events = []
 
     class FakeClient:
@@ -48,7 +50,13 @@ async def test_get_mcp_tools_propagates_backend_cancellation(monkeypatch):
     monkeypatch.setattr(mcp, "mcp_tools", None)
     monkeypatch.setattr(mcp, "mcp_tools_fetched_at", 0.0)
 
-    with pytest.raises(SimulatedCancellationError):
+    with (
+        caplog.at_level(logging.WARNING, logger=mcp.__name__),
+        pytest.raises(SimulatedCancellationError),
+    ):
         await mcp.get_mcp_tools()
 
     assert captured_events == []
+    assert caplog.messages == [
+        "MCP server tool loading cancelled; propagating cancellation: cancelled",
+    ]

--- a/api/tests/test_mcp_cancellation.py
+++ b/api/tests/test_mcp_cancellation.py
@@ -1,0 +1,54 @@
+import pytest
+
+from app.llms import mcp
+from app.utils.settings import McpServerSettings, Settings
+
+
+class SimulatedCancellationError(Exception):
+    pass
+
+
+@pytest.mark.anyio
+async def test_get_mcp_tools_propagates_backend_cancellation(monkeypatch):
+    captured_events = []
+
+    class FakeClient:
+        async def get_tools(self, *, server_name=None):
+            raise SimulatedCancellationError
+
+    def build_fake_client():
+        return FakeClient()
+
+    monkeypatch.setattr(mcp, "build_mcp_client", build_fake_client)
+    monkeypatch.setattr(
+        mcp,
+        "get_cancelled_exc_class",
+        lambda: SimulatedCancellationError,
+    )
+    monkeypatch.setattr(
+        mcp,
+        "capture",
+        lambda distinct_id, event, props: captured_events.append(
+            (distinct_id, event, props),
+        ),
+    )
+    monkeypatch.setattr(
+        mcp,
+        "settings",
+        Settings(
+            MCP_SERVERS=[
+                McpServerSettings(
+                    name="cancelled",
+                    url="https://cancelled-mcp:8808/mcp",
+                    transport="streamable_http",
+                ),
+            ],
+        ),
+    )
+    monkeypatch.setattr(mcp, "mcp_tools", None)
+    monkeypatch.setattr(mcp, "mcp_tools_fetched_at", 0.0)
+
+    with pytest.raises(SimulatedCancellationError):
+        await mcp.get_mcp_tools()
+
+    assert captured_events == []

--- a/api/tests/test_mcp_settings.py
+++ b/api/tests/test_mcp_settings.py
@@ -48,33 +48,29 @@ def test_settings_parses_structured_mcp_servers(monkeypatch):
 
 
 def test_settings_rejects_duplicate_mcp_server_names():
+    servers = [
+        McpServerSettings(
+            name="search",
+            url="https://search-mcp:8808/mcp",
+            transport="streamable_http",
+        ),
+        McpServerSettings(
+            name="search",
+            url="https://other-mcp:8808/mcp",
+            transport="streamable_http",
+        ),
+    ]
+
     with pytest.raises(ValidationError, match="unique names"):
-        Settings(
-            MCP_SERVERS=[
-                McpServerSettings(
-                    name="search",
-                    url="https://search-mcp:8808/mcp",
-                    transport="streamable_http",
-                ),
-                McpServerSettings(
-                    name="search",
-                    url="https://other-mcp:8808/mcp",
-                    transport="streamable_http",
-                ),
-            ],
-        )
+        Settings(MCP_SERVERS=servers)
 
 
-def test_settings_rejects_blank_mcp_server_identity():
+def test_mcp_server_settings_rejects_blank_identity():
     with pytest.raises(ValidationError):
-        Settings(
-            MCP_SERVERS=[
-                McpServerSettings(
-                    name="   ",
-                    url="https://search-mcp:8808/mcp",
-                    transport="streamable_http",
-                ),
-            ],
+        McpServerSettings(
+            name="   ",
+            url="https://search-mcp:8808/mcp",
+            transport="streamable_http",
         )
 
 

--- a/api/tests/test_mcp_settings.py
+++ b/api/tests/test_mcp_settings.py
@@ -2,10 +2,11 @@ import json
 from dataclasses import dataclass
 
 import pytest
+from anyio import lowlevel
 from pydantic import ValidationError
 
 from app.llms import mcp
-from app.utils.settings import Settings
+from app.utils.settings import McpServerSettings, Settings
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,16 +51,16 @@ def test_settings_rejects_duplicate_mcp_server_names():
     with pytest.raises(ValidationError, match="unique names"):
         Settings(
             MCP_SERVERS=[
-                {
-                    "name": "search",
-                    "url": "https://search-mcp:8808/mcp",
-                    "transport": "streamable_http",
-                },
-                {
-                    "name": "search",
-                    "url": "https://other-mcp:8808/mcp",
-                    "transport": "streamable_http",
-                },
+                McpServerSettings(
+                    name="search",
+                    url="https://search-mcp:8808/mcp",
+                    transport="streamable_http",
+                ),
+                McpServerSettings(
+                    name="search",
+                    url="https://other-mcp:8808/mcp",
+                    transport="streamable_http",
+                ),
             ],
         )
 
@@ -68,11 +69,11 @@ def test_settings_rejects_blank_mcp_server_identity():
     with pytest.raises(ValidationError):
         Settings(
             MCP_SERVERS=[
-                {
-                    "name": "   ",
-                    "url": "https://search-mcp:8808/mcp",
-                    "transport": "streamable_http",
-                },
+                McpServerSettings(
+                    name="   ",
+                    url="https://search-mcp:8808/mcp",
+                    transport="streamable_http",
+                ),
             ],
         )
 
@@ -81,12 +82,12 @@ def test_insecure_secret_names_include_default_structured_mcp_key():
     settings = Settings(
         API_KEY="custom-api-key",
         MCP_SERVERS=[
-            {
-                "name": "local",
-                "url": "https://local-mcp:8808/mcp",
-                "transport": "streamable_http",
-                "api_key": " SystemPass ",
-            },
+            McpServerSettings(
+                name="local",
+                url="https://local-mcp:8808/mcp",
+                transport="streamable_http",
+                api_key=" SystemPass ",
+            ),
         ],
     )
 
@@ -106,17 +107,17 @@ def test_build_mcp_client_uses_per_server_headers(monkeypatch):
         "settings",
         Settings(
             MCP_SERVERS=[
-                {
-                    "name": "search",
-                    "url": "https://search-mcp:8808/mcp",
-                    "transport": "streamable_http",
-                    "api_key": "search-key",
-                },
-                {
-                    "name": "events",
-                    "url": "https://events-mcp:8808/sse",
-                    "transport": "sse",
-                },
+                McpServerSettings(
+                    name="search",
+                    url="https://search-mcp:8808/mcp",
+                    transport="streamable_http",
+                    api_key="search-key",
+                ),
+                McpServerSettings(
+                    name="events",
+                    url="https://events-mcp:8808/sse",
+                    transport="sse",
+                ),
             ],
         ),
     )
@@ -163,19 +164,19 @@ async def test_get_mcp_tools_filters_each_server(monkeypatch):
         "settings",
         Settings(
             MCP_SERVERS=[
-                {
-                    "name": "search",
-                    "url": "https://search-mcp:8808/mcp",
-                    "transport": "streamable_http",
-                    "allowed_tools": ["web_search", "web_fetch"],
-                    "blocked_tools": ["web_fetch"],
-                },
-                {
-                    "name": "records",
-                    "url": "https://records-mcp:8808/mcp",
-                    "transport": "streamable_http",
-                    "blocked_tools": ["delete_record"],
-                },
+                McpServerSettings(
+                    name="search",
+                    url="https://search-mcp:8808/mcp",
+                    transport="streamable_http",
+                    allowed_tools=("web_search", "web_fetch"),
+                    blocked_tools=("web_fetch",),
+                ),
+                McpServerSettings(
+                    name="records",
+                    url="https://records-mcp:8808/mcp",
+                    transport="streamable_http",
+                    blocked_tools=("delete_record",),
+                ),
             ],
         ),
     )
@@ -193,6 +194,7 @@ async def test_get_mcp_tools_keeps_healthy_servers_when_one_server_fails(monkeyp
 
     class FakeClient:
         async def get_tools(self, *, server_name=None):
+            await lowlevel.checkpoint()
             if server_name == "broken":
                 raise OSError("TLS certificate verification failed")
             return [ToolStub("lookup")]
@@ -211,16 +213,16 @@ async def test_get_mcp_tools_keeps_healthy_servers_when_one_server_fails(monkeyp
         "settings",
         Settings(
             MCP_SERVERS=[
-                {
-                    "name": "local",
-                    "url": "https://local-mcp:8808/mcp",
-                    "transport": "streamable_http",
-                },
-                {
-                    "name": "broken",
-                    "url": "https://broken-mcp:8808/sse",
-                    "transport": "sse",
-                },
+                McpServerSettings(
+                    name="local",
+                    url="https://local-mcp:8808/mcp",
+                    transport="streamable_http",
+                ),
+                McpServerSettings(
+                    name="broken",
+                    url="https://broken-mcp:8808/sse",
+                    transport="sse",
+                ),
             ],
         ),
     )
@@ -275,12 +277,12 @@ async def test_get_mcp_tools_caches_intentionally_empty_filter_result(monkeypatc
         "settings",
         Settings(
             MCP_SERVERS=[
-                {
-                    "name": "blocked",
-                    "url": "https://blocked-mcp:8808/mcp",
-                    "transport": "streamable_http",
-                    "blocked_tools": ["blocked_tool"],
-                },
+                McpServerSettings(
+                    name="blocked",
+                    url="https://blocked-mcp:8808/mcp",
+                    transport="streamable_http",
+                    blocked_tools=("blocked_tool",),
+                ),
             ],
         ),
     )

--- a/api/tests/test_mcp_settings.py
+++ b/api/tests/test_mcp_settings.py
@@ -188,6 +188,58 @@ async def test_get_mcp_tools_filters_each_server(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_get_mcp_tools_keeps_healthy_servers_when_one_server_fails(monkeypatch):
+    captured = []
+
+    class FakeClient:
+        async def get_tools(self, *, server_name=None):
+            if server_name == "broken":
+                raise OSError("TLS certificate verification failed")
+            return [ToolStub("lookup")]
+
+    def build_fake_client():
+        return FakeClient()
+
+    monkeypatch.setattr(mcp, "build_mcp_client", build_fake_client)
+    monkeypatch.setattr(
+        mcp,
+        "capture",
+        lambda distinct_id, event, props: captured.append((distinct_id, event, props)),
+    )
+    monkeypatch.setattr(
+        mcp,
+        "settings",
+        Settings(
+            MCP_SERVERS=[
+                {
+                    "name": "local",
+                    "url": "https://local-mcp:8808/mcp",
+                    "transport": "streamable_http",
+                },
+                {
+                    "name": "broken",
+                    "url": "https://broken-mcp:8808/sse",
+                    "transport": "sse",
+                },
+            ],
+        ),
+    )
+    monkeypatch.setattr(mcp, "mcp_tools", None)
+    monkeypatch.setattr(mcp, "mcp_tools_fetched_at", 0.0)
+
+    tools = await mcp.get_mcp_tools()
+
+    assert [tool.name for tool in tools] == ["lookup"]
+    assert captured == [
+        (
+            "server",
+            "mcp_server_tool_loading_failed",
+            {"server_name": "broken", "transport": "sse", "error_type": "OSError"},
+        ),
+    ]
+
+
+@pytest.mark.anyio
 async def test_get_mcp_tools_caches_empty_list_when_no_servers(monkeypatch):
     def fail_build_client():
         msg = "MCP client should not be built without configured servers"


### PR DESCRIPTION
## Summary
- skip only the MCP server that fails during tool discovery
- emit a PostHog event when a server is skipped
- keep healthy MCP server tools available and cached

## Verification
- uv run pytest tests/test_mcp_settings.py tests/test_recommendation_tools.py -q
- uv run ruff check app/llms/mcp.py tests/test_mcp_settings.py
- uv run mypy app/llms/mcp.py tests/test_mcp_settings.py