### PR TITLE
fix(web): prevent chat switch welcome flicker

### DIFF
--- a/web/lib/use-conversation-chat-runtime.ts
+++ b/web/lib/use-conversation-chat-runtime.ts
@@ -131,6 +131,10 @@ export const useConversationChatRuntime = ({
       resume: activeId !== null,
       transport,
     });
+  const activeStreamConversationIdRef = useRef<null | string>(null);
+  if (activeId !== null && status !== 'ready') {
+    activeStreamConversationIdRef.current = activeId;
+  }
   const sendMessageRef = useRef(sendMessage);
   sendMessageRef.current = sendMessage;
 
@@ -143,6 +147,7 @@ export const useConversationChatRuntime = ({
 
   const hydratingConversation = useConversationHydration({
     activeId,
+    activeStreamConversationIdRef,
     convoIdRef,
     preserveEmptyHydrationIdRef,
     setActiveError,

--- a/web/lib/use-conversation-chat-runtime.ts
+++ b/web/lib/use-conversation-chat-runtime.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { useMemo, useRef, useState } from 'react';
+import { type RefObject, useMemo, useRef, useState } from 'react';
 
 import type { ErrorNotice, MyUIMessage, StatusPart } from '@/lib/api-types';
 
@@ -18,6 +18,7 @@ import { useStreamTiming } from '@/lib/use-stream-timing';
 type UseConversationChatRuntimeOptions = {
   readonly activeId: null | string;
   readonly model: string;
+  readonly preserveEmptyHydrationIdRef: RefObject<null | string>;
   readonly reasoning: boolean;
   readonly refreshConversations: () => Promise<void>;
   readonly setActiveId: (id: null | string) => void;
@@ -26,6 +27,7 @@ type UseConversationChatRuntimeOptions = {
 export const useConversationChatRuntime = ({
   activeId,
   model,
+  preserveEmptyHydrationIdRef,
   reasoning,
   refreshConversations,
   setActiveId,
@@ -139,9 +141,10 @@ export const useConversationChatRuntime = ({
     status,
   });
 
-  useConversationHydration({
+  const hydratingConversation = useConversationHydration({
     activeId,
     convoIdRef,
+    preserveEmptyHydrationIdRef,
     setActiveError,
     setActiveId,
     setActiveStatus,
@@ -152,6 +155,7 @@ export const useConversationChatRuntime = ({
     activeError,
     activeStatus,
     convoIdRef,
+    hydratingConversation,
     messages,
     modelRef,
     regenerate,

--- a/web/lib/use-conversation-hydration.ts
+++ b/web/lib/use-conversation-hydration.ts
@@ -1,6 +1,12 @@
 'use client';
 
-import { type RefObject, type SetStateAction, useEffect } from 'react';
+import {
+  type RefObject,
+  type SetStateAction,
+  useEffect,
+  useLayoutEffect,
+  useState,
+} from 'react';
 
 import type { ErrorNotice, MyUIMessage } from '@/lib/api-types';
 
@@ -10,6 +16,7 @@ import { loadChatConversationHistory } from '@/lib/transport';
 type UseConversationHydrationOptions = {
   readonly activeId: null | string;
   readonly convoIdRef: RefObject<null | string>;
+  readonly preserveEmptyHydrationIdRef: RefObject<null | string>;
   readonly setActiveError: (value: ErrorNotice | undefined) => void;
   readonly setActiveId: (id: null | string) => void;
   readonly setActiveStatus: (
@@ -21,11 +28,18 @@ type UseConversationHydrationOptions = {
 export const useConversationHydration = ({
   activeId,
   convoIdRef,
+  preserveEmptyHydrationIdRef,
   setActiveError,
   setActiveId,
   setActiveStatus,
   setMessages,
-}: UseConversationHydrationOptions): void => {
+}: UseConversationHydrationOptions): boolean => {
+  const [hydratingId, setHydratingId] = useState<null | string>(null);
+
+  useLayoutEffect(() => {
+    setHydratingId(activeId);
+  }, [activeId]);
+
   useEffect(() => {
     convoIdRef.current = activeId;
     setActiveError(undefined);
@@ -34,27 +48,45 @@ export const useConversationHydration = ({
     const isCancelled = (): boolean => cancelled;
 
     const hydrate = async (id: string): Promise<void> => {
-      const serverHistory = await loadChatConversationHistory(id);
-      if (serverHistory !== null) {
-        if (!isCancelled()) {
-          setMessages((current) =>
-            serverHistory.messages.length === 0 && current.length > 0
-              ? current
-              : [...serverHistory.messages],
-          );
+      try {
+        const serverHistory = await loadChatConversationHistory(id);
+        if (serverHistory !== null) {
+          if (!isCancelled()) {
+            setMessages((current) =>
+              serverHistory.messages.length === 0 &&
+              current.length > 0 &&
+              preserveEmptyHydrationIdRef.current === id
+                ? current
+                : [...serverHistory.messages],
+            );
+            preserveEmptyHydrationIdRef.current = null;
+          }
+          return;
         }
-        return;
-      }
 
-      if (!isCancelled()) {
-        setActiveId(null);
-        setMessages([]);
+        if (!isCancelled()) {
+          preserveEmptyHydrationIdRef.current = null;
+          setActiveId(null);
+          setMessages([]);
+        }
+      } catch {
+        if (!isCancelled()) {
+          preserveEmptyHydrationIdRef.current = null;
+          setActiveId(null);
+          setMessages([]);
+        }
+      } finally {
+        if (!isCancelled()) {
+          setHydratingId((current) => (current === id ? null : current));
+        }
       }
     };
 
     if (activeId) {
       fireAndForget(hydrate(activeId));
     } else {
+      preserveEmptyHydrationIdRef.current = null;
+      setHydratingId(null);
       setMessages([]);
     }
 
@@ -64,9 +96,12 @@ export const useConversationHydration = ({
   }, [
     activeId,
     convoIdRef,
+    preserveEmptyHydrationIdRef,
     setActiveError,
     setActiveId,
     setActiveStatus,
     setMessages,
   ]);
+
+  return activeId !== null && hydratingId === activeId;
 };

--- a/web/lib/use-conversation-hydration.ts
+++ b/web/lib/use-conversation-hydration.ts
@@ -15,6 +15,7 @@ import { loadChatConversationHistory } from '@/lib/transport';
 
 type UseConversationHydrationOptions = {
   readonly activeId: null | string;
+  readonly activeStreamConversationIdRef: RefObject<null | string>;
   readonly convoIdRef: RefObject<null | string>;
   readonly preserveEmptyHydrationIdRef: RefObject<null | string>;
   readonly setActiveError: (value: ErrorNotice | undefined) => void;
@@ -27,6 +28,7 @@ type UseConversationHydrationOptions = {
 
 export const useConversationHydration = ({
   activeId,
+  activeStreamConversationIdRef,
   convoIdRef,
   preserveEmptyHydrationIdRef,
   setActiveError,
@@ -46,6 +48,16 @@ export const useConversationHydration = ({
     setActiveStatus(undefined);
     let cancelled = false;
     const isCancelled = (): boolean => cancelled;
+    const clearPreserveMarker = (id: string): void => {
+      if (preserveEmptyHydrationIdRef.current === id) {
+        preserveEmptyHydrationIdRef.current = null;
+      }
+    };
+    const clearActiveStreamMarker = (id: string): void => {
+      if (activeStreamConversationIdRef.current === id) {
+        activeStreamConversationIdRef.current = null;
+      }
+    };
 
     const hydrate = async (id: string): Promise<void> => {
       try {
@@ -55,23 +67,27 @@ export const useConversationHydration = ({
             setMessages((current) =>
               serverHistory.messages.length === 0 &&
               current.length > 0 &&
-              preserveEmptyHydrationIdRef.current === id
+              (preserveEmptyHydrationIdRef.current === id ||
+                activeStreamConversationIdRef.current === id)
                 ? current
                 : [...serverHistory.messages],
             );
-            preserveEmptyHydrationIdRef.current = null;
+            clearPreserveMarker(id);
+            clearActiveStreamMarker(id);
           }
           return;
         }
 
         if (!isCancelled()) {
-          preserveEmptyHydrationIdRef.current = null;
+          clearPreserveMarker(id);
+          clearActiveStreamMarker(id);
           setActiveId(null);
           setMessages([]);
         }
       } catch {
         if (!isCancelled()) {
-          preserveEmptyHydrationIdRef.current = null;
+          clearPreserveMarker(id);
+          clearActiveStreamMarker(id);
           setActiveId(null);
           setMessages([]);
         }
@@ -94,6 +110,7 @@ export const useConversationHydration = ({
       cancelled = true;
     };
   }, [
+    activeStreamConversationIdRef,
     activeId,
     convoIdRef,
     preserveEmptyHydrationIdRef,

--- a/web/lib/use-conversation-management.ts
+++ b/web/lib/use-conversation-management.ts
@@ -129,7 +129,6 @@ export const useConversationManagement = ({
 
   const handleSelect = useCallback(
     (id: string) => {
-      preserveEmptyHydrationIdRef.current = null;
       if (id !== convoIdRef.current && status !== 'ready') {
         fireAndForget(
           (async () => {
@@ -143,7 +142,7 @@ export const useConversationManagement = ({
       convoIdRef.current = id;
       setActiveId(id);
     },
-    [convoIdRef, handleStop, preserveEmptyHydrationIdRef, setActiveId, status],
+    [convoIdRef, handleStop, setActiveId, status],
   );
 
   const deleteConversationEverywhere = useCallback(

--- a/web/lib/use-conversation-management.ts
+++ b/web/lib/use-conversation-management.ts
@@ -29,6 +29,7 @@ type UseConversationManagementOptions = {
   readonly convoIdRef: RefObject<null | string>;
   readonly handleStop: (order?: StopOrder) => Promise<void>;
   readonly model: string;
+  readonly preserveEmptyHydrationIdRef: RefObject<null | string>;
   readonly refreshConversations: () => Promise<void>;
   readonly sendMessageRef: RefObject<(message: MyUIMessage) => Promise<void>>;
   readonly setActiveError: Dispatch<SetStateAction<ErrorNotice | undefined>>;
@@ -42,6 +43,7 @@ export const useConversationManagement = ({
   convoIdRef,
   handleStop,
   model,
+  preserveEmptyHydrationIdRef,
   refreshConversations,
   sendMessageRef,
   setActiveError,
@@ -50,11 +52,18 @@ export const useConversationManagement = ({
   status,
 }: UseConversationManagementOptions) => {
   const resetActiveConversation = useCallback(() => {
+    preserveEmptyHydrationIdRef.current = null;
     setActiveId(null);
     setMessages([]);
     setActiveError(undefined);
     convoIdRef.current = null;
-  }, [convoIdRef, setActiveError, setActiveId, setMessages]);
+  }, [
+    convoIdRef,
+    preserveEmptyHydrationIdRef,
+    setActiveError,
+    setActiveId,
+    setMessages,
+  ]);
 
   const handleNewChat = useCallback(() => {
     if (status !== 'ready') {
@@ -86,6 +95,7 @@ export const useConversationManagement = ({
         });
         // eslint-disable-next-line require-atomic-updates -- fresh id, not a read-modify-write race
         convoIdRef.current = cid;
+        preserveEmptyHydrationIdRef.current = cid;
         flushSync(() => {
           setActiveId(cid);
         });
@@ -109,6 +119,7 @@ export const useConversationManagement = ({
       applyGeneratedTitle,
       convoIdRef,
       model,
+      preserveEmptyHydrationIdRef,
       refreshConversations,
       sendMessageRef,
       setActiveError,
@@ -118,22 +129,21 @@ export const useConversationManagement = ({
 
   const handleSelect = useCallback(
     (id: string) => {
+      preserveEmptyHydrationIdRef.current = null;
       if (id !== convoIdRef.current && status !== 'ready') {
         fireAndForget(
           (async () => {
             await handleStop('local-first');
             convoIdRef.current = id;
-            setMessages([]);
             setActiveId(id);
           })(),
         );
         return;
       }
       convoIdRef.current = id;
-      setMessages([]);
       setActiveId(id);
     },
-    [convoIdRef, handleStop, setActiveId, setMessages, status],
+    [convoIdRef, handleStop, preserveEmptyHydrationIdRef, setActiveId, status],
   );
 
   const deleteConversationEverywhere = useCallback(

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 
-import type { FeedbackType } from '@/lib/api-types';
+import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
 
 import { fireAndForget } from '@/lib/async';
 import { renderAnswerActions } from '@/lib/conversation-actions';
@@ -24,12 +24,14 @@ export const useConversations = (
 ) => {
   const activeId = useUiStore((s) => s.activeConversationId);
   const setActiveId = useUiStore((s) => s.setActiveConversationId);
+  const preserveEmptyHydrationIdRef = useRef<null | string>(null);
 
   const { conversations, refreshConversations } = useConversationList();
   const {
     activeError,
     activeStatus,
     convoIdRef,
+    hydratingConversation,
     messages,
     modelRef,
     regenerate,
@@ -45,6 +47,7 @@ export const useConversations = (
   } = useConversationChatRuntime({
     activeId,
     model,
+    preserveEmptyHydrationIdRef,
     reasoning,
     refreshConversations,
     setActiveId,
@@ -64,6 +67,7 @@ export const useConversations = (
     convoIdRef,
     handleStop,
     model,
+    preserveEmptyHydrationIdRef,
     refreshConversations,
     sendMessageRef,
     setActiveError,
@@ -108,7 +112,15 @@ export const useConversations = (
     [setMessages],
   );
 
-  const visibleMessages = previewRegeneration(messages, regeneratingMessageId);
+  const lastNonEmptyMessagesRef = useRef<readonly MyUIMessage[]>([]);
+  const previewMessages = previewRegeneration(messages, regeneratingMessageId);
+  if (previewMessages.length > 0) {
+    lastNonEmptyMessagesRef.current = previewMessages;
+  }
+  const visibleMessages =
+    hydratingConversation && previewMessages.length === 0
+      ? [...lastNonEmptyMessagesRef.current]
+      : previewMessages;
   const renderActions = renderAnswerActions({
     disabled,
     messages: visibleMessages,

--- a/web/lib/use-stop-chat.ts
+++ b/web/lib/use-stop-chat.ts
@@ -43,13 +43,10 @@ export const useStopChat = ({
 
       const stopCurrent = async (): Promise<void> => {
         const stopResult = Promise.resolve(stop());
-        const stopServerAfterLocalStop = async (): Promise<void> => {
-          await stopResult;
-          await stopServer();
-        };
 
         if (order === 'local-first') {
-          fireAndForget(stopServerAfterLocalStop());
+          await stopResult;
+          fireAndForget(stopServer());
           return;
         }
 

--- a/web/test/conversation-stop-order.test.tsx
+++ b/web/test/conversation-stop-order.test.tsx
@@ -1,0 +1,80 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MyUIMessage } from '@/lib/api-types';
+
+import { useUiStore } from '@/lib/ui-store';
+import { useConversations } from '@/lib/use-conversations';
+
+const chatState = { status: 'streaming' };
+const localStop = vi.fn<() => Promise<void> | void>();
+const stopChatStream =
+  vi.fn<(id: string, snapshot?: unknown) => Promise<void>>();
+
+vi.mock('@ai-sdk/react', () => ({
+  useChat: () => ({
+    messages: [] as MyUIMessage[],
+    regenerate: () => Promise.resolve(),
+    sendMessage: () => Promise.resolve(),
+    setMessages: () => null,
+    status: chatState.status,
+    stop: localStop,
+  }),
+}));
+
+vi.mock('posthog-js', () => ({
+  posthog: { capture: () => null },
+}));
+
+vi.mock('@/lib/transport', () => ({
+  buildChatTransport: () => ({}),
+  deleteChatConversation: () => Promise.resolve(),
+  saveChatConversation: () => Promise.resolve(),
+  stopChatStream: (id: string, snapshot?: unknown) =>
+    stopChatStream(id, snapshot),
+}));
+
+vi.mock('@/lib/use-conversation-hydration', () => ({
+  useConversationHydration: () => false,
+}));
+
+vi.mock('@/lib/use-conversation-list', () => ({
+  useConversationList: () => ({
+    conversations: [],
+    refreshConversations: () => Promise.resolve(),
+  }),
+}));
+
+describe('conversation stop order', () => {
+  beforeEach(() => {
+    chatState.status = 'streaming';
+    localStop.mockReset();
+    stopChatStream.mockReset();
+    stopChatStream.mockResolvedValue();
+    useUiStore.setState({ activeConversationId: 'conv-a', model: 'model-a' });
+  });
+
+  it('waits for local stop before selecting another streaming conversation', async () => {
+    let resolveLocalStop: (() => void) | undefined;
+    const localStopReleased = new Promise<void>((resolve) => {
+      resolveLocalStop = resolve;
+    });
+    localStop.mockReturnValue(localStopReleased);
+    const { result } = renderHook(() => useConversations('model-a'));
+
+    act(() => {
+      result.current.onSelect('conv-b');
+    });
+
+    expect(useUiStore.getState().activeConversationId).toBe('conv-a');
+
+    if (resolveLocalStop === undefined) {
+      throw new Error('Local stop resolver was not captured');
+    }
+    resolveLocalStop();
+
+    await waitFor(() => {
+      expect(useUiStore.getState().activeConversationId).toBe('conv-b');
+    });
+  });
+});

--- a/web/test/conversation-switch-runtime.test.tsx
+++ b/web/test/conversation-switch-runtime.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MyUIMessage } from '@/lib/api-types';
+
+import { Thread } from '@/components/chat/thread';
+import { useUiStore } from '@/lib/ui-store';
+import { useConversations } from '@/lib/use-conversations';
+
+type UseChatOptions = {
+  readonly id?: string;
+};
+
+const previousMessage: MyUIMessage = {
+  id: 'message-a',
+  metadata: {},
+  parts: [{ text: 'Conversation A', type: 'text' }],
+  role: 'user',
+};
+
+vi.mock('@ai-sdk/react', () => ({
+  useChat: (options: UseChatOptions) => ({
+    messages: options.id === 'conversation-b' ? [] : [previousMessage],
+    regenerate: () => Promise.resolve(),
+    sendMessage: () => Promise.resolve(),
+    setMessages: () => null,
+    status: 'ready',
+    stop: () => null,
+  }),
+}));
+
+vi.mock('@/lib/transport', () => ({
+  buildChatTransport: () => ({}),
+  deleteChatConversation: () => Promise.resolve(),
+  saveChatConversation: () => Promise.resolve(),
+  stopChatStream: () => Promise.resolve(),
+}));
+
+vi.mock('@/lib/use-conversation-hydration', () => ({
+  useConversationHydration: () => true,
+}));
+
+vi.mock('@/lib/use-conversation-list', () => ({
+  useConversationList: () => ({
+    conversations: [],
+    refreshConversations: () => Promise.resolve(),
+  }),
+}));
+
+const RuntimeSwitchHarness = () => {
+  const { messages, onSelect, status } = useConversations('model-a');
+
+  return (
+    <>
+      <button
+        onClick={() => {
+          onSelect('conversation-b');
+        }}
+        type="button"
+      >
+        Select conversation B
+      </button>
+      <Thread
+        messages={messages}
+        status={status}
+      />
+    </>
+  );
+};
+
+describe('conversation switch runtime', () => {
+  it('keeps previous messages visible while the selected chat runtime is empty and hydrating', () => {
+    useUiStore.setState({ activeConversationId: 'conversation-a' });
+    render(<RuntimeSwitchHarness />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Select conversation B' }),
+    );
+
+    expect(screen.queryByText('Започни разговор')).not.toBeInTheDocument();
+    expect(screen.getByText('Conversation A')).toBeInTheDocument();
+  });
+});

--- a/web/test/conversation-switch-runtime.test.tsx
+++ b/web/test/conversation-switch-runtime.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { MyUIMessage } from '@/lib/api-types';
 
@@ -69,6 +69,15 @@ const RuntimeSwitchHarness = () => {
 };
 
 describe('conversation switch runtime', () => {
+  beforeEach(() => {
+    useUiStore.setState({
+      activeConversationId: null,
+      model: 'model-a',
+      reasoning: false,
+      sidebarOpen: false,
+    });
+  });
+
   it('keeps previous messages visible while the selected chat runtime is empty and hydrating', () => {
     useUiStore.setState({ activeConversationId: 'conversation-a' });
     render(<RuntimeSwitchHarness />);

--- a/web/test/conversation-switch.test.tsx
+++ b/web/test/conversation-switch.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useRef, useState } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import type { MyUIMessage } from '@/lib/api-types';
+
+import { Thread } from '@/components/chat/thread';
+import { useConversationManagement } from '@/lib/use-conversation-management';
+
+const previousMessage: MyUIMessage = {
+  id: 'message-a',
+  metadata: {},
+  parts: [{ text: 'Conversation A', type: 'text' }],
+  role: 'user',
+};
+
+const ConversationSwitchHarness = () => {
+  const [messages, setMessages] = useState<MyUIMessage[]>([previousMessage]);
+  const convoIdRef = useRef<null | string>('conversation-a');
+  const preserveEmptyHydrationIdRef = useRef<null | string>(null);
+  const { handleSelect } = useConversationManagement({
+    applyGeneratedTitle: () => Promise.resolve(),
+    convoIdRef,
+    handleStop: () => Promise.resolve(),
+    model: 'model-a',
+    preserveEmptyHydrationIdRef,
+    refreshConversations: () => Promise.resolve(),
+    sendMessageRef: useRef(() => Promise.resolve()),
+    setActiveError: () => null,
+    setActiveId: () => null,
+    setMessages,
+    status: 'ready',
+  });
+
+  return (
+    <>
+      <button
+        onClick={() => {
+          handleSelect('conversation-b');
+        }}
+        type="button"
+      >
+        Select conversation B
+      </button>
+      <Thread
+        messages={messages}
+        status="ready"
+      />
+    </>
+  );
+};
+
+describe('conversation switching', () => {
+  it('keeps the current thread visible until the selected conversation hydrates', () => {
+    render(<ConversationSwitchHarness />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Select conversation B' }),
+    );
+
+    expect(screen.queryByText('Започни разговор')).not.toBeInTheDocument();
+    expect(screen.getByText('Conversation A')).toBeInTheDocument();
+  });
+});

--- a/web/test/use-conversation-hydration.test.tsx
+++ b/web/test/use-conversation-hydration.test.tsx
@@ -29,8 +29,10 @@ const message = (id: string, text: string): MyUIMessage => ({
 });
 
 const useHydratedMessages = ({
+  activeStreamConversationId,
   preserveEmptyHydrationId,
 }: {
+  readonly activeStreamConversationId?: string;
   readonly preserveEmptyHydrationId?: string;
 } = {}): MyUIMessage[] => {
   const [messages, setMessages] = useState<MyUIMessage[]>(() => [
@@ -39,6 +41,9 @@ const useHydratedMessages = ({
   const convoIdRef = useRef<null | string>(null);
   const preserveEmptyHydrationIdRef = useRef<null | string>(
     preserveEmptyHydrationId ?? null,
+  );
+  const activeStreamConversationIdRef = useRef<null | string>(
+    activeStreamConversationId ?? null,
   );
   const setActiveError = useRef(
     vi.fn<(value: ErrorNotice | undefined) => void>(),
@@ -49,6 +54,7 @@ const useHydratedMessages = ({
   ).current;
   useConversationHydration({
     activeId: 'conversation-b',
+    activeStreamConversationIdRef,
     convoIdRef,
     preserveEmptyHydrationIdRef,
     setActiveError,
@@ -100,6 +106,21 @@ describe('useConversationHydration', () => {
 
     const { result } = renderHook(() =>
       useHydratedMessages({ preserveEmptyHydrationId: 'conversation-b' }),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0]?.id).toBe('previous-a');
+    });
+  });
+
+  it('preserves resumed stream messages when server history is still empty', async () => {
+    transportMocks.loadChatConversationHistory.mockResolvedValue({
+      messages: [],
+    });
+
+    const { result } = renderHook(() =>
+      useHydratedMessages({ activeStreamConversationId: 'conversation-b' }),
     );
 
     await waitFor(() => {

--- a/web/test/use-conversation-hydration.test.tsx
+++ b/web/test/use-conversation-hydration.test.tsx
@@ -28,17 +28,32 @@ const message = (id: string, text: string): MyUIMessage => ({
   role: 'user',
 });
 
-const useHydratedMessages = (): MyUIMessage[] => {
+const useHydratedMessages = ({
+  preserveEmptyHydrationId,
+}: {
+  readonly preserveEmptyHydrationId?: string;
+} = {}): MyUIMessage[] => {
   const [messages, setMessages] = useState<MyUIMessage[]>(() => [
     message('previous-a', 'Conversation A'),
   ]);
   const convoIdRef = useRef<null | string>(null);
+  const preserveEmptyHydrationIdRef = useRef<null | string>(
+    preserveEmptyHydrationId ?? null,
+  );
+  const setActiveError = useRef(
+    vi.fn<(value: ErrorNotice | undefined) => void>(),
+  ).current;
+  const setActiveId = useRef(vi.fn<(id: null | string) => void>()).current;
+  const setActiveStatus = useRef(
+    vi.fn<(value: ActiveStatus) => void>(),
+  ).current;
   useConversationHydration({
     activeId: 'conversation-b',
     convoIdRef,
-    setActiveError: vi.fn<(value: ErrorNotice | undefined) => void>(),
-    setActiveId: vi.fn<(id: null | string) => void>(),
-    setActiveStatus: vi.fn<(value: ActiveStatus) => void>(),
+    preserveEmptyHydrationIdRef,
+    setActiveError,
+    setActiveId,
+    setActiveStatus,
     setMessages,
   });
 
@@ -64,5 +79,44 @@ describe('useConversationHydration', () => {
     expect(transportMocks.loadChatConversationHistory).toHaveBeenCalledWith(
       'conversation-b',
     );
+  });
+
+  it('clears previous messages when the selected server conversation is empty', async () => {
+    transportMocks.loadChatConversationHistory.mockResolvedValue({
+      messages: [],
+    });
+
+    const { result } = renderHook(useHydratedMessages);
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(0);
+    });
+  });
+
+  it('preserves local messages when a locally created conversation has not saved history yet', async () => {
+    transportMocks.loadChatConversationHistory.mockResolvedValue({
+      messages: [],
+    });
+
+    const { result } = renderHook(() =>
+      useHydratedMessages({ preserveEmptyHydrationId: 'conversation-b' }),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0]?.id).toBe('previous-a');
+    });
+  });
+
+  it('clears previous messages when selected conversation history rejects', async () => {
+    transportMocks.loadChatConversationHistory.mockRejectedValue(
+      new Error('network failed'),
+    );
+
+    const { result } = renderHook(useHydratedMessages);
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- keep the previous non-empty thread visible while an existing selected conversation is hydrating
- preserve empty hydration only for newly-created local conversations, while real empty or failed server histories clear stale messages
- wait for local stop before switching active conversations during streaming

## Verification
- npm run check
- npm run lint (13 warnings, 0 errors; warning count matches baseline)
- npm run test (56 files, 333 tests)
- npm run build with dev env values
- Playwright manual QA: delayed second-chat history produced no welcome-screen flicker, old message stayed visible until the new message rendered, console errors 0