### PR TITLE
feat(chat): persist assistant message parts

### DIFF
--- a/api/app/api/chat_state.py
+++ b/api/app/api/chat_state.py
@@ -295,6 +295,7 @@ async def upsert_user_message_state(
                 role=ChatMessageRole.USER,
                 content=payload.content,
                 metadata=payload.metadata,
+                parts=payload.parts,
             ),
         )
     except ChatMessageConflictError as error:
@@ -322,6 +323,7 @@ async def upsert_assistant_message_state(
             content=payload.content,
             response_id=response_id,
             metadata=payload.metadata,
+            parts=payload.parts,
         ),
     )
 
@@ -352,6 +354,7 @@ async def replace_assistant_message_state(
             content=payload.content,
             response_id=response_id,
             metadata=payload.metadata,
+            parts=payload.parts,
         ),
         retained_message_ids=payload.retained_message_ids,
         user_id=payload.user_id,

--- a/api/app/data/chat_persistence.py
+++ b/api/app/data/chat_persistence.py
@@ -171,13 +171,14 @@ async def upsert_message(
 ) -> ChatMessage:
     row = await db.fetchrow(
         """
-        INSERT INTO chat_message (id, conversation_id, role, content, response_id, metadata)
-        VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+        INSERT INTO chat_message (id, conversation_id, role, content, response_id, metadata, parts)
+        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb)
         ON CONFLICT (id) DO UPDATE SET
             role = EXCLUDED.role,
             content = EXCLUDED.content,
             response_id = EXCLUDED.response_id,
             metadata = EXCLUDED.metadata,
+            parts = EXCLUDED.parts,
             updated_at = NOW()
         WHERE chat_message.conversation_id = EXCLUDED.conversation_id
         RETURNING *
@@ -188,6 +189,7 @@ async def upsert_message(
         message.content,
         message.response_id,
         json.dumps(message.metadata),
+        None if message.parts is None else json.dumps(message.parts),
     )
     if row is None:
         raise ChatMessageConflictError

--- a/api/app/data/chat_rows.py
+++ b/api/app/data/chat_rows.py
@@ -25,28 +25,26 @@ def metadata_from_row(value: object) -> dict[str, JsonValue]:
     return {str(key): json_value(item) for key, item in parsed.items()}
 
 
+def parts_from_row(value: object) -> list[JsonValue] | None:
+    parsed: object = json.loads(value) if isinstance(value, str) else value
+    if (
+        parsed is None
+        or not isinstance(parsed, Sequence)
+        or isinstance(
+            parsed,
+            str | bytes | bytearray,
+        )
+    ):
+        return None
+    return [json_value(item) for item in parsed]
+
+
 def conversation_from_row(row: Mapping[str, object]) -> ChatConversation:
-    return ChatConversation(
-        id=row["id"],
-        user_id=row["user_id"],
-        active_stream_id=row["active_stream_id"],
-        active_response_id=row["active_response_id"],
-        active_status=row["active_status"],
-        model=row["model"],
-        title=row["title"],
-        created_at=row["created_at"],
-        updated_at=row["updated_at"],
-    )
+    return ChatConversation.model_validate(dict(row))
 
 
 def message_from_row(row: Mapping[str, object]) -> ChatMessage:
-    return ChatMessage(
-        id=row["id"],
-        conversation_id=row["conversation_id"],
-        role=row["role"],
-        content=row["content"],
-        response_id=row["response_id"],
-        metadata=metadata_from_row(row["metadata"]),
-        created_at=row["created_at"],
-        updated_at=row["updated_at"],
-    )
+    values = dict(row)
+    values["metadata"] = metadata_from_row(row["metadata"])
+    values["parts"] = parts_from_row(row.get("parts"))
+    return ChatMessage.model_validate(values)

--- a/api/app/data/chat_state.py
+++ b/api/app/data/chat_state.py
@@ -16,13 +16,14 @@ async def upsert_assistant_message_by_response_id(
 ) -> ChatMessage:
     row = await db.fetchrow(
         """
-        INSERT INTO chat_message (id, conversation_id, role, content, response_id, metadata)
-        VALUES ($3, $1, 'assistant', $4, $2, $5::jsonb)
+        INSERT INTO chat_message (id, conversation_id, role, content, response_id, metadata, parts)
+        VALUES ($3, $1, 'assistant', $4, $2, $5::jsonb, $6::jsonb)
         ON CONFLICT (conversation_id, response_id)
         WHERE response_id IS NOT NULL AND role = 'assistant'
         DO UPDATE SET
             content = EXCLUDED.content,
             metadata = EXCLUDED.metadata,
+            parts = EXCLUDED.parts,
             updated_at = NOW()
         RETURNING *
         """,
@@ -31,6 +32,7 @@ async def upsert_assistant_message_by_response_id(
         message.id,
         message.content,
         json.dumps(message.metadata),
+        None if message.parts is None else json.dumps(message.parts),
     )
     if row is None:
         raise RuntimeError("assistant chat_message upsert returned no row")
@@ -60,6 +62,7 @@ async def replace_assistant_message_and_prune_after(
             SET content = $4,
                 response_id = $5,
                 metadata = $6::jsonb,
+                parts = $7::jsonb,
                 updated_at = NOW()
             FROM target
             WHERE assistant.id = target.id
@@ -69,7 +72,7 @@ async def replace_assistant_message_and_prune_after(
             USING target
             WHERE stale.conversation_id = target.conversation_id
               AND stale.created_at > target.created_at
-              AND NOT (stale.id = ANY($7::uuid[]))
+              AND NOT (stale.id = ANY($8::uuid[]))
             RETURNING stale.id
         )
         SELECT * FROM updated
@@ -80,6 +83,7 @@ async def replace_assistant_message_and_prune_after(
         message.content,
         message.response_id,
         json.dumps(message.metadata),
+        None if message.parts is None else json.dumps(message.parts),
         retained_message_ids,
     )
     return None if row is None else message_from_row(row)

--- a/api/app/schemas/chat_persistence.py
+++ b/api/app/schemas/chat_persistence.py
@@ -82,6 +82,7 @@ class ChatMessageUpsert(BaseModel):
     content: str = Field(min_length=1)
     response_id: UUID | None = None
     metadata: dict[str, JsonValue] = Field(default_factory=dict)
+    parts: list[JsonValue] | None = None
 
     @field_validator("content")
     @classmethod
@@ -99,6 +100,7 @@ class ChatMessage(BaseModel):
     content: str
     response_id: UUID | None = None
     metadata: dict[str, JsonValue]
+    parts: list[JsonValue] | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/api/app/schemas/chat_state.py
+++ b/api/app/schemas/chat_state.py
@@ -35,6 +35,7 @@ class UserMessageUpsertRequest(UserScopedRequest):
     id: UUID
     content: str = Field(min_length=1)
     metadata: dict[str, JsonValue] = Field(default_factory=dict)
+    parts: list[JsonValue] | None = None
 
     @field_validator("content")
     @classmethod
@@ -52,6 +53,7 @@ class AssistantMessageUpsertRequest(UserMessageUpsertRequest):
 class AssistantMessageReplacementRequest(UserScopedRequest):
     content: str = Field(min_length=1)
     metadata: dict[str, JsonValue] = Field(default_factory=dict)
+    parts: list[JsonValue] | None = None
     retained_message_ids: list[UUID] = Field(min_length=1)
 
     @field_validator("content")

--- a/api/resources/migrations/0005_add_chat_message_parts.sql
+++ b/api/resources/migrations/0005_add_chat_message_parts.sql
@@ -1,0 +1,2 @@
+ALTER TABLE chat_message
+ADD COLUMN IF NOT EXISTS parts JSONB;

--- a/api/tests/chat_persistence_fake.py
+++ b/api/tests/chat_persistence_fake.py
@@ -80,9 +80,10 @@ class FakeChatDatabase:
                 ]
                 question = max(prior_questions, key=self._created_at, default=None)
                 metadata = assistant["metadata"]
+                parsed = json.loads(metadata) if isinstance(metadata, str) else metadata
                 inference_model = None
-                if isinstance(metadata, dict):
-                    inference_model = metadata.get("inferenceModel")
+                if isinstance(parsed, dict):
+                    inference_model = parsed.get("inferenceModel")
                 return {
                     "answer_text": assistant["content"],
                     "inference_model": inference_model,
@@ -242,7 +243,14 @@ class FakeChatDatabase:
             return deleted
 
         if "ON CONFLICT (conversation_id, response_id)" in query:
-            conversation_id, response_id, message_id, content, metadata_json = args
+            (
+                conversation_id,
+                response_id,
+                message_id,
+                content,
+                metadata_json,
+                parts_json,
+            ) = args
             for existing in self.messages.values():
                 if (
                     existing["conversation_id"] == conversation_id
@@ -251,6 +259,7 @@ class FakeChatDatabase:
                 ):
                     existing["content"] = content
                     existing["metadata"] = metadata_json
+                    existing["parts"] = parts_json
                     existing["updated_at"] = self.now
                     return existing
             inserted_assistant = {
@@ -260,6 +269,7 @@ class FakeChatDatabase:
                 "content": content,
                 "response_id": response_id,
                 "metadata": metadata_json,
+                "parts": parts_json,
                 "created_at": self.now,
                 "updated_at": self.now,
             }
@@ -274,6 +284,7 @@ class FakeChatDatabase:
                 content,
                 response_id,
                 metadata_json,
+                parts_json,
                 retained_message_ids,
             ) = args
             target = self.messages.get(message_id)
@@ -298,15 +309,22 @@ class FakeChatDatabase:
             target["content"] = content
             target["response_id"] = response_id
             target["metadata"] = metadata_json
+            target["parts"] = parts_json
             target["updated_at"] = self.now
             for stale_id in stale_message_ids:
                 del self.messages[stale_id]
             return target
 
         if "INSERT INTO chat_message" in query:
-            message_id, conversation_id, role, content, response_id, metadata_json = (
-                args
-            )
+            (
+                message_id,
+                conversation_id,
+                role,
+                content,
+                response_id,
+                metadata_json,
+                parts_json,
+            ) = args
             current_message = self.messages.get(message_id)
             if current_message is None:
                 inserted_message = {
@@ -316,6 +334,7 @@ class FakeChatDatabase:
                     "content": content,
                     "response_id": response_id,
                     "metadata": metadata_json,
+                    "parts": parts_json,
                     "created_at": self.now,
                     "updated_at": self.now,
                 }
@@ -327,6 +346,7 @@ class FakeChatDatabase:
             current_message["content"] = content
             current_message["response_id"] = response_id
             current_message["metadata"] = metadata_json
+            current_message["parts"] = parts_json
             current_message["updated_at"] = self.now
             return current_message
 

--- a/api/tests/test_chat_persistence.py
+++ b/api/tests/test_chat_persistence.py
@@ -21,6 +21,7 @@ from app.schemas.chat_persistence import (
     ChatConversationUpdate,
     ChatMessageRole,
     ChatMessageUpsert,
+    JsonValue,
 )
 from tests.chat_persistence_fake import FakeChatDatabase
 
@@ -35,6 +36,10 @@ async def test_chat_persistence_happy_path_orders_messages_and_clears_current_st
     # Given: a new web chat conversation owned by one anonymous user.
     db = FakeChatDatabase()
     response_id = uuid4()
+    assistant_parts: list[JsonValue] = [
+        {"state": "done", "text": "Check the enrollment rules.", "type": "reasoning"},
+        {"state": "done", "text": "Submit the semester form.", "type": "text"},
+    ]
     conversation = await create_conversation(
         db,
         ChatConversationCreate(
@@ -72,6 +77,7 @@ async def test_chat_persistence_happy_path_orders_messages_and_clears_current_st
             content="Submit the semester form.",
             response_id=response_id,
             metadata={"responseId": str(response_id)},
+            parts=assistant_parts,
         ),
     )
     cleared = await clear_active_stream_if_current(
@@ -98,6 +104,7 @@ async def test_chat_persistence_happy_path_orders_messages_and_clears_current_st
         ChatMessageRole.ASSISTANT,
     ]
     assert loaded.messages[1].metadata == {"responseId": str(response_id)}
+    assert loaded.messages[1].parts == assistant_parts
 
 
 @pytest.mark.anyio
@@ -253,12 +260,14 @@ async def test_chat_persistence_rejects_message_id_collision_across_conversation
 def test_chat_persistence_rejects_malformed_role_and_status() -> None:
     # Given / When / Then: malformed boundary inputs never reach SQL.
     with pytest.raises(ValueError, match="Input should be"):
-        ChatMessageUpsert(
-            id=uuid4(),
-            conversation_id=uuid4(),
-            role="system",
-            content="bad",
+        ChatMessageUpsert.model_validate(
+            {
+                "content": "bad",
+                "conversation_id": uuid4(),
+                "id": uuid4(),
+                "role": "system",
+            },
         )
 
     with pytest.raises(ValueError, match="Input should be"):
-        ChatConversationUpdate(active_status="lost")
+        ChatConversationUpdate.model_validate({"active_status": "lost"})

--- a/api/tests/test_chat_state_api.py
+++ b/api/tests/test_chat_state_api.py
@@ -254,6 +254,10 @@ def test_chat_state_lifecycle_persists_messages_and_active_stream() -> None:
     assistant_message_id = uuid4()
     stream_id = uuid4()
     response_id = uuid4()
+    final_parts = [
+        {"state": "done", "text": "Check the rules.", "type": "reasoning"},
+        {"state": "done", "text": "Final answer", "type": "text"},
+    ]
 
     created = client.post(
         "/chat/state/conversations",
@@ -300,6 +304,7 @@ def test_chat_state_lifecycle_persists_messages_and_active_stream() -> None:
             "user_id": OWNER_ID,
             "content": "Final answer",
             "metadata": {"responseId": str(response_id), "done": True},
+            "parts": final_parts,
         },
     )
     loaded = client.get(
@@ -325,6 +330,7 @@ def test_chat_state_lifecycle_persists_messages_and_active_stream() -> None:
         "responseId": str(response_id),
         "done": True,
     }
+    assert body["messages"][1]["parts"] == final_parts
 
 
 def test_chat_state_wrong_user_cannot_load_or_mutate_state() -> None:
@@ -400,6 +406,10 @@ def test_chat_state_replaces_regenerated_assistant_and_prunes_later_messages() -
         json={
             "content": "New first answer",
             "metadata": {"responseId": str(new_response_id)},
+            "parts": [
+                {"state": "done", "text": "New reasoning", "type": "reasoning"},
+                {"state": "done", "text": "New first answer", "type": "text"},
+            ],
             "retained_message_ids": [str(first_user_id), str(first_assistant_id)],
             "user_id": OWNER_ID,
         },
@@ -421,6 +431,10 @@ def test_chat_state_replaces_regenerated_assistant_and_prunes_later_messages() -
         str(first_assistant_id),
     ]
     assert messages[2]["content"] == "New first answer"
+    assert messages[2]["parts"] == [
+        {"state": "done", "text": "New reasoning", "type": "reasoning"},
+        {"state": "done", "text": "New first answer", "type": "text"},
+    ]
     assert messages[2]["response_id"] == str(new_response_id)
 
 

--- a/api/tests/test_feedback_api.py
+++ b/api/tests/test_feedback_api.py
@@ -1,3 +1,4 @@
+import json
 from uuid import UUID, uuid4
 
 from fastapi.testclient import TestClient
@@ -50,7 +51,11 @@ def _seed_owned_response(db: FakeChatDatabase) -> tuple[UUID, UUID]:
         "conversation_id": conversation_id,
         "created_at": db.now,
         "id": uuid4(),
-        "metadata": {"inferenceModel": "server-model"},
+        "metadata": json.dumps({"inferenceModel": "server-model"}),
+        "parts": [
+            {"state": "done", "text": "Stored reasoning", "type": "reasoning"},
+            {"state": "done", "text": "Server answer", "type": "text"},
+        ],
         "response_id": response_id,
         "role": "assistant",
         "updated_at": db.now,
@@ -92,6 +97,10 @@ def test_web_feedback_uses_server_owned_message_context() -> None:
         "feedback": "like",
         "inferenceModel": "server-model",
     }
+    assert assistant["parts"] == [
+        {"state": "done", "text": "Stored reasoning", "type": "reasoning"},
+        {"state": "done", "text": "Server answer", "type": "text"},
+    ]
 
 
 def test_web_feedback_rejects_unowned_response_id() -> None:

--- a/api/tests/test_migrations.py
+++ b/api/tests/test_migrations.py
@@ -83,6 +83,17 @@ def test_chat_user_migration_allows_supported_auth_providers() -> None:
     assert "provider IN ('google', 'microsoft-entra-id')" in migration
 
 
+def test_chat_message_parts_migration_adds_nullable_jsonb_column() -> None:
+    # Given: persisted chat messages need durable AI SDK UI parts.
+    migration = Path(
+        "resources/migrations/0005_add_chat_message_parts.sql",
+    ).read_text()
+
+    # When / Then: the forward migration keeps legacy rows valid while adding parts.
+    assert "ADD COLUMN IF NOT EXISTS parts JSONB" in migration
+    assert "NOT NULL" not in migration
+
+
 def test_run_migrations_applies_only_pending_versions(
     monkeypatch,
     tmp_path: Path,

--- a/web/app/api/chat/[id]/history/route.ts
+++ b/web/app/api/chat/[id]/history/route.ts
@@ -1,4 +1,6 @@
-import type { ModelId, MyMetadata, MyUIMessage } from '@/lib/api-types';
+import { safeValidateUIMessages } from 'ai';
+
+import type { ModelId, MyUIMessage } from '@/lib/api-types';
 import type { ChatStateJsonValue } from '@/lib/chat-state-client';
 
 import {
@@ -15,6 +17,7 @@ type ChatStateMessage = {
   readonly content: string;
   readonly id: string;
   readonly metadata: ChatStateJsonValue;
+  readonly parts: null | readonly ChatStateJsonValue[];
   readonly response_id: null | string;
   readonly role: 'assistant' | 'user';
 };
@@ -32,38 +35,80 @@ type RouteContext = {
 const empty = (status: number): Response => new Response(null, { status });
 
 const isRecord = (
-  value: ChatStateJsonValue,
+  value: unknown,
 ): value is Record<string, ChatStateJsonValue> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
 const metadataFrom = (
   metadata: ChatStateJsonValue,
   responseId: null | string,
-): MyMetadata => {
+): Record<string, ChatStateJsonValue> => {
   const base = isRecord(metadata) ? metadata : {};
-  const feedback = base['feedback'];
-  const inferenceModel = base['inferenceModel'];
   const persistedResponseId = base['responseId'];
-  const feedbackMetadata: Pick<MyMetadata, 'feedback'> =
-    feedback === 'dislike' || feedback === 'like' ? { feedback } : {};
+  const diagnostics = base['diagnostics'];
+  const serverTotalMs = isRecord(diagnostics)
+    ? diagnostics['serverTotalMs']
+    : undefined;
+  const serverTtftMs = isRecord(diagnostics)
+    ? diagnostics['serverTtftMs']
+    : undefined;
+  const derivedTiming =
+    base['timing'] === undefined && typeof serverTotalMs === 'number'
+      ? {
+          totalMs: serverTotalMs,
+          ttftMs: typeof serverTtftMs === 'number' ? serverTtftMs : null,
+        }
+      : undefined;
 
   return {
-    ...feedbackMetadata,
-    ...(typeof inferenceModel === 'string' && { inferenceModel }),
+    ...base,
     ...(responseId !== null && { responseId }),
     ...(responseId === null &&
       typeof persistedResponseId === 'string' && {
         responseId: persistedResponseId,
       }),
+    ...(derivedTiming !== undefined && { timing: derivedTiming }),
   };
 };
 
-const messageFrom = (message: ChatStateMessage): MyUIMessage => ({
-  id: message.id,
-  metadata: metadataFrom(message.metadata, message.response_id),
-  parts: [{ text: message.content, type: 'text' }],
-  role: message.role,
-});
+const messageFrom = async (
+  message: ChatStateMessage,
+): Promise<MyUIMessage | null> => {
+  const fallbackParts = [{ text: message.content, type: 'text' }] as const;
+  const parts =
+    message.parts === null || message.parts.length === 0
+      ? fallbackParts
+      : message.parts;
+  const validation = await safeValidateUIMessages<MyUIMessage>({
+    messages: [
+      {
+        id: message.id,
+        metadata: metadataFrom(message.metadata, message.response_id),
+        parts,
+        role: message.role,
+      },
+    ],
+  });
+
+  if (validation.success) {
+    return validation.data[0] ?? null;
+  }
+
+  const fallbackValidation = await safeValidateUIMessages<MyUIMessage>({
+    messages: [
+      {
+        id: message.id,
+        metadata: metadataFrom(message.metadata, message.response_id),
+        parts: fallbackParts,
+        role: message.role,
+      },
+    ],
+  });
+
+  return fallbackValidation.success
+    ? (fallbackValidation.data[0] ?? null)
+    : null;
+};
 
 const isMessageRole = (value: unknown): value is ChatStateMessage['role'] =>
   value === 'assistant' || value === 'user';
@@ -76,6 +121,7 @@ const parseMessage = (value: ChatStateJsonValue): ChatStateMessage | null => {
   const content = value['content'];
   const id = value['id'];
   const metadata = value['metadata'];
+  const parts = value['parts'] ?? null;
   const responseId = value['response_id'];
   const role = value['role'];
 
@@ -83,13 +129,14 @@ const parseMessage = (value: ChatStateJsonValue): ChatStateMessage | null => {
     typeof content !== 'string' ||
     typeof id !== 'string' ||
     metadata === undefined ||
+    (parts !== null && !Array.isArray(parts)) ||
     (responseId !== null && typeof responseId !== 'string') ||
     !isMessageRole(role)
   ) {
     return null;
   }
 
-  return { content, id, metadata, response_id: responseId, role };
+  return { content, id, metadata, parts, response_id: responseId, role };
 };
 
 export const GET = async (
@@ -107,11 +154,16 @@ export const GET = async (
       conversationId,
       userId,
     });
-    const uiMessages = messages.flatMap((message) => {
-      const parsed = parseMessage(message);
+    const parsedMessages = await Promise.all(
+      messages.map(async (message) => {
+        const parsed = parseMessage(message);
 
-      return parsed === null ? [] : [messageFrom(parsed)];
-    });
+        return parsed === null ? null : messageFrom(parsed);
+      }),
+    );
+    const uiMessages = parsedMessages.flatMap((message) =>
+      message === null ? [] : [message],
+    );
     const historyConversation: HistoryConversation = {
       id: conversation.id,
       model: conversation.model ?? null,

--- a/web/app/api/chat/[id]/history/route.ts
+++ b/web/app/api/chat/[id]/history/route.ts
@@ -121,7 +121,8 @@ const parseMessage = (value: ChatStateJsonValue): ChatStateMessage | null => {
   const content = value['content'];
   const id = value['id'];
   const metadata = value['metadata'];
-  const parts = value['parts'] ?? null;
+  const persistedParts = value['parts'];
+  const parts = Array.isArray(persistedParts) ? persistedParts : null;
   const responseId = value['response_id'];
   const role = value['role'];
 
@@ -129,7 +130,6 @@ const parseMessage = (value: ChatStateJsonValue): ChatStateMessage | null => {
     typeof content !== 'string' ||
     typeof id !== 'string' ||
     metadata === undefined ||
-    (parts !== null && !Array.isArray(parts)) ||
     (responseId !== null && typeof responseId !== 'string') ||
     !isMessageRole(role)
   ) {

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -8,7 +8,7 @@ import {
   getAuthenticatedChatUserId,
 } from '@/lib/authenticated-chat-user';
 import {
-  assistantMetadata,
+  assistantState,
   lastUserMessageForState,
   persistedTurns,
 } from '@/lib/chat-route-state';
@@ -337,12 +337,13 @@ export const POST = async (req: Request): Promise<Response> => {
           const content = joinText(responseMessage).trim();
 
           if (content.length > 0) {
-            const metadata = assistantMetadata(meta);
+            const { metadata, parts } = assistantState(responseMessage, meta);
             if (regenerationReplacement === null) {
               await chatState.upsertAssistantMessage({
                 content,
                 conversationId,
                 metadata,
+                parts,
                 responseId: streamId,
                 userId,
               });
@@ -352,6 +353,7 @@ export const POST = async (req: Request): Promise<Response> => {
                 conversationId,
                 messageId: regenerationReplacement.messageId,
                 metadata,
+                parts,
                 responseId: streamId,
                 retainedMessageIds: regenerationReplacement.retainedMessageIds,
                 userId,

--- a/web/e2e/helpers/chat-state.ts
+++ b/web/e2e/helpers/chat-state.ts
@@ -1,5 +1,7 @@
 import type { Page, Route } from '@playwright/test';
 
+import type { ChatConversationHistory } from '@/lib/conversation-types';
+
 type ConversationRow = {
   readonly id: string;
   readonly model: null | string;
@@ -7,6 +9,8 @@ type ConversationRow = {
 };
 
 type MockChatStateOptions = {
+  readonly conversations?: readonly ConversationRow[];
+  readonly histories?: Readonly<Record<string, ChatConversationHistory>>;
   readonly streamUrl: string;
 };
 
@@ -22,13 +26,20 @@ const conversationIdFrom = (route: Route): string => {
 
 export const installMockChatState = async (
   page: Page,
-  { streamUrl }: MockChatStateOptions,
+  {
+    conversations: initialConversations = [],
+    histories = {},
+    streamUrl,
+  }: MockChatStateOptions,
 ): Promise<void> => {
-  const conversations: ConversationRow[] = [];
+  const conversations = [...initialConversations];
 
   await page.route('**/api/chat/*/history', async (route) => {
+    const conversationId = conversationIdFrom(route);
     await route.fulfill({
-      body: JSON.stringify(emptyHistory(conversationIdFrom(route))),
+      body: JSON.stringify(
+        histories[conversationId] ?? emptyHistory(conversationId),
+      ),
       contentType: 'application/json',
       status: 200,
     });

--- a/web/e2e/reasoning.spec.ts
+++ b/web/e2e/reasoning.spec.ts
@@ -154,4 +154,95 @@ test.describe('reasoning streaming (mocked BFF)', () => {
       await chatServer.close();
     }
   });
+
+  test('keeps persisted reasoning and diagnostics visible after switching chats', async ({
+    page,
+  }) => {
+    const firstId = '11111111-1111-4111-8111-111111111111';
+    const secondId = '22222222-2222-4222-8222-222222222222';
+    await page.route('**/api/health', async (route) => {
+      await route.fulfill({
+        body: '{}',
+        contentType: 'application/json',
+        status: 200,
+      });
+    });
+    await mockModels(page);
+    await installMockChatState(page, {
+      conversations: [
+        { id: firstId, model: INFERENCE_MODEL, title: 'Reasoning history' },
+        { id: secondId, model: INFERENCE_MODEL, title: 'Other history' },
+      ],
+      histories: {
+        [firstId]: {
+          conversation: {
+            id: firstId,
+            model: INFERENCE_MODEL,
+            title: 'Reasoning history',
+          },
+          messages: [
+            {
+              id: 'assistant-reasoning-history',
+              metadata: {
+                diagnostics: {
+                  serverTotalMs: 1_700,
+                  serverTtftMs: 200,
+                  thinkingMs: 400,
+                },
+                inferenceModel: INFERENCE_MODEL,
+                responseId: RESPONSE_ID,
+                timing: { totalMs: 1_700, ttftMs: 200 },
+              },
+              parts: [
+                { state: 'done', text: 'Stored reasoning', type: 'reasoning' },
+                { state: 'done', text: 'Stored answer', type: 'text' },
+              ],
+              role: 'assistant',
+            },
+          ],
+        },
+        [secondId]: {
+          conversation: {
+            id: secondId,
+            model: INFERENCE_MODEL,
+            title: 'Other history',
+          },
+          messages: [
+            {
+              id: 'assistant-other-history',
+              metadata: {},
+              parts: [{ text: 'Other answer', type: 'text' }],
+              role: 'assistant',
+            },
+          ],
+        },
+      },
+      streamUrl: 'http://127.0.0.1:9/unused',
+    });
+
+    await page.goto('/');
+    await page
+      .getByRole('button', { exact: true, name: 'Reasoning history' })
+      .click();
+    await expect(page.getByTestId('reasoning')).toBeVisible();
+    await expect(page.getByTestId('message-timing')).toBeVisible();
+
+    await page
+      .getByRole('button', { exact: true, name: 'Other history' })
+      .click();
+    await expect(page.getByText('Other answer', { exact: true })).toBeVisible();
+    await page
+      .getByRole('button', { exact: true, name: 'Reasoning history' })
+      .click();
+
+    await expect(
+      page.getByText('Stored answer', { exact: true }),
+    ).toBeVisible();
+    await page.getByTestId('reasoning').getByRole('button').click();
+    await expect(page.getByTestId('reasoning-panel')).toContainText(
+      'Stored reasoning',
+    );
+    await page.getByTestId('message-timing').hover();
+    await expect(page.getByText(RESPONSE_ID)).toBeVisible();
+  });
 });

--- a/web/lib/chat-route-state.ts
+++ b/web/lib/chat-route-state.ts
@@ -12,6 +12,15 @@ import {
 } from '@/lib/api-types';
 import { joinText } from '@/lib/message-parts';
 
+type AssistantState = {
+  readonly metadata: ChatStateMetadata;
+  readonly parts: readonly ChatStateJsonValue[];
+};
+
+type JsonValueResult =
+  | { readonly success: false }
+  | { readonly success: true; readonly value: ChatStateJsonValue };
+
 type PersistedTurn = ConversationTurn & {
   readonly id: string;
 };
@@ -22,7 +31,7 @@ type UserMessageForState = {
 };
 
 const isRecord = (
-  value: ChatStateJsonValue,
+  value: unknown,
 ): value is Record<string, ChatStateJsonValue> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -84,9 +93,73 @@ export const lastUserMessageForState = (
   return content.length === 0 ? null : { content, id: message.id };
 };
 
-export const assistantMetadata = (meta: UiStreamMeta): ChatStateMetadata => ({
-  ...(meta.inferenceModel !== undefined && {
-    inferenceModel: meta.inferenceModel,
-  }),
-  ...(meta.responseId !== undefined && { responseId: meta.responseId }),
-});
+const jsonValueFrom = (value: unknown): JsonValueResult => {
+  if (value === null) {
+    return { success: true, value: null };
+  }
+  if (
+    typeof value === 'boolean' ||
+    typeof value === 'number' ||
+    typeof value === 'string'
+  ) {
+    return { success: true, value };
+  }
+  if (Array.isArray(value)) {
+    const parsedItems = value.flatMap((item) => {
+      const parsed = jsonValueFrom(item);
+
+      return parsed.success ? [parsed.value] : [];
+    });
+    return { success: true, value: parsedItems };
+  }
+  if (typeof value === 'object') {
+    const parsedRecord = Object.fromEntries(
+      Object.entries(value).flatMap(([key, item]) => {
+        const parsed = jsonValueFrom(item);
+
+        return parsed.success ? [[key, parsed.value]] : [];
+      }),
+    );
+    return { success: true, value: parsedRecord };
+  }
+
+  return { success: false };
+};
+
+export const assistantState = (
+  message: MyUIMessage,
+  meta: UiStreamMeta,
+): AssistantState => {
+  const persistedMetadata = jsonValueFrom(message.metadata ?? {});
+  const metadata =
+    persistedMetadata.success && isRecord(persistedMetadata.value)
+      ? persistedMetadata.value
+      : {};
+  const diagnostics = message.metadata?.diagnostics;
+  const serverTotalMs = diagnostics?.serverTotalMs;
+  const serverTtftMs = diagnostics?.serverTtftMs;
+  const timing =
+    message.metadata?.timing ??
+    (typeof serverTotalMs === 'number'
+      ? {
+          totalMs: serverTotalMs,
+          ttftMs: typeof serverTtftMs === 'number' ? serverTtftMs : null,
+        }
+      : undefined);
+
+  return {
+    metadata: {
+      ...metadata,
+      ...(meta.inferenceModel !== undefined && {
+        inferenceModel: meta.inferenceModel,
+      }),
+      ...(meta.responseId !== undefined && { responseId: meta.responseId }),
+      ...(timing !== undefined && { timing }),
+    },
+    parts: message.parts.flatMap((part) => {
+      const parsed = jsonValueFrom(part);
+
+      return parsed.success ? [parsed.value] : [];
+    }),
+  };
+};

--- a/web/lib/chat-state-client.ts
+++ b/web/lib/chat-state-client.ts
@@ -114,6 +114,7 @@ type ReplaceAssistantMessageInput = {
   readonly conversationId: string;
   readonly messageId: string;
   readonly metadata: Record<string, ChatStateJsonValue>;
+  readonly parts: readonly ChatStateJsonValue[];
   readonly responseId: string;
   readonly retainedMessageIds: readonly string[];
   readonly userId: string;
@@ -137,6 +138,7 @@ type UpsertAssistantMessageInput = {
   readonly content: string;
   readonly conversationId: string;
   readonly metadata: ChatStateMetadata;
+  readonly parts: readonly ChatStateJsonValue[];
   readonly responseId: string;
   readonly userId: string;
 };
@@ -282,6 +284,7 @@ export const createChatStateClient = (): ChatStateClient => ({
     conversationId,
     messageId,
     metadata,
+    parts,
     responseId,
     retainedMessageIds,
     userId,
@@ -292,6 +295,7 @@ export const createChatStateClient = (): ChatStateClient => ({
         body: JSON.stringify({
           content,
           metadata,
+          parts,
           retained_message_ids: retainedMessageIds,
           user_id: userId,
         }),
@@ -338,6 +342,7 @@ export const createChatStateClient = (): ChatStateClient => ({
     content,
     conversationId,
     metadata,
+    parts,
     responseId,
     userId,
   }) => {
@@ -348,6 +353,7 @@ export const createChatStateClient = (): ChatStateClient => ({
           content,
           id: crypto.randomUUID(),
           metadata,
+          parts,
           user_id: userId,
         }),
         method: 'PUT',

--- a/web/test/api-chat-route-support.ts
+++ b/web/test/api-chat-route-support.ts
@@ -39,6 +39,7 @@ type StateClientInput = {
   readonly messageId?: string;
   readonly metadata?: Record<string, unknown>;
   readonly model?: string;
+  readonly parts?: readonly unknown[];
   readonly responseId?: string;
   readonly retainedMessageIds?: readonly string[];
   readonly streamId?: string;

--- a/web/test/api-chat.route.test.ts
+++ b/web/test/api-chat.route.test.ts
@@ -25,6 +25,10 @@ const okStreamResponse = (...frames: string[]): Response =>
 
 const DONE_FRAME = 'event: done\ndata: {}\n\n';
 const HELLO_TOKEN_FRAME = 'event: token\ndata: {"text":"Здраво"}\n\n';
+const THINKING_FRAME =
+  'event: thinking\ndata: {"text":"Проверувам правила."}\n\n';
+const DIAGNOSTICS_FRAME =
+  'event: meta\ndata: {"timing":{"thinking_ms":400,"total_ms":1700,"ttft_ms":200},"tokens":{"input":10,"output":20,"total":30}}\n\n';
 const SERVER_USER_MESSAGE_ID = '018f0f36-2b1d-7cc0-a50b-5f2d90c91d31';
 const TARGET_ASSISTANT_ID = '018f0f36-2b1d-7cc0-a50b-5f2d90c91d32';
 
@@ -208,8 +212,10 @@ describe('POST /api/chat', () => {
         .fn<typeof fetch>()
         .mockResolvedValue(
           okStreamResponse(
+            THINKING_FRAME,
             HELLO_TOKEN_FRAME,
             'event: token\ndata: {"text":"!"}\n\n',
+            DIAGNOSTICS_FRAME,
             DONE_FRAME,
           ),
         ),
@@ -223,7 +229,28 @@ describe('POST /api/chat', () => {
     ).toHaveBeenCalledExactlyOnceWith({
       content: 'Здраво!',
       conversationId: CONVERSATION_ID,
-      metadata: { inferenceModel: MODEL, responseId: RESPONSE_ID },
+      metadata: {
+        diagnostics: {
+          candidateCount: null,
+          serverTotalMs: 1_700,
+          serverTtftMs: 200,
+          spans: {},
+          thinkingMs: 400,
+          tokens: { input: 10, output: 20, total: 30 },
+          topDistance: null,
+        },
+        inferenceModel: MODEL,
+        responseId: RESPONSE_ID,
+        timing: { totalMs: 1_700, ttftMs: 200 },
+      },
+      parts: [
+        {
+          state: 'done',
+          text: 'Проверувам правила.',
+          type: 'reasoning',
+        },
+        { state: 'done', text: 'Здраво!', type: 'text' },
+      ],
       responseId: RESPONSE_ID,
       userId: USER_ID,
     });
@@ -294,6 +321,7 @@ describe('POST /api/chat', () => {
       conversationId: CONVERSATION_ID,
       messageId: TARGET_ASSISTANT_ID,
       metadata: { inferenceModel: MODEL, responseId: RESPONSE_ID },
+      parts: [{ state: 'done', text: 'Нов одговор', type: 'text' }],
       responseId: RESPONSE_ID,
       retainedMessageIds: [SERVER_USER_MESSAGE_ID, TARGET_ASSISTANT_ID],
       userId: USER_ID,

--- a/web/test/chat-history.route.test.ts
+++ b/web/test/chat-history.route.test.ts
@@ -162,7 +162,7 @@ describe('GET /api/chat/[id]/history', () => {
           content: 'Recoverable answer',
           id: '018f0f36-2b1d-7cc0-a50b-5f2d90c91d34',
           metadata: {},
-          parts: [{ text: 42, type: 'text' }],
+          parts: { text: 'Unexpected non-array parts' },
           response_id: RESPONSE_ID,
           role: 'assistant',
         },

--- a/web/test/chat-history.route.test.ts
+++ b/web/test/chat-history.route.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+/* eslint-disable camelcase -- Test fixtures mirror the Python chat state API wire format. */
 import {
   CONVERSATION_ID,
   installRouteMocks,
+  MODEL,
   resetRouteMocks,
   RESPONSE_ID,
   routeMocks,
@@ -42,6 +44,49 @@ describe('GET /api/chat/[id]/history', () => {
 
   it('returns persisted UI messages for the owner', async () => {
     // Given: the Python API has durable conversation messages for this owner.
+    routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
+      conversation: {
+        active_response_id: null,
+        active_status: null,
+        active_stream_id: null,
+        id: CONVERSATION_ID,
+        model: MODEL,
+        title: 'Stored title',
+        user_id: USER_ID,
+      },
+      messages: [
+        {
+          content: 'Stored question',
+          id: '018f0f36-2b1d-7cc0-a50b-5f2d90c91d31',
+          metadata: {},
+          parts: null,
+          response_id: null,
+          role: 'user',
+        },
+        {
+          content: 'Stored answer',
+          id: '018f0f36-2b1d-7cc0-a50b-5f2d90c91d32',
+          metadata: {
+            diagnostics: {
+              serverTotalMs: 1_700,
+              serverTtftMs: 200,
+              thinkingMs: 400,
+            },
+            inferenceModel: MODEL,
+          },
+          parts: [
+            {
+              state: 'done',
+              text: 'Stored reasoning',
+              type: 'reasoning',
+            },
+            { state: 'done', text: 'Stored answer', type: 'text' },
+          ],
+          response_id: RESPONSE_ID,
+          role: 'assistant',
+        },
+      ],
+    });
     const get = await importGet();
 
     // When: the browser asks for completed history after local storage was cleared.
@@ -53,7 +98,7 @@ describe('GET /api/chat/[id]/history', () => {
     expect(body).toStrictEqual({
       conversation: {
         id: CONVERSATION_ID,
-        model: 'claude-sonnet-5',
+        model: MODEL,
         title: 'Stored title',
       },
       messages: [
@@ -66,10 +111,23 @@ describe('GET /api/chat/[id]/history', () => {
         {
           id: '018f0f36-2b1d-7cc0-a50b-5f2d90c91d32',
           metadata: {
-            inferenceModel: 'claude-sonnet-5',
+            diagnostics: {
+              serverTotalMs: 1_700,
+              serverTtftMs: 200,
+              thinkingMs: 400,
+            },
+            inferenceModel: MODEL,
             responseId: RESPONSE_ID,
+            timing: { totalMs: 1_700, ttftMs: 200 },
           },
-          parts: [{ text: 'Stored answer', type: 'text' }],
+          parts: [
+            {
+              state: 'done',
+              text: 'Stored reasoning',
+              type: 'reasoning',
+            },
+            { state: 'done', text: 'Stored answer', type: 'text' },
+          ],
           role: 'assistant',
         },
       ],
@@ -77,6 +135,66 @@ describe('GET /api/chat/[id]/history', () => {
     expect(routeMocks.stateClient.loadConversation).toHaveBeenCalledWith({
       conversationId: CONVERSATION_ID,
       userId: USER_ID,
+    });
+  });
+
+  it('falls back to text when persisted parts are absent or invalid', async () => {
+    // Given: legacy and malformed rows still have durable text content.
+    routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
+      conversation: {
+        active_response_id: null,
+        active_status: null,
+        active_stream_id: null,
+        id: CONVERSATION_ID,
+        model: MODEL,
+        title: 'Stored title',
+        user_id: USER_ID,
+      },
+      messages: [
+        {
+          content: 'Legacy question',
+          id: '018f0f36-2b1d-7cc0-a50b-5f2d90c91d33',
+          metadata: {},
+          response_id: null,
+          role: 'user',
+        },
+        {
+          content: 'Recoverable answer',
+          id: '018f0f36-2b1d-7cc0-a50b-5f2d90c91d34',
+          metadata: {},
+          parts: [{ text: 42, type: 'text' }],
+          response_id: RESPONSE_ID,
+          role: 'assistant',
+        },
+      ],
+    });
+
+    // When: history is reconstructed from those rows.
+    const res = await (await importGet())(historyRequest(), routeContext());
+    const body: unknown = await res.json();
+
+    // Then: neither turn is dropped and both use their durable text content.
+    expect(res.status).toBe(200);
+    expect(body).toStrictEqual({
+      conversation: {
+        id: CONVERSATION_ID,
+        model: MODEL,
+        title: 'Stored title',
+      },
+      messages: [
+        {
+          id: '018f0f36-2b1d-7cc0-a50b-5f2d90c91d33',
+          metadata: {},
+          parts: [{ text: 'Legacy question', type: 'text' }],
+          role: 'user',
+        },
+        {
+          id: '018f0f36-2b1d-7cc0-a50b-5f2d90c91d34',
+          metadata: { responseId: RESPONSE_ID },
+          parts: [{ text: 'Recoverable answer', type: 'text' }],
+          role: 'assistant',
+        },
+      ],
     });
   });
 
@@ -108,3 +226,5 @@ describe('GET /api/chat/[id]/history', () => {
     expect(routeMocks.stateClient.loadConversation).not.toHaveBeenCalled();
   });
 });
+
+/* eslint-enable camelcase -- end Python chat state API wire fixtures. */

--- a/web/test/chat-state-client.test.ts
+++ b/web/test/chat-state-client.test.ts
@@ -199,6 +199,60 @@ describe('createChatStateClient', () => {
     });
   });
 
+  it('serializes durable assistant parts on upsert', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { createChatStateClient } = await import('@/lib/chat-state-client');
+    await createChatStateClient().upsertAssistantMessage({
+      content: 'Answer',
+      conversationId: 'conv-parts',
+      metadata: { responseId: 'response-parts' },
+      parts: [
+        { state: 'done', text: 'Reasoning', type: 'reasoning' },
+        { state: 'done', text: 'Answer', type: 'text' },
+      ],
+      responseId: 'response-parts',
+      userId: CHAT_USER_ID,
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      parts: [
+        { state: 'done', text: 'Reasoning', type: 'reasoning' },
+        { state: 'done', text: 'Answer', type: 'text' },
+      ],
+    });
+  });
+
+  it('serializes durable assistant parts on replacement', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { createChatStateClient } = await import('@/lib/chat-state-client');
+    await createChatStateClient().replaceAssistantMessage({
+      content: 'Replacement',
+      conversationId: 'conv-parts',
+      messageId: 'message-parts',
+      metadata: { responseId: 'response-parts' },
+      parts: [{ state: 'done', text: 'Replacement', type: 'text' }],
+      responseId: 'response-parts',
+      retainedMessageIds: ['message-parts'],
+      userId: CHAT_USER_ID,
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      parts: [{ state: 'done', text: 'Replacement', type: 'text' }],
+    });
+  });
+
   it('forwards BYOK credential writes without exposing the secret elsewhere', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       Response.json(


### PR DESCRIPTION
## Summary
- persist AI SDK message parts and diagnostics in a nullable JSONB column
- restore reasoning, timing, and response metadata when switching conversations
- preserve legacy or malformed history through durable text fallback
- cover persistence, regeneration, feedback, history hydration, and browser chat switching

## Verification
- uv run pytest (180 passed)
- uv run ruff check .
- uv run mypy .
- npm run test (330 passed)
- npm run check
- npm run lint (0 errors; existing warnings remain)
- npm run build
- npx playwright test e2e/reasoning.spec.ts (2 passed)