### PR TITLE
feat(models): discover Ollama chat models dynamically

### DIFF
--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -680,6 +680,7 @@ async def chat(
     summary="List available LLM models",
     description="Retrieve a list of all available LLM models for chat.",
     status_code=status.HTTP_200_OK,
+    dependencies=[api_key_dep],
 )
 async def list_models(
     request: Request,

--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -28,7 +28,9 @@ from app.llms.chat import handle_chat
 from app.llms.context import get_retrieved_context_with_sources
 from app.llms.link_context import get_links_context
 from app.llms.model_catalog import model_catalog_service
-from app.llms.model_catalog_types import ModelCatalogResponse
+from app.llms.model_catalog_types import ModelCatalogResponse, OllamaCatalogModel
+from app.llms.models import model_id
+from app.llms.ollama import fetch_ollama_catalog
 from app.llms.pricing import cost_usd, is_self_hosted
 from app.llms.retrieval_result import RetrievedContext
 from app.schemas.chat import ChatSchema
@@ -160,9 +162,9 @@ def _chat_request_log_fields(
     payload: ChatSchema,
 ) -> dict[str, bool | float | int | str]:
     return {
-        "inference_model": payload.inference_model.value,
+        "inference_model": model_id(payload.inference_model),
         "embeddings_model": payload.embeddings_model.value,
-        "query_transform_model": payload.query_transform_model.value,
+        "query_transform_model": model_id(payload.query_transform_model),
         "query_transform_mode": payload.query_transform_mode.value,
         "reasoning": payload.reasoning,
         "interface": payload.interface,
@@ -214,7 +216,7 @@ def _capture_chat_response(
 
     props: dict[str, object] = {
         "$ai_trace_id": str(response_id),
-        "$ai_model": model.value,
+        "$ai_model": model_id(model),
         "$ai_provider": observation.provider or None,
         "$ai_input": _chat_messages(payload),
         "$ai_output_choices": [
@@ -404,9 +406,9 @@ async def _instrument_stream(
             json.dumps(
                 {
                     "response_id": str(response_id),
-                    "inference_model": payload.inference_model.value,
+                    "inference_model": model_id(payload.inference_model),
                     "embeddings_model": payload.embeddings_model.value,
-                    "query_transform_model": payload.query_transform_model.value,
+                    "query_transform_model": model_id(payload.query_transform_model),
                     "query_transform_mode": payload.query_transform_mode.value,
                     "retrieval_hit": retrieval_hit,
                     "outcome": outcome,
@@ -562,7 +564,9 @@ async def _chat_response_stream(
                     {
                         "response_id": str(response_id),
                         "embeddings_model": payload.embeddings_model.value,
-                        "query_transform_model": payload.query_transform_model.value,
+                        "query_transform_model": model_id(
+                            payload.query_transform_model,
+                        ),
                         "query_transform_mode": payload.query_transform_mode.value,
                         "candidate_count": timings.candidate_count,
                         "top_distance": timings.top_distance,
@@ -677,5 +681,18 @@ async def chat(
     description="Retrieve a list of all available LLM models for chat.",
     status_code=status.HTTP_200_OK,
 )
-async def list_models() -> ModelCatalogResponse:
-    return await model_catalog_service.get_catalog()
+async def list_models(
+    request: Request,
+    user_id: UUID | None = None,
+    db: Database = db_dep,
+) -> ModelCatalogResponse:
+    credentials = await resolve_provider_credentials(
+        db,
+        user_id=user_id,
+        providers=frozenset({"ollama"}),
+        settings=request.app.state.settings,
+    )
+    ollama_models: tuple[OllamaCatalogModel, ...] = ()
+    if credentials is not None and credentials.ollama is not None:
+        ollama_models = await fetch_ollama_catalog(credentials.ollama)
+    return await model_catalog_service.get_catalog(ollama_models)

--- a/api/app/api/provider_credentials.py
+++ b/api/app/api/provider_credentials.py
@@ -3,7 +3,7 @@ from typing import Literal
 from uuid import UUID
 
 from app.data.chat_credentials import ChatCredentialDatabase, get_chat_credential_secret
-from app.llms.models import Model
+from app.llms.models import ChatModel, Model
 from app.llms.provider_credentials import (
     LlmProviderCredentials,
     ProviderName,
@@ -62,7 +62,7 @@ async def _get_secret(
     return None
 
 
-def credential_providers_for_models(*models: Model) -> frozenset[ProviderName]:
+def credential_providers_for_models(*models: ChatModel) -> frozenset[ProviderName]:
     providers: set[ProviderName] = set()
     for model in models:
         provider = provider_for_model(model)
@@ -74,10 +74,10 @@ def credential_providers_for_models(*models: Model) -> frozenset[ProviderName]:
 def missing_mandatory_credential(
     credentials: LlmProviderCredentials | None,
     *,
-    inference_model: Model,
+    inference_model: ChatModel,
     embeddings_model: Model,
 ) -> MissingProviderCredential | None:
-    required_models: tuple[tuple[CredentialStage, Model], ...] = (
+    required_models: tuple[tuple[CredentialStage, ChatModel], ...] = (
         ("inference", inference_model),
         ("embeddings", embeddings_model),
     )

--- a/api/app/llms/chat.py
+++ b/api/app/llms/chat.py
@@ -4,6 +4,7 @@ from fastapi.responses import StreamingResponse
 
 from app.data.connection import Database
 from app.llms.agents import StreamObservation
+from app.llms.models import model_id
 from app.llms.prompts import (
     DEFAULT_AGENT_SYSTEM_PROMPT,
     build_user_agent_prompt,
@@ -36,7 +37,7 @@ async def handle_chat(
     logger.info(
         "Handling chat for user prompt length: '%d' with model: %s",
         len(payload.query),
-        payload.inference_model.value,
+        model_id(payload.inference_model),
     )
 
     system_prompt = "\n\n".join(

--- a/api/app/llms/context.py
+++ b/api/app/llms/context.py
@@ -9,7 +9,7 @@ from app.data.connection import Database
 from app.data.documents import get_chunks_window, get_closest_chunks
 from app.data.questions import get_closest_questions
 from app.llms.embeddings import generate_embeddings
-from app.llms.models import Model
+from app.llms.models import ChatModel, Model
 from app.llms.prompts import CONTEXTUALIZE_SYSTEM_PROMPT
 from app.llms.provider_credentials import (
     LlmProviderCredentials,
@@ -238,7 +238,7 @@ async def get_retrieved_context(
     db: Database,
     query: str,
     embedding_model: Model,
-    query_transform_model: Model,
+    query_transform_model: ChatModel,
     *,
     query_transform_mode: QueryTransformMode = QueryTransformMode.REWRITE_HYDE,
     history_text: str | None = None,
@@ -266,7 +266,7 @@ async def get_retrieved_context_with_sources(
     db: Database,
     query: str,
     embedding_model: Model,
-    query_transform_model: Model,
+    query_transform_model: ChatModel,
     *,
     query_transform_mode: QueryTransformMode = QueryTransformMode.REWRITE_HYDE,
     history_text: str | None = None,
@@ -509,7 +509,7 @@ async def get_retrieved_context_with_sources(
 
 async def _contextualize_query(
     query: str,
-    query_transform_model: Model,
+    query_transform_model: ChatModel,
     history_text: str | None,
     credentials: LlmProviderCredentials | None = None,
 ) -> str:

--- a/api/app/llms/model_catalog.py
+++ b/api/app/llms/model_catalog.py
@@ -14,8 +14,10 @@ from app.llms.model_catalog_remote import CatalogMetadataError, parse_models_dev
 from app.llms.model_catalog_types import (
     CatalogSource,
     DisplayMetadata,
+    ExecutionPolicy,
     ModelCatalogResponse,
     ModelDescriptor,
+    OllamaCatalogModel,
     SnapshotCatalog,
 )
 from app.llms.models import Model
@@ -57,15 +59,15 @@ def _load_snapshot() -> dict[Model, DisplayMetadata]:
         raise CatalogMetadataError(
             reason="bundled model snapshot is invalid",
         ) from error
+    entries = {entry.id: entry for entry in snapshot.models}
     expected = tuple(policy.model.value for policy in MODEL_CATALOG)
-    actual = tuple(entry.id for entry in snapshot.models)
-    if actual != expected:
-        raise CatalogMetadataError(reason="bundled model snapshot order is invalid")
+    if not all(model_id in entries for model_id in expected):
+        raise CatalogMetadataError(reason="bundled model snapshot is incomplete")
     return {
-        Model(entry.id): DisplayMetadata.model_validate(
-            entry.model_dump(exclude={"id"}),
+        policy.model: DisplayMetadata.model_validate(
+            entries[policy.model.value].model_dump(exclude={"id"}),
         )
-        for entry in snapshot.models
+        for policy in MODEL_CATALOG
     }
 
 
@@ -84,6 +86,21 @@ def _descriptor(
         limits=metadata.limits,
         pricing=metadata.pricing,
         status=metadata.status,
+    )
+
+
+def _ollama_descriptor(model: OllamaCatalogModel) -> ModelDescriptor:
+    return ModelDescriptor(
+        id=model.id,
+        provider="ollama",
+        name=model.name,
+        execution=ExecutionPolicy(
+            reasoning=False,
+            sampling=True,
+            tool_call=False,
+            structured_output=False,
+        ),
+        loaded=model.loaded,
     )
 
 
@@ -139,6 +156,7 @@ class ModelCatalogService:
         self,
         source: CatalogSource,
         remote: dict[Model, DisplayMetadata],
+        ollama_models: tuple[OllamaCatalogModel, ...] = (),
     ) -> ModelCatalogResponse:
         metadata = {
             model: _merge_metadata(snapshot, remote.get(model))
@@ -146,21 +164,42 @@ class ModelCatalogService:
         }
         return ModelCatalogResponse(
             source=source,
-            models=tuple(
-                _descriptor(policy, metadata[policy.model]) for policy in MODEL_CATALOG
+            models=(
+                *(
+                    _descriptor(policy, metadata[policy.model])
+                    for policy in MODEL_CATALOG
+                ),
+                *(_ollama_descriptor(model) for model in ollama_models),
             ),
         )
 
-    async def get_catalog(self) -> ModelCatalogResponse:
+    async def get_catalog(
+        self,
+        ollama_models: tuple[OllamaCatalogModel, ...] = (),
+    ) -> ModelCatalogResponse:
         """Return live, cached, stale, or bundled catalog data without ever emptying it."""
         now = self._clock()
         if self._cached is not None and now < self._expires_at:
-            return self._cached
+            return self._cached.model_copy(
+                update={
+                    "models": (
+                        *self._cached.models,
+                        *map(_ollama_descriptor, ollama_models),
+                    ),
+                },
+            )
 
         async with self._lock:
             now = self._clock()
             if self._cached is not None and now < self._expires_at:
-                return self._cached
+                return self._cached.model_copy(
+                    update={
+                        "models": (
+                            *self._cached.models,
+                            *map(_ollama_descriptor, ollama_models),
+                        ),
+                    },
+                )
             try:
                 payload = await self._fetch_metadata()
                 remote = parse_models_dev(payload)
@@ -170,18 +209,40 @@ class ModelCatalogService:
                         "model catalog refresh failed; source=stale error=%s",
                         error,
                     )
-                    return self._cached.model_copy(update={"source": "stale"})
+                    stale = self._cached.model_copy(update={"source": "stale"})
+                    return stale.model_copy(
+                        update={
+                            "models": (
+                                *stale.models,
+                                *map(_ollama_descriptor, ollama_models),
+                            ),
+                        },
+                    )
                 logger.warning(
                     "model catalog refresh failed; source=snapshot error=%s",
                     error,
                 )
                 self._cached = self._build("snapshot", {})
                 self._expires_at = now + CATALOG_TTL_SECONDS
-                return self._cached
+                return self._cached.model_copy(
+                    update={
+                        "models": (
+                            *self._cached.models,
+                            *map(_ollama_descriptor, ollama_models),
+                        ),
+                    },
+                )
 
             self._cached = self._build("live", remote)
             self._expires_at = now + CATALOG_TTL_SECONDS
-            return self._cached
+            return self._cached.model_copy(
+                update={
+                    "models": (
+                        *self._cached.models,
+                        *map(_ollama_descriptor, ollama_models),
+                    ),
+                },
+            )
 
 
 model_catalog_service = ModelCatalogService()

--- a/api/app/llms/model_catalog_policy.py
+++ b/api/app/llms/model_catalog_policy.py
@@ -58,17 +58,6 @@ MODEL_CATALOG: Final[tuple[CatalogPolicy, ...]] = (
     _policy(Model.CLAUDE_OPUS_4_8, "anthropic", "Claude Opus 4.8"),
     _policy(Model.CLAUDE_SONNET_5, "anthropic", "Claude Sonnet 5"),
     _policy(Model.CLAUDE_HAIKU_4_5, "anthropic", "Claude Haiku 4.5"),
-    _policy(
-        Model.QWEN3_30B_THINKING,
-        "ollama",
-        "Qwen3 30B Thinking",
-    ),
-    _policy(
-        Model.QWEN3_30B_INSTRUCT,
-        "ollama",
-        "Qwen3 30B Instruct",
-    ),
-    _policy(Model.QWEN3_14B, "ollama", "Qwen3 14B"),
 )
 
 if tuple(policy.model for policy in MODEL_CATALOG) != CHAT_MODEL_ORDER:

--- a/api/app/llms/model_catalog_types.py
+++ b/api/app/llms/model_catalog_types.py
@@ -79,7 +79,7 @@ class OllamaCatalogModel(BaseModel):
 
     id: str
     name: str
-    loaded: bool
+    loaded: bool | None
 
 
 class ModelCatalogResponse(BaseModel):

--- a/api/app/llms/model_catalog_types.py
+++ b/api/app/llms/model_catalog_types.py
@@ -71,6 +71,15 @@ class ModelDescriptor(BaseModel):
     limits: ModelLimits | None = None
     pricing: ModelPricing | None = None
     status: str | None = None
+    loaded: bool | None = None
+
+
+class OllamaCatalogModel(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    name: str
+    loaded: bool
 
 
 class ModelCatalogResponse(BaseModel):

--- a/api/app/llms/models.py
+++ b/api/app/llms/models.py
@@ -63,11 +63,9 @@ CHAT_MODEL_ORDER: Final[tuple[Model, ...]] = (
     Model.CLAUDE_OPUS_4_8,
     Model.CLAUDE_SONNET_5,
     Model.CLAUDE_HAIKU_4_5,
-    Model.QWEN3_30B_THINKING,
-    Model.QWEN3_30B_INSTRUCT,
-    Model.QWEN3_14B,
 )
 CHAT_MODELS: Final[frozenset[Model]] = frozenset(CHAT_MODEL_ORDER)
+type ChatModel = Model | str
 
 OPENAI_QUERY_TRANSFORM_MODELS: Final[frozenset[Model]] = frozenset(
     {
@@ -90,13 +88,7 @@ GOOGLE_QUERY_TRANSFORM_MODELS: Final[frozenset[Model]] = frozenset(
 ANTHROPIC_QUERY_TRANSFORM_MODELS: Final[frozenset[Model]] = frozenset(
     {Model.CLAUDE_OPUS_4_8, Model.CLAUDE_SONNET_5, Model.CLAUDE_HAIKU_4_5},
 )
-OLLAMA_QUERY_TRANSFORM_MODELS: Final[frozenset[Model]] = frozenset(
-    {
-        Model.QWEN3_30B_THINKING,
-        Model.QWEN3_30B_INSTRUCT,
-        Model.QWEN3_14B,
-    },
-)
+OLLAMA_QUERY_TRANSFORM_MODELS: Final[frozenset[Model]] = frozenset()
 QUERY_TRANSFORM_MODELS: Final[frozenset[Model]] = frozenset(
     {
         *OPENAI_QUERY_TRANSFORM_MODELS,
@@ -121,8 +113,6 @@ REASONING_CAPABLE_MODELS: Final[frozenset[Model]] = frozenset(
         Model.CLAUDE_OPUS_4_8,
         Model.CLAUDE_SONNET_5,
         Model.CLAUDE_HAIKU_4_5,
-        Model.QWEN3_30B_THINKING,
-        Model.QWEN3_14B,
     },
 )
 OPENAI_MINIMAL_EFFORT_MODELS: Final[frozenset[Model]] = frozenset()
@@ -161,3 +151,30 @@ def _validate_model_maps() -> None:
 
 
 _validate_model_maps()
+
+
+def model_id(model: ChatModel) -> str:
+    return model.value if isinstance(model, Model) else model
+
+
+def is_ollama_model_tag(value: str) -> bool:
+    stripped = value.strip()
+    return stripped == value and ":" in value and bool(value)
+
+
+def parse_chat_model(value: Model | str, active_models: frozenset[Model]) -> ChatModel:
+    if isinstance(value, Model):
+        if value in active_models:
+            return value
+        raise ValueError("model must be an active chat model")
+    try:
+        model = Model(value)
+    except ValueError:
+        if is_ollama_model_tag(value):
+            return value
+        raise ValueError("model must be an active chat model") from None
+    if model in active_models:
+        return model
+    if is_ollama_model_tag(value):
+        return value
+    raise ValueError("model must be an active chat model")

--- a/api/app/llms/models.py
+++ b/api/app/llms/models.py
@@ -1,3 +1,4 @@
+import re
 from enum import StrEnum
 from typing import Final
 
@@ -66,6 +67,10 @@ CHAT_MODEL_ORDER: Final[tuple[Model, ...]] = (
 )
 CHAT_MODELS: Final[frozenset[Model]] = frozenset(CHAT_MODEL_ORDER)
 type ChatModel = Model | str
+
+_OLLAMA_MODEL_TAG_PATTERN: Final = re.compile(
+    r"[A-Za-z0-9][A-Za-z0-9._/-]*:[A-Za-z0-9][A-Za-z0-9._-]*",
+)
 
 OPENAI_QUERY_TRANSFORM_MODELS: Final[frozenset[Model]] = frozenset(
     {
@@ -158,8 +163,7 @@ def model_id(model: ChatModel) -> str:
 
 
 def is_ollama_model_tag(value: str) -> bool:
-    stripped = value.strip()
-    return stripped == value and ":" in value and bool(value)
+    return _OLLAMA_MODEL_TAG_PATTERN.fullmatch(value) is not None
 
 
 def parse_chat_model(value: Model | str, active_models: frozenset[Model]) -> ChatModel:

--- a/api/app/llms/ollama.py
+++ b/api/app/llms/ollama.py
@@ -3,12 +3,10 @@ import logging
 from collections.abc import Generator
 from typing import overload
 
-import httpx
 from fastapi.responses import StreamingResponse
 from langchain.agents import create_agent
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from langchain_ollama import ChatOllama, OllamaEmbeddings
-from pydantic import BaseModel, ConfigDict, ValidationError
 
 from app.llms.agents import (
     StreamObservation,
@@ -16,36 +14,19 @@ from app.llms.agents import (
     create_agent_token_generator,
     stream_sync_gen_as_sse,
 )
-from app.llms.model_catalog_types import OllamaCatalogModel
 from app.llms.models import ChatModel, Model, model_id
 from app.llms.prompts import build_agent_messages, stitch_conversation
 from app.llms.provider_credentials import require_provider_credential
 from app.llms.tools import get_agent_tools
 from app.schemas.chat_credentials import OLLAMA_DEFAULT_BASE_URL, ChatCredentialSecret
-from app.utils.http_client import get_http_client
+
+from .ollama_catalog import fetch_ollama_catalog
 
 logger = logging.getLogger(__name__)
 
 type _OllamaClientKwargs = dict[str, dict[str, str]]
 
-
-class _OllamaTagModel(BaseModel):
-    model_config = ConfigDict(frozen=True)
-
-    name: str
-    capabilities: tuple[str, ...] = ()
-
-
-class _OllamaTagsResponse(BaseModel):
-    model_config = ConfigDict(frozen=True)
-
-    models: tuple[_OllamaTagModel, ...] = ()
-
-
-class _OllamaPsResponse(BaseModel):
-    model_config = ConfigDict(frozen=True)
-
-    models: tuple[_OllamaTagModel, ...] = ()
+__all__ = ("fetch_ollama_catalog",)
 
 
 def _connection(
@@ -288,37 +269,3 @@ async def stream_ollama_agent_response(
             max_tokens=max_tokens,
             credential=credential,
         )
-
-
-async def fetch_ollama_catalog(
-    credential: ChatCredentialSecret | None,
-) -> tuple[OllamaCatalogModel, ...]:
-    base_url, client_kwargs = _connection(credential)
-    headers = client_kwargs["headers"]
-    timeout = httpx.Timeout(connect=3.0, read=5.0, write=5.0, pool=3.0)
-
-    try:
-        tags_response = await get_http_client().get(
-            f"{base_url.rstrip('/')}/api/tags",
-            headers=headers,
-            timeout=timeout,
-        )
-        ps_response = await get_http_client().get(
-            f"{base_url.rstrip('/')}/api/ps",
-            headers=headers,
-            timeout=timeout,
-        )
-        tags_response.raise_for_status()
-        ps_response.raise_for_status()
-        tags = _OllamaTagsResponse.model_validate(tags_response.json())
-        ps = _OllamaPsResponse.model_validate(ps_response.json())
-    except (httpx.HTTPError, ValidationError, ValueError) as error:
-        logger.warning("Ollama model discovery failed: %s", type(error).__name__)
-        return ()
-
-    loaded = frozenset(model.name for model in ps.models)
-    return tuple(
-        OllamaCatalogModel(id=model.name, name=model.name, loaded=model.name in loaded)
-        for model in tags.models
-        if "completion" in model.capabilities
-    )

--- a/api/app/llms/ollama.py
+++ b/api/app/llms/ollama.py
@@ -3,10 +3,12 @@ import logging
 from collections.abc import Generator
 from typing import overload
 
+import httpx
 from fastapi.responses import StreamingResponse
 from langchain.agents import create_agent
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from langchain_ollama import ChatOllama, OllamaEmbeddings
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from app.llms.agents import (
     StreamObservation,
@@ -14,15 +16,36 @@ from app.llms.agents import (
     create_agent_token_generator,
     stream_sync_gen_as_sse,
 )
-from app.llms.models import Model
+from app.llms.model_catalog_types import OllamaCatalogModel
+from app.llms.models import ChatModel, Model, model_id
 from app.llms.prompts import build_agent_messages, stitch_conversation
 from app.llms.provider_credentials import require_provider_credential
 from app.llms.tools import get_agent_tools
 from app.schemas.chat_credentials import OLLAMA_DEFAULT_BASE_URL, ChatCredentialSecret
+from app.utils.http_client import get_http_client
 
 logger = logging.getLogger(__name__)
 
 type _OllamaClientKwargs = dict[str, dict[str, str]]
+
+
+class _OllamaTagModel(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    capabilities: tuple[str, ...] = ()
+
+
+class _OllamaTagsResponse(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    models: tuple[_OllamaTagModel, ...] = ()
+
+
+class _OllamaPsResponse(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    models: tuple[_OllamaTagModel, ...] = ()
 
 
 def _connection(
@@ -51,7 +74,7 @@ def get_embedder(
 
 
 def get_llm(
-    model: Model,
+    model: ChatModel,
     temperature: float,
     top_p: float,
     max_tokens: int,
@@ -61,7 +84,7 @@ def get_llm(
 ) -> ChatOllama:
     base_url, client_kwargs = _connection(credential)
     return ChatOllama(
-        model=model.value,
+        model=model_id(model),
         base_url=base_url,
         client_kwargs=client_kwargs,
         temperature=temperature,
@@ -112,7 +135,7 @@ async def generate_ollama_embeddings(
 
 def stream_ollama_response(
     user_prompt: str,
-    model: Model,
+    model: ChatModel,
     *,
     system_prompt: str,
     history: list[BaseMessage] | None = None,
@@ -132,7 +155,7 @@ def stream_ollama_response(
     logger.info(
         "Streaming Ollama response for user prompt length: '%d' with model: %s",
         len(user_prompt),
-        model.value,
+        model_id(model),
     )
 
     llm = get_llm(
@@ -154,7 +177,7 @@ def stream_ollama_response(
 
 async def transform_query_with_ollama(
     query: str,
-    model: Model,
+    model: ChatModel,
     *,
     system_prompt: str,
     temperature: float,
@@ -169,7 +192,7 @@ async def transform_query_with_ollama(
 
     logger.info(
         "Transforming query with model=%s query_len=%d",
-        model.value,
+        model_id(model),
         len(query),
     )
 
@@ -197,7 +220,7 @@ async def transform_query_with_ollama(
 
 async def stream_ollama_agent_response(
     user_prompt: str,
-    model: Model,
+    model: ChatModel,
     *,
     system_prompt: str,
     history: list[BaseMessage] | None = None,
@@ -215,7 +238,7 @@ async def stream_ollama_agent_response(
     logger.info(
         "Streaming Ollama agent response for user prompt length: '%d' with model: %s",
         len(user_prompt),
-        model.value,
+        model_id(model),
     )
 
     try:
@@ -250,8 +273,8 @@ async def stream_ollama_agent_response(
         )
         capture_model_fallback(
             observation,
-            from_model=model.value,
-            to_model=model.value,
+            from_model=model_id(model),
+            to_model=model_id(model),
             reason="agent_setup_failed",
         )
 
@@ -265,3 +288,37 @@ async def stream_ollama_agent_response(
             max_tokens=max_tokens,
             credential=credential,
         )
+
+
+async def fetch_ollama_catalog(
+    credential: ChatCredentialSecret | None,
+) -> tuple[OllamaCatalogModel, ...]:
+    base_url, client_kwargs = _connection(credential)
+    headers = client_kwargs["headers"]
+    timeout = httpx.Timeout(connect=3.0, read=5.0, write=5.0, pool=3.0)
+
+    try:
+        tags_response = await get_http_client().get(
+            f"{base_url.rstrip('/')}/api/tags",
+            headers=headers,
+            timeout=timeout,
+        )
+        ps_response = await get_http_client().get(
+            f"{base_url.rstrip('/')}/api/ps",
+            headers=headers,
+            timeout=timeout,
+        )
+        tags_response.raise_for_status()
+        ps_response.raise_for_status()
+        tags = _OllamaTagsResponse.model_validate(tags_response.json())
+        ps = _OllamaPsResponse.model_validate(ps_response.json())
+    except (httpx.HTTPError, ValidationError, ValueError) as error:
+        logger.warning("Ollama model discovery failed: %s", type(error).__name__)
+        return ()
+
+    loaded = frozenset(model.name for model in ps.models)
+    return tuple(
+        OllamaCatalogModel(id=model.name, name=model.name, loaded=model.name in loaded)
+        for model in tags.models
+        if "completion" in model.capabilities
+    )

--- a/api/app/llms/ollama_catalog.py
+++ b/api/app/llms/ollama_catalog.py
@@ -1,0 +1,155 @@
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Final
+
+import anyio
+import httpx
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from app.llms.model_catalog_types import OllamaCatalogModel
+from app.llms.provider_credentials import require_provider_credential
+from app.schemas.chat_credentials import OLLAMA_DEFAULT_BASE_URL, ChatCredentialSecret
+from app.utils.http_client import get_http_client
+
+logger = logging.getLogger(__name__)
+
+_CAPABILITY_CONCURRENCY: Final = 8
+_MAX_DISCOVERY_MODELS: Final = 100
+
+
+class _OllamaTagModel(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    capabilities: tuple[str, ...] = ()
+
+
+class _OllamaTagsResponse(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    models: tuple[_OllamaTagModel, ...] = ()
+
+
+class _OllamaPsResponse(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    models: tuple[_OllamaTagModel, ...] = ()
+
+
+class _OllamaShowResponse(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    capabilities: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class _DiscoveryContext:
+    base_url: str
+    headers: Mapping[str, str]
+    timeout: httpx.Timeout
+    limiter: anyio.CapacityLimiter
+
+
+async def _fetch_capabilities(
+    context: _DiscoveryContext,
+    model_name: str,
+) -> tuple[str, ...]:
+    async with context.limiter:
+        try:
+            response = await get_http_client().post(
+                f"{context.base_url}/api/show",
+                headers=context.headers,
+                json={"model": model_name},
+                timeout=context.timeout,
+            )
+            response.raise_for_status()
+            return _OllamaShowResponse.model_validate(
+                response.json(),
+            ).capabilities
+        except (httpx.HTTPError, ValidationError, ValueError) as error:
+            logger.warning(
+                "Ollama model capability discovery failed: model=%s error=%s",
+                model_name,
+                type(error).__name__,
+            )
+            return ()
+
+
+async def _fetch_loaded_models(
+    context: _DiscoveryContext,
+) -> frozenset[str] | None:
+    try:
+        response = await get_http_client().get(
+            f"{context.base_url}/api/ps",
+            headers=context.headers,
+            timeout=context.timeout,
+        )
+        response.raise_for_status()
+        parsed = _OllamaPsResponse.model_validate(response.json())
+    except (httpx.HTTPError, ValidationError, ValueError) as error:
+        logger.warning(
+            "Ollama loaded-status discovery failed: %s",
+            type(error).__name__,
+        )
+        return None
+    return frozenset(model.name for model in parsed.models)
+
+
+async def fetch_ollama_catalog(
+    credential: ChatCredentialSecret,
+) -> tuple[OllamaCatalogModel, ...]:
+    credential = require_provider_credential("ollama", credential)
+    context = _DiscoveryContext(
+        base_url=(credential.base_url or OLLAMA_DEFAULT_BASE_URL).rstrip("/"),
+        headers={"Authorization": f"Bearer {credential.api_key}"},
+        timeout=httpx.Timeout(connect=3.0, read=5.0, write=5.0, pool=3.0),
+        limiter=anyio.CapacityLimiter(_CAPABILITY_CONCURRENCY),
+    )
+
+    try:
+        response = await get_http_client().get(
+            f"{context.base_url}/api/tags",
+            headers=context.headers,
+            timeout=context.timeout,
+        )
+        response.raise_for_status()
+        tags = _OllamaTagsResponse.model_validate(response.json())
+    except (httpx.HTTPError, ValidationError, ValueError) as error:
+        logger.warning("Ollama model discovery failed: %s", type(error).__name__)
+        return ()
+
+    models = tags.models[:_MAX_DISCOVERY_MODELS]
+    if len(tags.models) > _MAX_DISCOVERY_MODELS:
+        logger.warning(
+            "Ollama model discovery truncated: count=%d limit=%d",
+            len(tags.models),
+            _MAX_DISCOVERY_MODELS,
+        )
+
+    loaded_models: frozenset[str] | None = None
+    discovered_capabilities: dict[str, tuple[str, ...]] = {}
+    async with anyio.create_task_group() as task_group:
+        loaded_handle = task_group.create_task(_fetch_loaded_models(context))
+        capability_handles = {
+            model.name: task_group.create_task(
+                _fetch_capabilities(context, model.name),
+            )
+            for model in models
+            if not model.capabilities
+        }
+        loaded_models = await loaded_handle
+        discovered_capabilities = {
+            name: await handle for name, handle in capability_handles.items()
+        }
+
+    return tuple(
+        OllamaCatalogModel(
+            id=model.name,
+            name=model.name,
+            loaded=(None if loaded_models is None else model.name in loaded_models),
+        )
+        for model in models
+        if "completion"
+        in (model.capabilities or discovered_capabilities.get(model.name, ()))
+    )

--- a/api/app/llms/pricing.py
+++ b/api/app/llms/pricing.py
@@ -5,7 +5,7 @@ marginal token cost and are priced at 0; provider models without a reliable publ
 are omitted, so callers treat their cost as unknown rather than guessing.
 """
 
-from app.llms.models import Model
+from app.llms.models import ChatModel, Model
 
 # (input_usd_per_1m, output_usd_per_1m) for hosted models with a reliable published price.
 HOSTED_PRICING: dict[Model, tuple[float, float]] = {
@@ -32,12 +32,14 @@ SELF_HOSTED_MODELS: frozenset[Model] = frozenset(
 )
 
 
-def is_self_hosted(model: Model) -> bool:
+def is_self_hosted(model: ChatModel) -> bool:
+    if not isinstance(model, Model):
+        return False
     return model in SELF_HOSTED_MODELS
 
 
 def cost_usd(
-    model: Model,
+    model: ChatModel,
     input_tokens: int,
     output_tokens: int,
 ) -> tuple[float, float, float] | None:
@@ -46,6 +48,8 @@ def cost_usd(
     Self-hosted models cost 0; an unpriced hosted model returns None so the caller can flag
     the cost as unknown instead of recording a fabricated 0.
     """
+    if not isinstance(model, Model):
+        return None
     if model in SELF_HOSTED_MODELS:
         return (0.0, 0.0, 0.0)
     price = HOSTED_PRICING.get(model)

--- a/api/app/llms/provider_credentials.py
+++ b/api/app/llms/provider_credentials.py
@@ -6,6 +6,7 @@ from app.llms.models import (
     GOOGLE_QUERY_TRANSFORM_MODELS,
     OLLAMA_QUERY_TRANSFORM_MODELS,
     OPENAI_QUERY_TRANSFORM_MODELS,
+    ChatModel,
     Model,
 )
 from app.schemas.chat_credentials import ChatCredentialSecret
@@ -28,7 +29,9 @@ def require_provider_credential(
     return credential
 
 
-def provider_for_model(model: Model) -> ProviderName | None:
+def provider_for_model(model: ChatModel) -> ProviderName | None:
+    if not isinstance(model, Model):
+        return "ollama"
     if model in OPENAI_QUERY_TRANSFORM_MODELS or model == Model.TEXT_EMBEDDING_3_LARGE:
         return "openai"
     if model in GOOGLE_QUERY_TRANSFORM_MODELS or model == Model.GEMINI_EMBEDDING_001:
@@ -64,7 +67,7 @@ class LlmProviderCredentials:
 
 def has_provider_credential(
     credentials: LlmProviderCredentials | None,
-    model: Model,
+    model: ChatModel,
 ) -> bool:
     provider = provider_for_model(model)
     return provider is None or (

--- a/api/app/llms/query_transform.py
+++ b/api/app/llms/query_transform.py
@@ -7,6 +7,7 @@ from app.llms.models import (
     GOOGLE_QUERY_TRANSFORM_MODELS,
     OLLAMA_QUERY_TRANSFORM_MODELS,
     OPENAI_QUERY_TRANSFORM_MODELS,
+    ChatModel,
     Model,
 )
 from app.llms.ollama import transform_query_with_ollama
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 async def transform_query(
     query: str,
-    model: Model,
+    model: ChatModel,
     *,
     system_prompt: str = DEFAULT_QUERY_TRANSFORM_SYSTEM_PROMPT,
     temperature: float,
@@ -29,9 +30,20 @@ async def transform_query(
 ) -> str:
     logger.info(
         "Transforming query with model=%s query_length=%d",
-        model.value,
+        model.value if isinstance(model, Model) else model,
         len(query),
     )
+
+    if not isinstance(model, Model):
+        return await transform_query_with_ollama(
+            query,
+            model,
+            system_prompt=system_prompt,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            credential=None if credentials is None else credentials.ollama,
+        )
 
     match model:
         case model if model in OPENAI_QUERY_TRANSFORM_MODELS:

--- a/api/app/llms/query_variants.py
+++ b/api/app/llms/query_variants.py
@@ -2,7 +2,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import Literal, assert_never
 
-from app.llms.models import Model
+from app.llms.models import ChatModel
 from app.llms.prompts import HYDE_SYSTEM_PROMPT
 from app.llms.provider_credentials import LlmProviderCredentials
 from app.llms.query_modes import QueryTransformMode
@@ -40,7 +40,7 @@ def query_variant_count(mode: QueryTransformMode) -> int:
 
 async def build_query_variants(
     search_query: str,
-    query_transform_model: Model,
+    query_transform_model: ChatModel,
     mode: QueryTransformMode,
     credentials: LlmProviderCredentials | None = None,
 ) -> QueryVariantBundle:
@@ -92,7 +92,7 @@ async def build_query_variants(
 
 async def _rewrite_query(
     search_query: str,
-    query_transform_model: Model,
+    query_transform_model: ChatModel,
     credentials: LlmProviderCredentials | None = None,
 ) -> str:
     with timed("retrieval.query_rewrite"):
@@ -109,7 +109,7 @@ async def _rewrite_query(
 
 async def _hyde_passage(
     search_query: str,
-    query_transform_model: Model,
+    query_transform_model: ChatModel,
     credentials: LlmProviderCredentials | None = None,
 ) -> str:
     with timed("retrieval.hyde"):

--- a/api/app/llms/streams.py
+++ b/api/app/llms/streams.py
@@ -6,7 +6,7 @@ from langchain_core.messages import BaseMessage
 from app.llms.agents import StreamObservation
 from app.llms.anthropic import stream_anthropic_agent_response
 from app.llms.google import stream_google_agent_response
-from app.llms.models import REASONING_CAPABLE_MODELS, Model
+from app.llms.models import REASONING_CAPABLE_MODELS, ChatModel, Model, model_id
 from app.llms.ollama import stream_ollama_agent_response
 from app.llms.openai import stream_openai_agent_response
 from app.llms.provider_credentials import LlmProviderCredentials
@@ -22,7 +22,7 @@ def _tag_provider(observation: StreamObservation | None, provider: str) -> None:
 
 async def stream_response_with_agent(
     user_prompt: str,
-    model: Model,
+    model: ChatModel,
     *,
     system_prompt: str,
     history: list[BaseMessage],
@@ -38,15 +38,32 @@ async def stream_response_with_agent(
         "Streaming response with agent for user prompt length: '%d' "
         "with model: %s, interface: %s, and %d prior turn(s)",
         len(user_prompt),
-        model.value,
+        model_id(model),
         interface,
         len(history),
     )
 
-    reasoning = reasoning and model in REASONING_CAPABLE_MODELS
+    reasoning = (
+        reasoning and isinstance(model, Model) and model in REASONING_CAPABLE_MODELS
+    )
 
     if observation is not None:
-        observation.model = model.value
+        observation.model = model_id(model)
+
+    if not isinstance(model, Model):
+        _tag_provider(observation, "ollama")
+        return await stream_ollama_agent_response(
+            user_prompt,
+            model,
+            system_prompt=system_prompt,
+            history=history,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            reasoning=reasoning,
+            observation=observation,
+            credential=None if credentials is None else credentials.ollama,
+        )
 
     match model:
         case Model.QWEN3_30B_THINKING | Model.QWEN3_30B_INSTRUCT | Model.QWEN3_14B:

--- a/api/app/schemas/chat.py
+++ b/api/app/schemas/chat.py
@@ -75,7 +75,7 @@ class ChatSchema(BaseModel):
         examples=[DEFAULT_INFERENCE_MODEL.value],
         description=(
             "Which Model to use for generating / streaming the response. "
-            "Must be one of the values in `app.llms.models.Model`."
+            "Must be an active hosted model or an installed Ollama model tag."
         ),
     )
     query_transform_model: ChatModel = Field(

--- a/api/app/schemas/chat.py
+++ b/api/app/schemas/chat.py
@@ -12,7 +12,9 @@ from app.llms.models import (
     ACTIVE_EMBEDDING_MODELS,
     CHAT_MODELS,
     QUERY_TRANSFORM_MODELS,
+    ChatModel,
     Model,
+    parse_chat_model,
 )
 from app.llms.query_modes import QueryTransformMode
 
@@ -68,7 +70,7 @@ class ChatSchema(BaseModel):
             "Must be one of the values in `app.llms.models.Model`."
         ),
     )
-    inference_model: Model = Field(
+    inference_model: ChatModel = Field(
         DEFAULT_INFERENCE_MODEL,
         examples=[DEFAULT_INFERENCE_MODEL.value],
         description=(
@@ -76,7 +78,7 @@ class ChatSchema(BaseModel):
             "Must be one of the values in `app.llms.models.Model`."
         ),
     )
-    query_transform_model: Model = Field(
+    query_transform_model: ChatModel = Field(
         DEFAULT_QUERY_TRANSFORM_MODEL,
         examples=[DEFAULT_QUERY_TRANSFORM_MODEL.value],
         description=(
@@ -147,17 +149,21 @@ class ChatSchema(BaseModel):
 
     @field_validator("query_transform_model")
     @classmethod
-    def _must_support_query_transform(cls, value: Model) -> Model:
-        if value not in QUERY_TRANSFORM_MODELS:
-            raise ValueError("query_transform_model must be a chat-capable model")
-        return value
+    def _must_support_query_transform(cls, value: ChatModel) -> ChatModel:
+        try:
+            return parse_chat_model(value, QUERY_TRANSFORM_MODELS)
+        except ValueError as error:
+            raise ValueError(
+                "query_transform_model must be a chat-capable model",
+            ) from error
 
     @field_validator("inference_model")
     @classmethod
-    def _must_be_active_chat_model(cls, value: Model) -> Model:
-        if value not in CHAT_MODELS:
-            raise ValueError("inference_model must be an active chat model")
-        return value
+    def _must_be_active_chat_model(cls, value: ChatModel) -> ChatModel:
+        try:
+            return parse_chat_model(value, CHAT_MODELS)
+        except ValueError as error:
+            raise ValueError("inference_model must be an active chat model") from error
 
     @field_validator("embeddings_model")
     @classmethod

--- a/api/app/schemas/chat_title.py
+++ b/api/app/schemas/chat_title.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.constants.defaults import DEFAULT_QUERY_TRANSFORM_MODEL
-from app.llms.models import QUERY_TRANSFORM_MODELS, Model
+from app.llms.models import QUERY_TRANSFORM_MODELS, ChatModel, parse_chat_model
 from app.schemas.chat import ConversationTurn
 
 
@@ -19,7 +19,7 @@ class ChatTitleSchema(BaseModel):
         max_length=4,
         description="The first conversation turns used to generate a concise title.",
     )
-    query_transform_model: Model = Field(
+    query_transform_model: ChatModel = Field(
         DEFAULT_QUERY_TRANSFORM_MODEL,
         description="Which chat-capable model to use for title generation.",
     )
@@ -36,10 +36,13 @@ class ChatTitleSchema(BaseModel):
 
     @field_validator("query_transform_model")
     @classmethod
-    def _must_support_title_generation(cls, value: Model) -> Model:
-        if value not in QUERY_TRANSFORM_MODELS:
-            raise ValueError("query_transform_model must be a chat-capable model")
-        return value
+    def _must_support_title_generation(cls, value: ChatModel) -> ChatModel:
+        try:
+            return parse_chat_model(value, QUERY_TRANSFORM_MODELS)
+        except ValueError as error:
+            raise ValueError(
+                "query_transform_model must be a chat-capable model",
+            ) from error
 
     @property
     def first_user_text(self) -> str:

--- a/api/tests/test_api_endpoints.py
+++ b/api/tests/test_api_endpoints.py
@@ -46,7 +46,7 @@ def test_api_exposes_liveness_and_model_catalog_over_http(monkeypatch):
     body = models_without_key.json()
     assert body["version"] == 1
     assert body["source"] in {"live", "stale", "snapshot"}
-    assert len(body["models"]) == 16
+    assert len(body["models"]) == 13
     assert "claude-sonnet-5" in {model["id"] for model in body["models"]}
 
 
@@ -68,7 +68,7 @@ def test_models_endpoint_keeps_unauthenticated_access_with_typed_envelope(monkey
     # Then its contract is a typed, ordered descriptor envelope
     assert response.status_code == 200
     assert response.json()["version"] == 1
-    assert len(response.json()["models"]) == 16
+    assert len(response.json()["models"]) == 13
     assert all(isinstance(model["id"], str) for model in response.json()["models"])
 
 

--- a/api/tests/test_api_endpoints.py
+++ b/api/tests/test_api_endpoints.py
@@ -34,6 +34,10 @@ def test_api_exposes_liveness_and_model_catalog_over_http(monkeypatch):
         liveness = client.get("/health/")
         health = client.get("/health/health")
         models_without_key = client.get("/chat/models")
+        models_with_key = client.get(
+            "/chat/models",
+            headers={"x-api-key": "test-api-key"},
+        )
 
     assert liveness.status_code == 200
     assert liveness.json() == {"message": "The API is up and running."}
@@ -42,16 +46,17 @@ def test_api_exposes_liveness_and_model_catalog_over_http(monkeypatch):
         "healthy": True,
         "status": "ok",
     }
-    assert models_without_key.status_code == 200
-    body = models_without_key.json()
+    assert models_without_key.status_code == 401
+    assert models_with_key.status_code == 200
+    body = models_with_key.json()
     assert body["version"] == 1
     assert body["source"] in {"live", "stale", "snapshot"}
     assert len(body["models"]) == 13
     assert "claude-sonnet-5" in {model["id"] for model in body["models"]}
 
 
-def test_models_endpoint_keeps_unauthenticated_access_with_typed_envelope(monkeypatch):
-    # Given the modernized unauthenticated models endpoint
+def test_models_endpoint_returns_typed_envelope_with_api_key(monkeypatch):
+    # Given the authenticated models endpoint
     monkeypatch.setattr("app.main.Database", HealthyDatabase)
     app = make_app(
         Settings(
@@ -61,9 +66,12 @@ def test_models_endpoint_keeps_unauthenticated_access_with_typed_envelope(monkey
         ),
     )
 
-    # When the endpoint is requested without an API key
+    # When the endpoint is requested with an API key
     with TestClient(app) as client:
-        response = client.get("/chat/models")
+        response = client.get(
+            "/chat/models",
+            headers={"x-api-key": "test-api-key"},
+        )
 
     # Then its contract is a typed, ordered descriptor envelope
     assert response.status_code == 200

--- a/api/tests/test_byok_provider_clients.py
+++ b/api/tests/test_byok_provider_clients.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 
 from app.llms import anthropic, google, ollama, openai
@@ -152,6 +153,30 @@ def test_ollama_byok_client_uses_user_endpoint_and_bearer_key(monkeypatch) -> No
     ]
 
 
+def test_ollama_byok_client_accepts_dynamic_model_tag(monkeypatch) -> None:
+    captured_clients: list[dict] = []
+
+    class OllamaCapturingClient:
+        def __init__(self, **kwargs):
+            captured_clients.append(kwargs)
+
+    monkeypatch.setattr(ollama, "ChatOllama", OllamaCapturingClient)
+
+    ollama.get_llm(
+        "bge-m3:latest",
+        temperature=0.0,
+        top_p=1.0,
+        max_tokens=128,
+        credential=ChatCredentialSecret(
+            provider="ollama",
+            api_key="ollama-user-key",
+            base_url="https://ollama.example",
+        ),
+    )
+
+    assert captured_clients[0]["model"] == "bge-m3:latest"
+
+
 def test_ollama_byok_clients_are_not_shared_between_requests(monkeypatch) -> None:
     captured_clients: list[tuple[str, str]] = []
 
@@ -179,6 +204,41 @@ def test_ollama_byok_clients_are_not_shared_between_requests(monkeypatch) -> Non
         ("https://ollama.com", "Bearer first-user-key"),
         ("https://ollama.com", "Bearer second-user-key"),
     ]
+
+
+@pytest.mark.anyio
+async def test_ollama_catalog_discovers_completion_models_and_loaded_status(
+    monkeypatch,
+) -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/tags":
+            return httpx.Response(
+                200,
+                json={
+                    "models": [
+                        {"name": "llama3.2:latest", "capabilities": ["completion"]},
+                        {"name": "bge-m3:latest", "capabilities": ["embedding"]},
+                    ],
+                },
+            )
+        return httpx.Response(
+            200,
+            json={"models": [{"name": "llama3.2:latest"}]},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        monkeypatch.setattr(ollama, "get_http_client", lambda: client)
+
+        models = await ollama.fetch_ollama_catalog(
+            ChatCredentialSecret(
+                provider="ollama",
+                api_key="ollama-user-key",
+                base_url="https://ollama.example",
+            ),
+        )
+
+    assert [model.id for model in models] == ["llama3.2:latest"]
+    assert models[0].loaded is True
 
 
 @pytest.mark.parametrize(

--- a/api/tests/test_byok_provider_clients.py
+++ b/api/tests/test_byok_provider_clients.py
@@ -1,4 +1,3 @@
-import httpx
 import pytest
 
 from app.llms import anthropic, google, ollama, openai
@@ -204,41 +203,6 @@ def test_ollama_byok_clients_are_not_shared_between_requests(monkeypatch) -> Non
         ("https://ollama.com", "Bearer first-user-key"),
         ("https://ollama.com", "Bearer second-user-key"),
     ]
-
-
-@pytest.mark.anyio
-async def test_ollama_catalog_discovers_completion_models_and_loaded_status(
-    monkeypatch,
-) -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/api/tags":
-            return httpx.Response(
-                200,
-                json={
-                    "models": [
-                        {"name": "llama3.2:latest", "capabilities": ["completion"]},
-                        {"name": "bge-m3:latest", "capabilities": ["embedding"]},
-                    ],
-                },
-            )
-        return httpx.Response(
-            200,
-            json={"models": [{"name": "llama3.2:latest"}]},
-        )
-
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        monkeypatch.setattr(ollama, "get_http_client", lambda: client)
-
-        models = await ollama.fetch_ollama_catalog(
-            ChatCredentialSecret(
-                provider="ollama",
-                api_key="ollama-user-key",
-                base_url="https://ollama.example",
-            ),
-        )
-
-    assert [model.id for model in models] == ["llama3.2:latest"]
-    assert models[0].loaded is True
 
 
 @pytest.mark.parametrize(

--- a/api/tests/test_chat_cost_meta.py
+++ b/api/tests/test_chat_cost_meta.py
@@ -7,7 +7,7 @@ import pytest
 
 from app.api import chat as chat_api
 from app.llms.agents import StreamObservation
-from app.llms.models import Model
+from app.llms.models import ChatModel, Model
 from app.schemas.chat import ChatSchema
 from app.utils.timing import RequestTimings
 
@@ -35,7 +35,7 @@ async def _gpu_fragmented_body() -> AsyncIterator[str]:
 def _run_captured_stream(
     monkeypatch,
     body: AsyncIterator[str],
-    model: Model,
+    model: ChatModel,
 ) -> tuple[list[str], dict[str, object]]:
     captured: list[tuple[str, str, dict[str, object]]] = []
     monkeypatch.setattr(
@@ -91,7 +91,11 @@ def test_chat_stream_emits_cost_diagnostics_when_pricing_is_known(monkeypatch):
 
 
 def test_chat_stream_records_bare_data_token_frames(monkeypatch):
-    chunks, props = _run_captured_stream(monkeypatch, _gpu_body(), Model.QWEN3_14B)
+    chunks, props = _run_captured_stream(
+        monkeypatch,
+        _gpu_body(),
+        "qwen3:14b-q4_K_M",
+    )
 
     assert chunks[0] == "data: self-hosted answer\n\n"
     assert props["$ai_output_choices"] == [
@@ -103,7 +107,7 @@ def test_chat_stream_records_fragmented_bare_data_token_frames(monkeypatch):
     chunks, props = _run_captured_stream(
         monkeypatch,
         _gpu_fragmented_body(),
-        Model.QWEN3_14B,
+        "qwen3:14b-q4_K_M",
     )
 
     assert chunks[:3] == [

--- a/api/tests/test_chat_schema.py
+++ b/api/tests/test_chat_schema.py
@@ -3,6 +3,33 @@ import pytest
 from app.schemas.chat import ChatSchema
 
 
+def test_chat_schema_accepts_dynamic_ollama_chat_model_tag():
+    # Given: an installed Ollama model tag returned by the user's Ollama instance.
+    ollama_model = "bge-m3:latest"
+
+    # When: the model is used for generation and query transformation.
+    payload = ChatSchema(
+        inference_model=ollama_model,
+        messages=[{"role": "user", "content": "hi"}],
+        query_transform_model=ollama_model,
+    )
+
+    # Then: the dynamic tag is preserved instead of being forced through the enum.
+    assert payload.inference_model == ollama_model
+    assert payload.query_transform_model == ollama_model
+
+
+def test_chat_schema_rejects_unknown_non_ollama_chat_model_id():
+    with pytest.raises(
+        ValueError,
+        match="inference_model must be an active chat model",
+    ):
+        ChatSchema(
+            inference_model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+
 def test_chat_schema_rejects_more_than_10_messages():
     messages = [
         {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"}

--- a/api/tests/test_chat_schema.py
+++ b/api/tests/test_chat_schema.py
@@ -30,6 +30,21 @@ def test_chat_schema_rejects_unknown_non_ollama_chat_model_id():
         )
 
 
+@pytest.mark.parametrize(
+    "model_id",
+    [":latest", "llama3.2:", "llama 3:latest", "llama3:latest:extra"],
+)
+def test_chat_schema_rejects_invalid_ollama_model_tags(model_id: str):
+    with pytest.raises(
+        ValueError,
+        match="inference_model must be an active chat model",
+    ):
+        ChatSchema(
+            inference_model=model_id,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+
 def test_chat_schema_rejects_more_than_10_messages():
     messages = [
         {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"}

--- a/api/tests/test_chat_title.py
+++ b/api/tests/test_chat_title.py
@@ -53,7 +53,7 @@ def test_chat_title_uses_transform_prompt_and_normalizes_quotes(monkeypatch):
     payload = ChatTitleSchema(
         user_id=user_id,
         messages=[ConversationTurn(role="user", content="Кога е јунската сесија?")],
-        query_transform_model=Model.QWEN3_14B,
+        query_transform_model="qwen3:14b-q4_K_M",
     )
 
     async def run_title():
@@ -108,7 +108,7 @@ def test_chat_title_falls_back_to_first_user_message_when_model_returns_empty(
                 content="  Како да пријавам испит?\nИ кои се роковите?  ",
             ),
         ],
-        query_transform_model=Model.QWEN3_14B,
+        query_transform_model="qwen3:14b-q4_K_M",
     )
 
     response = anyio.run(chat_title.generate_chat_title, payload)

--- a/api/tests/test_model_catalog.py
+++ b/api/tests/test_model_catalog.py
@@ -13,6 +13,7 @@ from app.llms.model_catalog import (
     fetch_models_dev,
 )
 from app.llms.model_catalog_policy import MODEL_CATALOG
+from app.llms.model_catalog_types import OllamaCatalogModel
 
 EXPECTED_IDS = [
     "gpt-5.6-sol",
@@ -28,9 +29,6 @@ EXPECTED_IDS = [
     "claude-opus-4-8",
     "claude-sonnet-5",
     "claude-haiku-4-5",
-    "qwen3:30b-a3b-thinking-2507-q4_K_M",
-    "qwen3:30b-a3b-instruct-2507-q4_K_M",
-    "qwen3:14b-q4_K_M",
 ]
 
 
@@ -78,11 +76,35 @@ def test_static_catalog_has_exact_order_and_providers_without_tiers() -> None:
         "anthropic",
         "anthropic",
         "anthropic",
-        "ollama",
-        "ollama",
-        "ollama",
     ]
     assert all(not hasattr(entry, "tier") for entry in MODEL_CATALOG)
+
+
+def test_catalog_can_append_dynamic_ollama_models_with_loaded_status() -> None:
+    async def fetch() -> bytes:
+        await anyio.lowlevel.checkpoint()
+        return b"not-json"
+
+    service = ModelCatalogService(fetch_metadata=fetch, clock=FakeClock())
+
+    response = anyio.run(
+        service.get_catalog,
+        (
+            OllamaCatalogModel(id="bge-m3:latest", name="bge-m3:latest", loaded=True),
+            OllamaCatalogModel(
+                id="llama3.2:latest",
+                name="llama3.2:latest",
+                loaded=False,
+            ),
+        ),
+    )
+
+    ollama_models = [model for model in response.models if model.provider == "ollama"]
+    assert [model.id for model in ollama_models] == [
+        "bge-m3:latest",
+        "llama3.2:latest",
+    ]
+    assert [model.loaded for model in ollama_models] == [True, False]
 
 
 def test_remote_metadata_only_enriches_allowlisted_display_fields() -> None:

--- a/api/tests/test_models.py
+++ b/api/tests/test_models.py
@@ -44,9 +44,6 @@ EXPECTED_CHAT_IDS = (
     "claude-opus-4-8",
     "claude-sonnet-5",
     "claude-haiku-4-5",
-    "qwen3:30b-a3b-thinking-2507-q4_K_M",
-    "qwen3:30b-a3b-instruct-2507-q4_K_M",
-    "qwen3:14b-q4_K_M",
 )
 
 

--- a/api/tests/test_ollama_catalog.py
+++ b/api/tests/test_ollama_catalog.py
@@ -1,0 +1,120 @@
+import json
+
+import httpx
+import pytest
+
+from app.llms import ollama
+from app.schemas.chat_credentials import ChatCredentialSecret
+
+
+@pytest.mark.anyio
+async def test_ollama_catalog_discovers_completion_models_and_loaded_status(
+    monkeypatch,
+) -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/tags":
+            return httpx.Response(
+                200,
+                json={
+                    "models": [
+                        {"name": "llama3.2:latest"},
+                        {"name": "bge-m3:latest"},
+                    ],
+                },
+            )
+        if request.url.path == "/api/show":
+            model = json.loads(request.content)["model"]
+            capabilities = (
+                ["completion"] if model == "llama3.2:latest" else ["embedding"]
+            )
+            return httpx.Response(200, json={"capabilities": capabilities})
+        return httpx.Response(200, json={"models": [{"name": "llama3.2:latest"}]})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        monkeypatch.setattr(
+            "app.llms.ollama_catalog.get_http_client",
+            lambda: client,
+        )
+
+        models = await ollama.fetch_ollama_catalog(
+            ChatCredentialSecret(
+                provider="ollama",
+                api_key="ollama-user-key",
+                base_url="https://ollama.example",
+            ),
+        )
+
+    assert [model.id for model in models] == ["llama3.2:latest"]
+    assert models[0].loaded is True
+
+
+@pytest.mark.anyio
+async def test_ollama_catalog_keeps_models_when_loaded_status_is_unavailable(
+    monkeypatch,
+) -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/tags":
+            return httpx.Response(
+                200,
+                json={
+                    "models": [
+                        {"name": "llama3.2:latest", "capabilities": ["completion"]},
+                    ],
+                },
+            )
+        return httpx.Response(503)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        monkeypatch.setattr(
+            "app.llms.ollama_catalog.get_http_client",
+            lambda: client,
+        )
+
+        models = await ollama.fetch_ollama_catalog(
+            ChatCredentialSecret(
+                provider="ollama",
+                api_key="ollama-user-key",
+                base_url="https://ollama.example",
+            ),
+        )
+
+    assert [model.id for model in models] == ["llama3.2:latest"]
+    assert models[0].loaded is None
+
+
+@pytest.mark.anyio
+async def test_ollama_catalog_caps_capability_discovery_fanout(monkeypatch) -> None:
+    show_requests = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal show_requests
+        if request.url.path == "/api/tags":
+            return httpx.Response(
+                200,
+                json={
+                    "models": [
+                        {"name": f"model-{index}:latest"} for index in range(101)
+                    ],
+                },
+            )
+        if request.url.path == "/api/show":
+            show_requests += 1
+            return httpx.Response(200, json={"capabilities": ["completion"]})
+        return httpx.Response(200, json={"models": []})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        monkeypatch.setattr(
+            "app.llms.ollama_catalog.get_http_client",
+            lambda: client,
+        )
+
+        models = await ollama.fetch_ollama_catalog(
+            ChatCredentialSecret(
+                provider="ollama",
+                api_key="ollama-user-key",
+                base_url="https://ollama.example",
+            ),
+        )
+
+    assert len(models) == 100
+    assert show_requests == 100

--- a/api/tests/test_provider_credentials.py
+++ b/api/tests/test_provider_credentials.py
@@ -27,7 +27,13 @@ def test_credential_providers_for_models_includes_retrieval_time_models() -> Non
 
 
 def test_credential_providers_for_models_includes_ollama_models() -> None:
-    providers = credential_providers_for_models(Model.QWEN3_14B, Model.BGE_M3_LOCAL)
+    providers = credential_providers_for_models("qwen3:14b-q4_K_M", Model.BGE_M3_LOCAL)
+
+    assert providers == frozenset({"ollama"})
+
+
+def test_credential_providers_for_models_includes_dynamic_ollama_tags() -> None:
+    providers = credential_providers_for_models("bge-m3:latest", Model.BGE_M3_LOCAL)
 
     assert providers == frozenset({"ollama"})
 

--- a/web/app/api/models/route.ts
+++ b/web/app/api/models/route.ts
@@ -1,5 +1,6 @@
 import type { ModelCatalog } from '@/lib/api-types';
 
+import { getAuthenticatedChatUserId } from '@/lib/authenticated-chat-user';
 import { API_BASE_URL, CHAT_API_KEY } from '@/lib/env';
 import { parseModelCatalog } from '@/lib/model-catalog';
 
@@ -26,7 +27,9 @@ export const GET = async (): Promise<Response> => {
   let upstream: Response;
 
   try {
-    upstream = await fetch(`${API_BASE_URL}/chat/models`, {
+    const userId = await getAuthenticatedChatUserId();
+    const url = `${API_BASE_URL}/chat/models?user_id=${encodeURIComponent(userId)}`;
+    upstream = await fetch(url, {
       headers: { accept: 'application/json', 'x-api-key': CHAT_API_KEY },
       method: 'GET',
     });

--- a/web/app/api/models/route.ts
+++ b/web/app/api/models/route.ts
@@ -7,7 +7,7 @@ import { parseModelCatalog } from '@/lib/model-catalog';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-const CACHE_CONTROL = 'public, max-age=300, stale-while-revalidate=600';
+const CACHE_CONTROL = 'private, no-store';
 
 const ERROR_CATALOG: ModelCatalog = { models: [], source: 'error', version: 1 };
 

--- a/web/components/chat/composer-actions.tsx
+++ b/web/components/chat/composer-actions.tsx
@@ -170,6 +170,14 @@ export const ComposerActions = ({
                   >
                     <span className="flex min-w-0 flex-1 items-center justify-between gap-3">
                       <span className="truncate">{entry.name}</span>
+                      {entry.provider === 'ollama' &&
+                      entry.loaded !== undefined ? (
+                        <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
+                          {entry.loaded
+                            ? t('composer.modelLoaded')
+                            : t('composer.modelNotLoaded')}
+                        </span>
+                      ) : null}
                       {availableProviders.has(entry.provider) ? null : (
                         <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
                           <KeyRound aria-hidden="true" />

--- a/web/components/chat/composer-actions.tsx
+++ b/web/components/chat/composer-actions.tsx
@@ -171,7 +171,7 @@ export const ComposerActions = ({
                     <span className="flex min-w-0 flex-1 items-center justify-between gap-3">
                       <span className="truncate">{entry.name}</span>
                       {entry.provider === 'ollama' &&
-                      entry.loaded !== undefined ? (
+                      typeof entry.loaded === 'boolean' ? (
                         <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
                           {entry.loaded
                             ? t('composer.modelLoaded')

--- a/web/lib/api-types.ts
+++ b/web/lib/api-types.ts
@@ -74,6 +74,7 @@ export type ModelCatalog = {
 export type ModelDescriptor = {
   readonly description?: string;
   readonly id: ModelId;
+  readonly loaded?: boolean | null;
   readonly name: string;
   readonly provider: string;
 };

--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -16,6 +16,8 @@ export const messages = {
     'ФИНКИ Хаб може да направи грешки. Проверете важни информации.',
   'composer.message': 'Порака',
   'composer.model': 'Модел',
+  'composer.modelLoaded': 'Вчитан',
+  'composer.modelNotLoaded': 'Не е вчитан',
   'composer.modelsError': 'Моделите се недостапни',
   'composer.modelsLoading': 'Се вчитуваат модели…',
   'composer.placeholder': 'Напиши порака…',

--- a/web/lib/model-catalog.ts
+++ b/web/lib/model-catalog.ts
@@ -91,7 +91,7 @@ const normalizeDescriptor = (
   if (!isRecord(value)) {
     return null;
   }
-  const { description, id, name, provider } = value;
+  const { description, id, loaded, name, provider } = value;
   if (typeof id !== 'string' || id.length === 0) {
     return null;
   }
@@ -100,6 +100,9 @@ const normalizeDescriptor = (
     (typeof name !== 'string' ||
       name.length === 0 ||
       !isCatalogProvider(provider) ||
+      (loaded !== undefined &&
+        loaded !== null &&
+        typeof loaded !== 'boolean') ||
       (description !== undefined &&
         description !== null &&
         typeof description !== 'string'))
@@ -108,6 +111,7 @@ const normalizeDescriptor = (
   }
   const base = {
     id,
+    ...(typeof loaded === 'boolean' && { loaded }),
     name: typeof name === 'string' && name.length > 0 ? name : id,
     provider: isCatalogProvider(provider) ? provider : inferProvider(id),
   } satisfies ModelDescriptor;

--- a/web/lib/model-catalog.ts
+++ b/web/lib/model-catalog.ts
@@ -111,7 +111,7 @@ const normalizeDescriptor = (
   }
   const base = {
     id,
-    ...(typeof loaded === 'boolean' && { loaded }),
+    ...((loaded === null || typeof loaded === 'boolean') && { loaded }),
     name: typeof name === 'string' && name.length > 0 ? name : id,
     provider: isCatalogProvider(provider) ? provider : inferProvider(id),
   } satisfies ModelDescriptor;

--- a/web/test/api-models.route.test.ts
+++ b/web/test/api-models.route.test.ts
@@ -17,7 +17,7 @@ vi.mock('@/lib/authenticated-chat-user', () => ({
 }));
 
 const CACHE_CONTROL = 'cache-control';
-const CACHE_HEADER = 'public, max-age=300, stale-while-revalidate=600';
+const CACHE_HEADER = 'private, no-store';
 const SOURCE_HEADER = 'x-models-source';
 const LIVE = 'live';
 const ERROR = 'error';
@@ -28,6 +28,7 @@ const GPT_MINI = 'gpt-5.4-mini';
 const GPT_MINI_NAME = 'GPT-5.4 Mini';
 const CLAUDE_5 = 'claude-sonnet-5';
 const CLAUDE_5_NAME = 'Claude Sonnet 5';
+const OLLAMA_MODEL = 'llama3.2:latest';
 
 const okJson = (body: unknown, init?: ResponseInit): Response =>
   Response.json(body, {
@@ -69,6 +70,12 @@ describe('GET /api/models', () => {
           provider: OPENAI,
         },
         { ...claudeSonnet, loaded: false },
+        {
+          id: OLLAMA_MODEL,
+          loaded: null,
+          name: OLLAMA_MODEL,
+          provider: 'ollama',
+        },
       ],
       source: LIVE,
       version: 1,
@@ -102,6 +109,12 @@ describe('GET /api/models', () => {
           provider: OPENAI,
         },
         { ...claudeSonnet, loaded: false },
+        {
+          id: OLLAMA_MODEL,
+          loaded: null,
+          name: OLLAMA_MODEL,
+          provider: 'ollama',
+        },
       ],
       source: LIVE,
       version: 1,

--- a/web/test/api-models.route.test.ts
+++ b/web/test/api-models.route.test.ts
@@ -8,6 +8,14 @@ vi.mock('@/lib/env', () => ({
   env: { API_BASE_URL: 'https://api:8880', CHAT_API_KEY: 'test-key' },
 }));
 
+const USER_ID = '00000000-0000-4000-8000-000000000001';
+
+vi.mock('@/lib/authenticated-chat-user', () => ({
+  getAuthenticatedChatUserId: vi.fn<() => Promise<string>>(() =>
+    Promise.resolve(USER_ID),
+  ),
+}));
+
 const CACHE_CONTROL = 'cache-control';
 const CACHE_HEADER = 'public, max-age=300, stale-while-revalidate=600';
 const SOURCE_HEADER = 'x-models-source';
@@ -60,7 +68,7 @@ describe('GET /api/models', () => {
           pricing: { input: 0.75, output: 4.5 },
           provider: OPENAI,
         },
-        claudeSonnet,
+        { ...claudeSonnet, loaded: false },
       ],
       source: LIVE,
       version: 1,
@@ -75,7 +83,9 @@ describe('GET /api/models', () => {
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
 
-    expect(url).toBe('https://api:8880/chat/models');
+    expect(url).toBe(
+      `https://api:8880/chat/models?user_id=${encodeURIComponent(USER_ID)}`,
+    );
     expect(init.method ?? 'GET').toBe('GET');
     expect(new Headers(init.headers).get('x-api-key')).toBe('test-key');
 
@@ -91,7 +101,7 @@ describe('GET /api/models', () => {
           name: GPT_MINI_NAME,
           provider: OPENAI,
         },
-        claudeSonnet,
+        { ...claudeSonnet, loaded: false },
       ],
       source: LIVE,
       version: 1,

--- a/web/test/composer.test.tsx
+++ b/web/test/composer.test.tsx
@@ -19,6 +19,8 @@ const GPT_CHEAP_NAME = 'GPT-5.4 Nano';
 const OLLAMA_ID = 'llama3.2:latest';
 const OLLAMA_NAME = 'llama3.2:latest';
 const OLLAMA_OPTION_NAME = /llama3\.2:latest/u;
+const OLLAMA_UNKNOWN_ID = 'qwen3:14b';
+const OLLAMA_UNKNOWN_NAME = 'qwen3:14b';
 const MODEL_SELECTOR_TEST_ID = 'composer-model';
 
 const MODELS: ModelDescriptor[] = [
@@ -30,6 +32,12 @@ const MODELS: ModelDescriptor[] = [
   { id: GPT_ID, name: GPT_NAME, provider: 'openai' },
   { id: CLAUDE_ID, name: CLAUDE_NAME, provider: 'anthropic' },
   { id: OLLAMA_ID, loaded: true, name: OLLAMA_NAME, provider: 'ollama' },
+  {
+    id: OLLAMA_UNKNOWN_ID,
+    loaded: null,
+    name: OLLAMA_UNKNOWN_NAME,
+    provider: 'ollama',
+  },
   { id: GPT_CHEAP_ID, name: GPT_CHEAP_NAME, provider: 'openai' },
 ];
 const ALL_PROVIDERS = new Set(['anthropic', 'ollama', 'openai']);
@@ -125,6 +133,9 @@ describe('Composer', () => {
     expect(
       screen.getByRole('option', { name: OLLAMA_OPTION_NAME }),
     ).toHaveTextContent('Вчитан');
+    expect(
+      screen.getByRole('option', { name: OLLAMA_UNKNOWN_NAME }),
+    ).not.toHaveTextContent('Не е вчитан');
   });
 
   it('groups models only by provider in catalog order', async () => {

--- a/web/test/composer.test.tsx
+++ b/web/test/composer.test.tsx
@@ -16,6 +16,9 @@ const GPT_PREMIUM_ID = 'gpt-5.4';
 const GPT_PREMIUM_NAME = 'GPT-5.4';
 const GPT_CHEAP_ID = 'gpt-5.4-nano';
 const GPT_CHEAP_NAME = 'GPT-5.4 Nano';
+const OLLAMA_ID = 'llama3.2:latest';
+const OLLAMA_NAME = 'llama3.2:latest';
+const OLLAMA_OPTION_NAME = /llama3\.2:latest/u;
 const MODEL_SELECTOR_TEST_ID = 'composer-model';
 
 const MODELS: ModelDescriptor[] = [
@@ -26,9 +29,10 @@ const MODELS: ModelDescriptor[] = [
   },
   { id: GPT_ID, name: GPT_NAME, provider: 'openai' },
   { id: CLAUDE_ID, name: CLAUDE_NAME, provider: 'anthropic' },
+  { id: OLLAMA_ID, loaded: true, name: OLLAMA_NAME, provider: 'ollama' },
   { id: GPT_CHEAP_ID, name: GPT_CHEAP_NAME, provider: 'openai' },
 ];
-const ALL_PROVIDERS = new Set(['anthropic', 'openai']);
+const ALL_PROVIDERS = new Set(['anthropic', 'ollama', 'openai']);
 
 const setup = (overrides: Partial<ComponentProps<typeof Composer>> = {}) => {
   const onSubmit = vi.fn<(text: string) => void>();
@@ -118,6 +122,9 @@ describe('Composer', () => {
     expect(
       screen.getByRole('option', { name: GPT_PREMIUM_NAME }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: OLLAMA_OPTION_NAME }),
+    ).toHaveTextContent('Вчитан');
   });
 
   it('groups models only by provider in catalog order', async () => {
@@ -130,6 +137,7 @@ describe('Composer', () => {
     expect(providerLabels.map((label) => label.textContent)).toStrictEqual([
       'OpenAI',
       'Anthropic',
+      'Ollama',
     ]);
   });
 

--- a/web/test/model-catalog.test.ts
+++ b/web/test/model-catalog.test.ts
@@ -74,6 +74,7 @@ const typedModels = [
   },
   {
     id: QWEN_THINKING,
+    loaded: true,
     name: 'Qwen3 30B Thinking',
     provider: OLLAMA,
   },
@@ -103,6 +104,11 @@ describe('parseModelCatalog', () => {
       id: GPT,
       name: 'GPT-5.4',
       provider: OPENAI,
+    });
+    expect(catalog.models.at(-1)).toMatchObject({
+      id: QWEN_THINKING,
+      loaded: true,
+      provider: OLLAMA,
     });
   });
 

--- a/web/test/model-catalog.test.ts
+++ b/web/test/model-catalog.test.ts
@@ -112,6 +112,23 @@ describe('parseModelCatalog', () => {
     });
   });
 
+  it('preserves an unknown Ollama loaded status', () => {
+    const catalog = parseModelCatalog({
+      models: [
+        {
+          id: 'llama3.2:latest',
+          loaded: null,
+          name: 'llama3.2:latest',
+          provider: OLLAMA,
+        },
+      ],
+      source: LIVE,
+      version: 1,
+    });
+
+    expect(catalog.models[0]).toMatchObject({ loaded: null });
+  });
+
   it('normalizes every curated legacy id with its immutable fallback descriptor', () => {
     const catalog = parseModelCatalog(EXPECTED_CURATED_IDS);
 


### PR DESCRIPTION
## Summary
- remove the fixed Ollama chat-model allowlist from the curated hosted model catalog
- discover completion-capable Ollama models from the configured Ollama /api/tags endpoint and annotate loaded status from /api/ps
- pass the authenticated chat user through the web models route and show Ollama loaded/not-loaded labels in the composer

## Verification
- uv run pytest (api): 185 passed
- uv run ruff check . (api): passed
- uv run mypy . (api): success
- npm run check (web): passed
- npm run lint (web): 0 errors, existing warnings only
- npm run test -- --run (web): 56 files / 334 tests passed
- API_BASE_URL=https://api.example.test CHAT_API_KEY=test-key RESUMABLE_STREAM_REDIS_URL=redis://localhost:6379 npm run build (web): passed
- manual driver against https://ollama.finki-hub.com: returned 24 completion-capable models and excluded embedding-only bge-m3:latest
