### PR TITLE
fix(chat): regenerate titles with cheapest provider model

### DIFF
--- a/api/app/api/chat_title.py
+++ b/api/app/api/chat_title.py
@@ -69,6 +69,7 @@ async def generate_chat_title(
     db: ChatCredentialDatabase | None = None,
     settings: Settings | None = None,
 ) -> ChatTitleResponse:
+    candidate_models: tuple[Model, ...]
     if payload.query_transform_model is not None:
         candidate_models = (payload.query_transform_model,)
     else:

--- a/api/app/api/chat_title.py
+++ b/api/app/api/chat_title.py
@@ -1,4 +1,5 @@
 from html import escape
+from typing import Final
 
 from fastapi import APIRouter, Depends, Request, status
 
@@ -8,7 +9,9 @@ from app.api.provider_credentials import (
 )
 from app.data.chat_credentials import ChatCredentialDatabase
 from app.data.db import get_db
-from app.llms.provider_credentials import has_provider_credential
+from app.llms.models import Model
+from app.llms.pricing import HOSTED_PRICING
+from app.llms.provider_credentials import has_provider_credential, provider_for_model
 from app.llms.query_transform import transform_query
 from app.schemas.chat_title import ChatTitleResponse, ChatTitleSchema
 from app.utils.auth import verify_api_key
@@ -21,6 +24,12 @@ router = APIRouter(prefix="/chat", tags=["Chat"])
 
 _TITLE_MAX = 60
 _FALLBACK_TITLE = "Нов разговор"
+_TITLE_MODELS_BY_COST: Final[tuple[Model, ...]] = (
+    *sorted(HOSTED_PRICING, key=lambda model: sum(HOSTED_PRICING[model])),
+    Model.QWEN3_14B,
+    Model.QWEN3_30B_INSTRUCT,
+    Model.QWEN3_30B_THINKING,
+)
 _TITLE_SYSTEM_PROMPT = """Создај краток наслов за разговорот.
 
 Правила:
@@ -60,6 +69,15 @@ async def generate_chat_title(
     db: ChatCredentialDatabase | None = None,
     settings: Settings | None = None,
 ) -> ChatTitleResponse:
+    if payload.query_transform_model is not None:
+        candidate_models = (payload.query_transform_model,)
+    else:
+        provider = provider_for_model(payload.provider_model)
+        candidate_models = tuple(
+            model
+            for model in _TITLE_MODELS_BY_COST
+            if provider_for_model(model) == provider
+        )
     if payload.user_id is None:
         credentials = None
     elif db is None:
@@ -72,17 +90,25 @@ async def generate_chat_title(
         credentials = await resolve_provider_credentials(
             db,
             user_id=payload.user_id,
-            providers=credential_providers_for_models(payload.query_transform_model),
+            providers=credential_providers_for_models(*candidate_models),
             settings=settings,
         )
-    if not has_provider_credential(credentials, payload.query_transform_model):
+    selected_model = next(
+        (
+            model
+            for model in candidate_models
+            if has_provider_credential(credentials, model)
+        ),
+        None,
+    )
+    if selected_model is None:
         return ChatTitleResponse(
             title=_normalize_title("", payload.first_user_text),
         )
     prompt = _build_title_prompt(payload.transcript)
     raw_title = await transform_query(
         prompt,
-        payload.query_transform_model,
+        selected_model,
         system_prompt=_TITLE_SYSTEM_PROMPT,
         temperature=0.2,
         top_p=1.0,

--- a/api/app/schemas/chat_title.py
+++ b/api/app/schemas/chat_title.py
@@ -38,9 +38,19 @@ class ChatTitleSchema(BaseModel):
             raise ValueError("messages must include at least one user turn")
         return value
 
-    @field_validator("provider_model", "query_transform_model")
+    @field_validator("provider_model")
     @classmethod
-    def _must_support_title_generation(cls, value: Model | None) -> Model | None:
+    def _provider_must_support_title_generation(cls, value: Model) -> Model:
+        if value not in QUERY_TRANSFORM_MODELS:
+            raise ValueError("provider_model must be a chat-capable model")
+        return value
+
+    @field_validator("query_transform_model")
+    @classmethod
+    def _override_must_support_title_generation(
+        cls,
+        value: Model | None,
+    ) -> Model | None:
         if value is not None and value not in QUERY_TRANSFORM_MODELS:
             raise ValueError("query_transform_model must be a chat-capable model")
         return value

--- a/api/app/schemas/chat_title.py
+++ b/api/app/schemas/chat_title.py
@@ -19,9 +19,13 @@ class ChatTitleSchema(BaseModel):
         max_length=4,
         description="The first conversation turns used to generate a concise title.",
     )
-    query_transform_model: Model = Field(
+    query_transform_model: Model | None = Field(
+        None,
+        description="Optional chat-capable model override for title generation.",
+    )
+    provider_model: Model = Field(
         DEFAULT_QUERY_TRANSFORM_MODEL,
-        description="Which chat-capable model to use for title generation.",
+        description="Active model whose provider should be used for automatic selection.",
     )
 
     @field_validator("messages")
@@ -34,10 +38,10 @@ class ChatTitleSchema(BaseModel):
             raise ValueError("messages must include at least one user turn")
         return value
 
-    @field_validator("query_transform_model")
+    @field_validator("provider_model", "query_transform_model")
     @classmethod
-    def _must_support_title_generation(cls, value: Model) -> Model:
-        if value not in QUERY_TRANSFORM_MODELS:
+    def _must_support_title_generation(cls, value: Model | None) -> Model | None:
+        if value is not None and value not in QUERY_TRANSFORM_MODELS:
             raise ValueError("query_transform_model must be a chat-capable model")
         return value
 

--- a/api/tests/test_chat_title_model_selection.py
+++ b/api/tests/test_chat_title_model_selection.py
@@ -1,6 +1,8 @@
 from uuid import UUID
 
 import anyio
+import pytest
+from pydantic import ValidationError
 
 from app.api import chat_title
 from app.data.chat_credentials import upsert_chat_credential
@@ -10,6 +12,21 @@ from app.schemas.chat_credentials import ChatCredentialUpsert
 from app.schemas.chat_title import ChatTitleSchema
 from app.utils.settings import Settings
 from tests.chat_persistence_fake import FakeChatDatabase
+
+
+def test_provider_model_validation_names_the_invalid_field() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="provider_model must be a chat-capable model",
+    ):
+        ChatTitleSchema.model_validate(
+            {
+                "messages": [
+                    ConversationTurn(role="user", content="Кога е јунската сесија?"),
+                ],
+                "provider_model": Model.BGE_M3_LOCAL,
+            },
+        )
 
 
 def test_chat_title_uses_cheapest_model_for_active_provider(monkeypatch):

--- a/api/tests/test_chat_title_model_selection.py
+++ b/api/tests/test_chat_title_model_selection.py
@@ -1,0 +1,71 @@
+from uuid import UUID
+
+import anyio
+
+from app.api import chat_title
+from app.data.chat_credentials import upsert_chat_credential
+from app.llms.models import Model
+from app.schemas.chat import ConversationTurn
+from app.schemas.chat_credentials import ChatCredentialUpsert
+from app.schemas.chat_title import ChatTitleSchema
+from app.utils.settings import Settings
+from tests.chat_persistence_fake import FakeChatDatabase
+
+
+def test_chat_title_uses_cheapest_model_for_active_provider(monkeypatch):
+    selected_models: list[Model] = []
+
+    async def fake_transform_query(
+        query: str,
+        model: Model,
+        *,
+        system_prompt: str,
+        temperature: float,
+        top_p: float,
+        max_tokens: int,
+        credentials=None,
+    ) -> str:
+        selected_models.append(model)
+        return "Испитен рок"
+
+    monkeypatch.setattr(chat_title, "transform_query", fake_transform_query)
+    db = FakeChatDatabase()
+    user_id = UUID("00000000-0000-4000-8000-000000000001")
+    settings = Settings(
+        API_KEY="test-api-key",
+        CREDENTIAL_ENCRYPTION_KEY="runtime-credential-key",
+        MCP_API_KEY="test-mcp-key",
+    )
+
+    async def run_title():
+        for provider in ("anthropic", "openai"):
+            await upsert_chat_credential(
+                db,
+                user_id=user_id,
+                credential=ChatCredentialUpsert(
+                    api_key=f"{provider}-user-key",
+                    provider=provider,
+                ),
+                settings=settings,
+            )
+        return await chat_title.generate_chat_title(
+            ChatTitleSchema.model_validate(
+                {
+                    "user_id": user_id,
+                    "messages": [
+                        ConversationTurn(
+                            role="user",
+                            content="Кога е јунската сесија?",
+                        ),
+                    ],
+                    "provider_model": Model.CLAUDE_SONNET_5,
+                },
+            ),
+            db,
+            settings,
+        )
+
+    response = anyio.run(run_title)
+
+    assert response.title == "Испитен рок"
+    assert selected_models == [Model.CLAUDE_HAIKU_4_5]

--- a/web/app/api/chat/title/route.ts
+++ b/web/app/api/chat/title/route.ts
@@ -44,6 +44,20 @@ const parseTurn = (value: unknown): ConversationTurn | null => {
   return { content, role };
 };
 
+const readModelField = (
+  candidate: Record<string, unknown>,
+  snakeCaseKey: string,
+  camelCaseKey: string,
+): string | undefined => {
+  const snakeCaseValue = candidate[snakeCaseKey];
+  if (typeof snakeCaseValue === 'string') {
+    return snakeCaseValue;
+  }
+
+  const camelCaseValue = candidate[camelCaseKey];
+  return typeof camelCaseValue === 'string' ? camelCaseValue : undefined;
+};
+
 const parsePayload = (value: unknown): ParsePayloadResult => {
   if (typeof value !== 'object' || value === null) {
     return { kind: 'invalid' };
@@ -79,16 +93,23 @@ const parsePayload = (value: unknown): ParsePayloadResult => {
     messages.push(turn);
   }
 
-  const queryTransformModel =
-    typeof candidate['query_transform_model'] === 'string'
-      ? candidate['query_transform_model']
-      : candidate['queryTransformModel'];
+  const queryTransformModel = readModelField(
+    candidate,
+    'query_transform_model',
+    'queryTransformModel',
+  );
+  const providerModel = readModelField(
+    candidate,
+    'provider_model',
+    'providerModel',
+  );
 
   return {
     kind: 'ok',
     payload: {
       messages,
-      ...(typeof queryTransformModel === 'string' && {
+      ...(providerModel !== undefined && { providerModel }),
+      ...(queryTransformModel !== undefined && {
         queryTransformModel,
       }),
     },
@@ -109,6 +130,10 @@ const unauthenticated = (): Response =>
 
 const toSchema = (payload: ChatTitleClientPayload, userId: string) => ({
   messages: payload.messages,
+  ...(payload.providerModel !== undefined && {
+    // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+    provider_model: payload.providerModel,
+  }),
   ...(payload.queryTransformModel !== undefined && {
     // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
     query_transform_model: payload.queryTransformModel,

--- a/web/lib/api-types.ts
+++ b/web/lib/api-types.ts
@@ -43,11 +43,13 @@ export type ChatRequestBody = {
 
 export type ChatTitleClientPayload = {
   readonly messages: readonly ConversationTurn[];
+  readonly providerModel?: ModelId;
   readonly queryTransformModel?: ModelId;
 };
 
 export type ChatTitleRequestBody = {
   readonly messages: readonly ConversationTurn[];
+  readonly provider_model?: ModelId;
   readonly query_transform_model?: ModelId;
   readonly user_id?: string;
 };

--- a/web/lib/chat-title-translate.ts
+++ b/web/lib/chat-title-translate.ts
@@ -11,6 +11,7 @@ const TITLE_CONTEXT_TURNS = 4;
 
 type ChatTitleTranslateInput = {
   readonly messages: readonly MyUIMessage[];
+  readonly providerModel?: ModelId;
   readonly queryTransformModel?: ModelId;
 };
 
@@ -26,6 +27,10 @@ export const toChatTitleRequestBody = (
   body: ChatTitleTranslateInput,
 ): ChatTitleRequestBody => ({
   messages: body.messages.slice(0, TITLE_CONTEXT_TURNS).map(toTurn),
+  ...(body.providerModel !== undefined && {
+    // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+    provider_model: body.providerModel,
+  }),
   ...(body.queryTransformModel !== undefined && {
     // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
     query_transform_model: body.queryTransformModel,

--- a/web/lib/chat-title.ts
+++ b/web/lib/chat-title.ts
@@ -4,7 +4,8 @@ import { toChatTitleRequestBody } from '@/lib/chat-title-translate';
 
 type GenerateTitleInput = {
   readonly messages: readonly MyUIMessage[];
-  readonly queryTransformModel: ModelId;
+  readonly providerModel?: ModelId;
+  readonly queryTransformModel?: ModelId;
 };
 
 const parseTitle = (value: unknown): null | string => {
@@ -29,11 +30,12 @@ const parseTitle = (value: unknown): null | string => {
 
 export const generateChatTitle = async ({
   messages,
+  providerModel,
   queryTransformModel,
 }: GenerateTitleInput): Promise<null | string> => {
   const response = await fetch('/api/chat/title', {
     body: JSON.stringify(
-      toChatTitleRequestBody({ messages, queryTransformModel }),
+      toChatTitleRequestBody({ messages, providerModel, queryTransformModel }),
     ),
     headers: { 'content-type': 'application/json' },
     method: 'POST',

--- a/web/lib/use-generated-title.ts
+++ b/web/lib/use-generated-title.ts
@@ -37,7 +37,7 @@ export const useGeneratedTitle = ({
       try {
         const title = await generateChatTitle({
           messages: titleMessages,
-          queryTransformModel: modelRef.current,
+          providerModel: modelRef.current,
         });
 
         if (title === null) {

--- a/web/test/chat-title-translate.test.ts
+++ b/web/test/chat-title-translate.test.ts
@@ -23,6 +23,7 @@ describe('toChatTitleRequestBody', () => {
     expect(
       toChatTitleRequestBody({
         messages,
+        providerModel: 'claude-sonnet-5',
         queryTransformModel: 'claude-sonnet-5',
       }),
     ).toStrictEqual({
@@ -32,6 +33,8 @@ describe('toChatTitleRequestBody', () => {
         { content: 'Дополнително?', role: 'user' },
         { content: 'Уште еден одговор.', role: 'assistant' },
       ],
+      // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+      provider_model: 'claude-sonnet-5',
       // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
       query_transform_model: 'claude-sonnet-5',
     });

--- a/web/test/chat-title.route.test.ts
+++ b/web/test/chat-title.route.test.ts
@@ -13,6 +13,7 @@ const { getAuthenticatedChatUserIdMock } = vi.hoisted(() => ({
 }));
 
 const API_USER_ID = 'api-user-1';
+const CLAUDE_MODEL = 'claude-sonnet-5';
 
 vi.mock('@/lib/env', () => ({
   API_BASE_URL: 'https://api:8880',
@@ -66,7 +67,9 @@ describe('POST /api/chat/title', () => {
     const payload: ChatTitleRequestBody = {
       messages: [{ content: 'Кога е испитот?', role: 'user' }],
       // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
-      query_transform_model: 'claude-sonnet-5',
+      provider_model: CLAUDE_MODEL,
+      // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+      query_transform_model: CLAUDE_MODEL,
       // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
       user_id: API_USER_ID,
     };
@@ -90,7 +93,9 @@ describe('POST /api/chat/title', () => {
     expect(JSON.parse(init.body as string)).toStrictEqual({
       messages: [{ content: 'Кога е испитот?', role: 'user' }],
       // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
-      query_transform_model: 'claude-sonnet-5',
+      provider_model: CLAUDE_MODEL,
+      // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+      query_transform_model: CLAUDE_MODEL,
       // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
       user_id: API_USER_ID,
     });
@@ -101,7 +106,7 @@ describe('POST /api/chat/title', () => {
   it('also accepts the legacy camelCase model field', async () => {
     const payload: ChatTitleClientPayload = {
       messages: [{ content: 'Кога е испитот?', role: 'user' }],
-      queryTransformModel: 'claude-sonnet-5',
+      queryTransformModel: CLAUDE_MODEL,
     };
     const fetchMock = vi
       .fn<typeof fetch>()
@@ -116,7 +121,7 @@ describe('POST /api/chat/title', () => {
     expect(JSON.parse(init.body as string)).toStrictEqual({
       messages: [{ content: 'Кога е испитот?', role: 'user' }],
       // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
-      query_transform_model: 'claude-sonnet-5',
+      query_transform_model: CLAUDE_MODEL,
       // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
       user_id: API_USER_ID,
     });

--- a/web/test/use-generated-title.test.tsx
+++ b/web/test/use-generated-title.test.tsx
@@ -1,7 +1,9 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { MyUIMessage } from '@/lib/api-types';
+import type { ChatConversationHistory } from '@/lib/conversation-types';
+import type { SaveChatConversationInput } from '@/lib/transport';
 
 import { useGeneratedTitle } from '@/lib/use-generated-title';
 
@@ -11,9 +13,16 @@ type GenerateChatTitle = (input: {
 }) => Promise<null | string>;
 
 const generateChatTitle = vi.fn<GenerateChatTitle>();
-const loadChatConversationHistory = vi.fn<() => Promise<null>>();
+const loadChatConversationHistory =
+  vi.fn<(conversationId: string) => Promise<ChatConversationHistory | null>>();
 const refreshConversations = vi.fn<() => Promise<void>>();
-const saveChatConversation = vi.fn<() => Promise<void>>();
+const saveChatConversation =
+  vi.fn<(input: SaveChatConversationInput) => Promise<void>>();
+
+const CONVERSATION_ID = 'conversation-1';
+const GENERATED_TITLE = 'Јунска испитна сесија';
+const MODEL_ID = 'claude-sonnet-5';
+const OLD_TITLE = 'Old title';
 
 vi.mock('@/lib/chat-title', () => ({
   generateChatTitle: (input: { readonly messages: readonly MyUIMessage[] }) =>
@@ -21,13 +30,17 @@ vi.mock('@/lib/chat-title', () => ({
 }));
 
 vi.mock('@/lib/transport', () => ({
-  loadChatConversationHistory: () => loadChatConversationHistory(),
-  saveChatConversation: () => saveChatConversation(),
+  loadChatConversationHistory: (conversationId: string) =>
+    loadChatConversationHistory(conversationId),
+  saveChatConversation: (input: SaveChatConversationInput) =>
+    saveChatConversation(input),
 }));
 
 beforeEach(() => {
   generateChatTitle.mockReset();
-  generateChatTitle.mockResolvedValue('Јунска испитна сесија');
+  generateChatTitle.mockResolvedValue(GENERATED_TITLE);
+  loadChatConversationHistory.mockReset();
+  loadChatConversationHistory.mockResolvedValue(null);
   refreshConversations.mockReset();
   refreshConversations.mockResolvedValue();
   saveChatConversation.mockReset();
@@ -44,23 +57,69 @@ test('requests a generated title without coupling it to the active chat model', 
   ];
   const options = {
     conversations: [],
-    modelRef: { current: 'claude-sonnet-5' },
+    modelRef: { current: MODEL_ID },
     refreshConversations,
   };
   const { result } = renderHook(() => useGeneratedTitle(options));
 
   await act(async () => {
     await result.current.applyGeneratedTitle(
-      'conversation-1',
+      CONVERSATION_ID,
       messages,
-      'Old title',
+      OLD_TITLE,
     );
   });
 
   expect(generateChatTitle).toHaveBeenCalledWith({
     messages,
-    providerModel: 'claude-sonnet-5',
+    providerModel: MODEL_ID,
   });
   expect(saveChatConversation).toHaveBeenCalledOnce();
   expect(refreshConversations).toHaveBeenCalledOnce();
+});
+
+test('loads the requested conversation before generating its title', async () => {
+  const messages: readonly MyUIMessage[] = [
+    {
+      id: 'user-1',
+      parts: [{ text: 'Кога е јунската сесија?', type: 'text' }],
+      role: 'user',
+    },
+  ];
+  loadChatConversationHistory.mockResolvedValue({
+    conversation: {
+      id: CONVERSATION_ID,
+      model: MODEL_ID,
+      title: OLD_TITLE,
+    },
+    messages,
+  });
+  const { result } = renderHook(() =>
+    useGeneratedTitle({
+      conversations: [
+        {
+          id: CONVERSATION_ID,
+          model: MODEL_ID,
+          title: OLD_TITLE,
+        },
+      ],
+      modelRef: { current: MODEL_ID },
+      refreshConversations,
+    }),
+  );
+
+  act(() => {
+    result.current.handleGenerateTitle(CONVERSATION_ID);
+  });
+
+  await waitFor(() => {
+    expect(loadChatConversationHistory).toHaveBeenCalledWith(CONVERSATION_ID);
+  });
+  await waitFor(() => {
+    expect(saveChatConversation).toHaveBeenCalledWith({
+      expectedTitle: OLD_TITLE,
+      id: CONVERSATION_ID,
+      title: GENERATED_TITLE,
+    });
+  });
 });

--- a/web/test/use-generated-title.test.tsx
+++ b/web/test/use-generated-title.test.tsx
@@ -1,0 +1,66 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { MyUIMessage } from '@/lib/api-types';
+
+import { useGeneratedTitle } from '@/lib/use-generated-title';
+
+type GenerateChatTitle = (input: {
+  readonly messages: readonly MyUIMessage[];
+  readonly providerModel?: string;
+}) => Promise<null | string>;
+
+const generateChatTitle = vi.fn<GenerateChatTitle>();
+const loadChatConversationHistory = vi.fn<() => Promise<null>>();
+const refreshConversations = vi.fn<() => Promise<void>>();
+const saveChatConversation = vi.fn<() => Promise<void>>();
+
+vi.mock('@/lib/chat-title', () => ({
+  generateChatTitle: (input: { readonly messages: readonly MyUIMessage[] }) =>
+    generateChatTitle(input),
+}));
+
+vi.mock('@/lib/transport', () => ({
+  loadChatConversationHistory: () => loadChatConversationHistory(),
+  saveChatConversation: () => saveChatConversation(),
+}));
+
+beforeEach(() => {
+  generateChatTitle.mockReset();
+  generateChatTitle.mockResolvedValue('Јунска испитна сесија');
+  refreshConversations.mockReset();
+  refreshConversations.mockResolvedValue();
+  saveChatConversation.mockReset();
+  saveChatConversation.mockResolvedValue();
+});
+
+test('requests a generated title without coupling it to the active chat model', async () => {
+  const messages: readonly MyUIMessage[] = [
+    {
+      id: 'user-1',
+      parts: [{ text: 'Кога е јунската сесија?', type: 'text' }],
+      role: 'user',
+    },
+  ];
+  const options = {
+    conversations: [],
+    modelRef: { current: 'claude-sonnet-5' },
+    refreshConversations,
+  };
+  const { result } = renderHook(() => useGeneratedTitle(options));
+
+  await act(async () => {
+    await result.current.applyGeneratedTitle(
+      'conversation-1',
+      messages,
+      'Old title',
+    );
+  });
+
+  expect(generateChatTitle).toHaveBeenCalledWith({
+    messages,
+    providerModel: 'claude-sonnet-5',
+  });
+  expect(saveChatConversation).toHaveBeenCalledOnce();
+  expect(refreshConversations).toHaveBeenCalledOnce();
+});


### PR DESCRIPTION
## Summary
- decouple sidebar title regeneration from the active model while preserving its provider
- select the cheapest credential-backed title model within that provider
- preserve explicit title-model overrides and first-message fallback behavior
- add API, BFF, translation, and hook regression coverage

## Verification
- API: 180 tests passed
- Web: 335 tests passed
- Ruff: passed
- TypeScript: passed
- ESLint: 0 errors (13 pre-existing warnings)
- Next.js production build: passed with a local Redis validation URL
- Real Chromium hover/click/title-persistence scenario: passed