### PR TITLE
fix(web): remove outdated local storage disclaimer

### DIFF
--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -13,7 +13,7 @@ export const messages = {
   'composer.apiKeyRequired': 'Потребен е API клуч',
   'composer.credentialsError': 'API клучевите се недостапни',
   'composer.disclaimer':
-    'ФИНКИ Хаб може да направи грешки. Проверете важни информации. Разговорите се чуваат само локално на вашиот уред.',
+    'ФИНКИ Хаб може да направи грешки. Проверете важни информации.',
   'composer.message': 'Порака',
   'composer.model': 'Модел',
   'composer.modelsError': 'Моделите се недостапни',


### PR DESCRIPTION
## Summary
- remove the outdated claim that conversations are stored only on the local device
- retain the existing accuracy disclaimer in the composer

## Verification
- npm run check
- npm run lint (0 errors; 13 pre-existing warnings)
- npm test (327 tests passed)
- npm run build (with local placeholder server env vars)
- browser QA at 375px, 768px, and 1280px