### PR TITLE
feat(chat): support Discord user identities

### DIFF
--- a/api/app/schemas/chat_user.py
+++ b/api/app/schemas/chat_user.py
@@ -4,6 +4,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.schemas.chat_persistence import JsonValue
+
 ChatUserProvider = Literal["google", "microsoft-entra-id", "discord"]
 
 
@@ -14,7 +16,12 @@ class ChatUserUpsert(BaseModel):
     name: str | None = None
     avatar_url: str | None = None
 
-    @field_validator("provider", "provider_subject", "email", "name", "avatar_url")
+    @field_validator("provider", mode="before")
+    @classmethod
+    def _strip_provider(cls, value: JsonValue) -> JsonValue:
+        return value.strip() if isinstance(value, str) else value
+
+    @field_validator("provider_subject", "email", "name", "avatar_url")
     @classmethod
     def _strip_present_text(cls, value: str | None) -> str | None:
         if value is None:
@@ -27,7 +34,7 @@ class ChatUserUpsert(BaseModel):
 
 class ChatUser(BaseModel):
     id: UUID
-    provider: str
+    provider: ChatUserProvider
     provider_subject: str
     email: str | None = None
     name: str | None = None

--- a/api/app/schemas/chat_user.py
+++ b/api/app/schemas/chat_user.py
@@ -1,11 +1,14 @@
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
 
+ChatUserProvider = Literal["google", "microsoft-entra-id", "discord"]
+
 
 class ChatUserUpsert(BaseModel):
-    provider: str = Field(min_length=1)
+    provider: ChatUserProvider
     provider_subject: str = Field(min_length=1)
     email: str | None = None
     name: str | None = None

--- a/api/resources/migrations/0006_allow_discord_chat_user_provider.sql
+++ b/api/resources/migrations/0006_allow_discord_chat_user_provider.sql
@@ -1,0 +1,5 @@
+ALTER TABLE chat_user
+DROP CONSTRAINT IF EXISTS chat_user_provider_check;
+
+ALTER TABLE chat_user
+ADD CONSTRAINT chat_user_provider_check CHECK (provider IN ('google', 'microsoft-entra-id', 'discord'));

--- a/api/tests/test_chat_state_api.py
+++ b/api/tests/test_chat_state_api.py
@@ -67,6 +67,41 @@ def test_chat_state_upserts_provider_user() -> None:
     assert second.json()["email"] == "new@example.com"
 
 
+def test_chat_state_upserts_discord_provider_user_idempotently() -> None:
+    # Given: an authenticated Discord bot integration resolves a Discord user.
+    db = FakeChatDatabase()
+    client = _client(db)
+
+    # When: the same Discord subject is upserted twice with updated profile metadata.
+    first = client.post(
+        "/chat/state/users",
+        headers=_auth_headers(),
+        json={
+            "provider": "discord",
+            "provider_subject": "123456789012345678",
+            "name": "Discord User",
+            "avatar_url": "https://cdn.discordapp.com/avatars/123456789012345678/old.png",
+        },
+    )
+    second = client.post(
+        "/chat/state/users",
+        headers=_auth_headers(),
+        json={
+            "provider": "discord",
+            "provider_subject": "123456789012345678",
+            "name": "Updated Discord User",
+            "avatar_url": "https://cdn.discordapp.com/avatars/123456789012345678/new.png",
+        },
+    )
+
+    # Then: the backend assigns one stable UUID across both upserts.
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["id"] == second.json()["id"]
+    assert second.json()["provider"] == "discord"
+    assert second.json()["name"] == "Updated Discord User"
+
+
 def test_chat_state_manages_user_credentials_without_exposing_secret() -> None:
     # Given: an authenticated BFF client and no stored BYOK credentials.
     db = FakeChatDatabase()

--- a/api/tests/test_chat_user_schema.py
+++ b/api/tests/test_chat_user_schema.py
@@ -1,0 +1,27 @@
+from app.schemas.chat_user import ChatUser, ChatUserUpsert
+
+
+def test_chat_user_upsert_normalizes_provider_before_literal_validation() -> None:
+    # Given: a supported provider with surrounding transport whitespace.
+    payload = {
+        "provider": " discord ",
+        "provider_subject": " discord-user-1 ",
+    }
+
+    # When: the request schema parses the payload.
+    user = ChatUserUpsert.model_validate(payload)
+
+    # Then: provider validation sees the normalized value.
+    assert user.provider == "discord"
+    assert user.provider_subject == "discord-user-1"
+
+
+def test_chat_user_response_exposes_supported_providers_in_json_schema() -> None:
+    # Given: the response model used by the chat user endpoint.
+    schema = ChatUser.model_json_schema()
+
+    # When: its provider property is rendered for OpenAPI.
+    provider_schema = schema["properties"]["provider"]
+
+    # Then: clients receive the same closed provider set as the request model.
+    assert provider_schema["enum"] == ["google", "microsoft-entra-id", "discord"]

--- a/api/tests/test_migrations.py
+++ b/api/tests/test_migrations.py
@@ -74,13 +74,19 @@ def test_load_migrations_returns_non_empty_sql_files_in_filename_order(
 
 
 def test_chat_user_migration_allows_supported_auth_providers() -> None:
-    # Given: a forward migration owns the persisted provider whitelist update.
-    migration = Path(
+    # Given: forward migrations own the persisted provider whitelist updates.
+    microsoft_migration = Path(
         "resources/migrations/0003_allow_microsoft_chat_user_provider.sql",
     ).read_text()
+    discord_migration = Path(
+        "resources/migrations/0006_allow_discord_chat_user_provider.sql",
+    ).read_text()
 
-    # When / Then: both Auth.js providers accepted by the web BFF are allowed.
-    assert "provider IN ('google', 'microsoft-entra-id')" in migration
+    # When / Then: every provider accepted by the web BFF and Discord bot is allowed.
+    assert "provider IN ('google', 'microsoft-entra-id')" in microsoft_migration
+    assert (
+        "provider IN ('google', 'microsoft-entra-id', 'discord')" in discord_migration
+    )
 
 
 def test_chat_message_parts_migration_adds_nullable_jsonb_column() -> None:


### PR DESCRIPTION
## Summary
- add Discord as a typed chat user identity provider
- add migration 0006 to allow Discord identities in persisted chat users
- cover stable, idempotent Discord identity upserts
- extend migration contract coverage

## Verification
- 24 targeted tests passed
- Ruff checks passed

## Context
Required by the Discord bot per-user BYOK integration.