### PR TITLE
fix(web): show authenticated user name in header

### DIFF
--- a/web/components/shell/auth-button.tsx
+++ b/web/components/shell/auth-button.tsx
@@ -10,9 +10,12 @@ export const AuthButton = () => {
   const { data: session, status } = useSession();
 
   if (status === 'authenticated') {
+    const userLabel =
+      session.user?.name ?? session.user?.email ?? t('auth.signOut');
+
     return (
       <IconButton
-        aria-label={t('auth.signOut')}
+        aria-label={`${t('auth.signOut')}: ${userLabel}`}
         className="w-auto gap-2 px-3"
         onClick={() => {
           void signOut();
@@ -23,8 +26,8 @@ export const AuthButton = () => {
           aria-hidden="true"
           className="h-5 w-5"
         />
-        <span className="hidden max-w-32 truncate sm:inline">
-          {session.user?.name ?? session.user?.email ?? t('auth.signOut')}
+        <span className="block min-w-0 max-w-16 truncate sm:max-w-32">
+          {userLabel}
         </span>
       </IconButton>
     );

--- a/web/components/shell/auth-button.tsx
+++ b/web/components/shell/auth-button.tsx
@@ -10,24 +10,32 @@ export const AuthButton = () => {
   const { data: session, status } = useSession();
 
   if (status === 'authenticated') {
-    const userLabel =
-      session.user?.name ?? session.user?.email ?? t('auth.signOut');
+    const signOutLabel = t('auth.signOut');
+    const userLabel = session.user?.name ?? session.user?.email ?? null;
+    const accessibleLabel =
+      userLabel === null ? signOutLabel : `${signOutLabel}: ${userLabel}`;
 
     return (
       <IconButton
-        aria-label={`${t('auth.signOut')}: ${userLabel}`}
+        aria-label={accessibleLabel}
         className="w-auto gap-2 px-3"
         onClick={() => {
           void signOut();
         }}
-        title={session.user?.email ?? t('auth.signOut')}
+        title={userLabel ?? signOutLabel}
       >
         <LogOut
           aria-hidden="true"
           className="h-5 w-5"
         />
-        <span className="block min-w-0 max-w-16 truncate sm:max-w-32">
-          {userLabel}
+        <span
+          className={
+            userLabel === null
+              ? 'block min-w-0'
+              : 'block min-w-0 max-w-16 truncate sm:max-w-32'
+          }
+        >
+          {userLabel ?? signOutLabel}
         </span>
       </IconButton>
     );

--- a/web/components/shell/header.tsx
+++ b/web/components/shell/header.tsx
@@ -23,7 +23,7 @@ const GitHubIcon = () => (
 
 export const Header = ({ onOpenCredentials, onToggleSidebar }: HeaderProps) => (
   <header className="z-30 shrink-0 border-b border-border/60 bg-background pt-[env(safe-area-inset-top)]">
-    <div className="flex h-14 items-center gap-2 px-3 sm:gap-3 sm:px-4">
+    <div className="flex min-h-14 flex-wrap items-center gap-2 px-3 py-1.5 sm:h-14 sm:flex-nowrap sm:gap-3 sm:px-4 sm:py-0">
       <IconButton
         aria-label={t('header.toggleSidebar')}
         onClick={onToggleSidebar}
@@ -38,7 +38,7 @@ export const Header = ({ onOpenCredentials, onToggleSidebar }: HeaderProps) => (
         className="hidden h-9 w-9 shrink-0 object-contain sm:block"
         src="/logo.png"
       />
-      <h1 className="min-w-0 flex-1 truncate text-base font-bold leading-tight tracking-tight sm:text-lg">
+      <h1 className="min-w-24 flex-1 truncate text-base font-bold leading-tight tracking-tight sm:min-w-0 sm:text-lg">
         {t('header.title')}
       </h1>
       <div className="ml-auto flex shrink-0 items-center gap-2">

--- a/web/e2e/mobile-chat.spec.ts
+++ b/web/e2e/mobile-chat.spec.ts
@@ -3,7 +3,7 @@ import { expect, type Page, test } from '@playwright/test';
 import { installMockChatState } from './helpers/chat-state';
 import { mockModels } from './helpers/models';
 
-const mockSession = async (page: Page): Promise<void> => {
+const mockSession = async (page: Page, name = 'Student'): Promise<void> => {
   await page.route('**/api/health', async (route) => {
     await route.fulfill({
       body: JSON.stringify({ ok: true }),
@@ -15,7 +15,7 @@ const mockSession = async (page: Page): Promise<void> => {
     await route.fulfill({
       body: JSON.stringify({
         expires: '2099-01-01T00:00:00.000Z',
-        user: { email: 'student@example.com', name: 'Student' },
+        user: { email: 'student@example.com', name },
       }),
       contentType: 'application/json',
       status: 200,
@@ -72,4 +72,49 @@ test('mobile primary controls meet the 44px touch target minimum', async ({
     expect(box?.height).toBeGreaterThanOrEqual(44);
     expect(box?.width).toBeGreaterThanOrEqual(44);
   }
+});
+
+test('mobile authenticated header shows the current user name', async ({
+  page,
+}) => {
+  await page.setViewportSize({ height: 812, width: 375 });
+  await mockSession(page);
+  await mockModels(page);
+  await installMockChatState(page, { streamUrl: 'http://127.0.0.1:9/stream' });
+  await page.goto('/');
+
+  const signOutButton = page.getByRole('button', {
+    name: 'Одјави се: Student',
+  });
+  await expect(signOutButton.getByText('Student')).toBeVisible();
+
+  const box = await signOutButton.boundingBox();
+  expect(box?.width).toBeGreaterThan(box?.height ?? Infinity);
+});
+
+test('mobile authenticated header truncates long names without overflowing', async ({
+  page,
+}) => {
+  const name = 'Student With An Exceptionally Long Display Name';
+  await page.setViewportSize({ height: 812, width: 320 });
+  await mockSession(page, name);
+  await mockModels(page);
+  await installMockChatState(page, { streamUrl: 'http://127.0.0.1:9/stream' });
+  await page.goto('/');
+
+  const signOutButton = page.getByRole('button', {
+    name: `Одјави се: ${name}`,
+  });
+  const label = signOutButton.getByText(name);
+  await expect(label).toBeVisible();
+  await expect
+    .poll(async () =>
+      label.evaluate((element) => element.scrollWidth > element.clientWidth),
+    )
+    .toBe(true);
+
+  const box = await signOutButton.boundingBox();
+  expect((box?.x ?? Infinity) + (box?.width ?? Infinity)).toBeLessThanOrEqual(
+    320,
+  );
 });

--- a/web/e2e/mobile-chat.spec.ts
+++ b/web/e2e/mobile-chat.spec.ts
@@ -3,7 +3,21 @@ import { expect, type Page, test } from '@playwright/test';
 import { installMockChatState } from './helpers/chat-state';
 import { mockModels } from './helpers/models';
 
-const mockSession = async (page: Page, name = 'Student'): Promise<void> => {
+type MockSessionUser = {
+  readonly email?: string;
+  readonly name?: string;
+};
+
+const DEFAULT_SESSION_USER = {
+  email: 'student@example.com',
+  name: 'Student',
+} as const satisfies MockSessionUser;
+const STREAM_URL = 'http://127.0.0.1:9/stream';
+
+const mockSession = async (
+  page: Page,
+  user: MockSessionUser = DEFAULT_SESSION_USER,
+): Promise<void> => {
   await page.route('**/api/health', async (route) => {
     await route.fulfill({
       body: JSON.stringify({ ok: true }),
@@ -15,7 +29,7 @@ const mockSession = async (page: Page, name = 'Student'): Promise<void> => {
     await route.fulfill({
       body: JSON.stringify({
         expires: '2099-01-01T00:00:00.000Z',
-        user: { email: 'student@example.com', name },
+        user,
       }),
       contentType: 'application/json',
       status: 200,
@@ -29,7 +43,7 @@ test('mobile drawer traps focus, closes with Escape, and restores the trigger', 
   await page.setViewportSize({ height: 812, width: 375 });
   await mockSession(page);
   await mockModels(page);
-  await installMockChatState(page, { streamUrl: 'http://127.0.0.1:9/stream' });
+  await installMockChatState(page, { streamUrl: STREAM_URL });
   await page.goto('/');
 
   const trigger = page.getByRole('button', {
@@ -57,12 +71,13 @@ test('mobile primary controls meet the 44px touch target minimum', async ({
   await page.setViewportSize({ height: 812, width: 375 });
   await mockSession(page);
   await mockModels(page);
-  await installMockChatState(page, { streamUrl: 'http://127.0.0.1:9/stream' });
+  await installMockChatState(page, { streamUrl: STREAM_URL });
   await page.goto('/');
 
   const controls = [
     page.getByRole('button', { name: 'Прикажи/сокриј странична лента' }),
     page.getByRole('button', { name: 'API клучеви' }),
+    page.getByRole('button', { name: 'Одјави се: Student' }),
     page.getByRole('button', { name: 'Промени тема' }),
     page.getByTestId('composer-submit'),
   ];
@@ -80,7 +95,7 @@ test('mobile authenticated header shows the current user name', async ({
   await page.setViewportSize({ height: 812, width: 375 });
   await mockSession(page);
   await mockModels(page);
-  await installMockChatState(page, { streamUrl: 'http://127.0.0.1:9/stream' });
+  await installMockChatState(page, { streamUrl: STREAM_URL });
   await page.goto('/');
 
   const signOutButton = page.getByRole('button', {
@@ -97,19 +112,28 @@ test('mobile authenticated header truncates long names without overflowing', asy
 }) => {
   const name = 'Student With An Exceptionally Long Display Name';
   await page.setViewportSize({ height: 812, width: 320 });
-  await mockSession(page, name);
+  await mockSession(page, { email: 'student@example.com', name });
   await mockModels(page);
-  await installMockChatState(page, { streamUrl: 'http://127.0.0.1:9/stream' });
+  await installMockChatState(page, { streamUrl: STREAM_URL });
   await page.goto('/');
 
   const signOutButton = page.getByRole('button', {
     name: `Одјави се: ${name}`,
   });
   const label = signOutButton.getByText(name);
+  const title = page.getByRole('heading', { name: 'ФИНКИ Хаб' });
   await expect(label).toBeVisible();
+  await expect(label).toHaveCSS('overflow', 'hidden');
+  await expect(label).toHaveCSS('text-overflow', 'ellipsis');
+  await expect(label).toHaveCSS('white-space', 'nowrap');
   await expect
     .poll(async () =>
       label.evaluate((element) => element.scrollWidth > element.clientWidth),
+    )
+    .toBe(true);
+  await expect
+    .poll(async () =>
+      title.evaluate((element) => element.scrollWidth <= element.clientWidth),
     )
     .toBe(true);
 
@@ -117,4 +141,32 @@ test('mobile authenticated header truncates long names without overflowing', asy
   expect((box?.x ?? Infinity) + (box?.width ?? Infinity)).toBeLessThanOrEqual(
     320,
   );
+});
+
+test('mobile authenticated header shows the full sign-out label without identity', async ({
+  page,
+}) => {
+  await page.setViewportSize({ height: 812, width: 320 });
+  await mockSession(page, {});
+  await mockModels(page);
+  await installMockChatState(page, { streamUrl: STREAM_URL });
+  await page.goto('/');
+
+  const signOutButton = page.getByRole('button', {
+    exact: true,
+    name: 'Одјави се',
+  });
+  const label = signOutButton.getByText('Одјави се');
+
+  await expect(label).toBeVisible();
+  await expect
+    .poll(async () =>
+      label.evaluate((element) => element.scrollWidth <= element.clientWidth),
+    )
+    .toBe(true);
+
+  const box = await signOutButton.boundingBox();
+
+  expect(box?.height).toBeGreaterThanOrEqual(44);
+  expect(box?.width).toBeGreaterThanOrEqual(44);
 });

--- a/web/test/auth-button.test.tsx
+++ b/web/test/auth-button.test.tsx
@@ -40,8 +40,12 @@ describe('AuthButton', () => {
     });
 
     render(<AuthButton />);
-    fireEvent.click(screen.getByRole('button', { name: 'Одјави се' }));
+    const signOutButton = screen.getByRole('button', {
+      name: 'Одјави се: Test User',
+    });
+    fireEvent.click(signOutButton);
 
+    expect(signOutButton).toHaveTextContent('Test User');
     expect(authMocks.signOut).toHaveBeenCalledOnce();
   });
 });

--- a/web/test/auth-button.test.tsx
+++ b/web/test/auth-button.test.tsx
@@ -7,7 +7,10 @@ type MockSessionState =
   | { readonly data: null; readonly status: 'unauthenticated' }
   | {
       readonly data: {
-        readonly user: { readonly email: string; readonly name: string };
+        readonly user: {
+          readonly email?: null | string;
+          readonly name?: null | string;
+        };
       };
       readonly status: 'authenticated';
     };
@@ -47,5 +50,18 @@ describe('AuthButton', () => {
 
     expect(signOutButton).toHaveTextContent('Test User');
     expect(authMocks.signOut).toHaveBeenCalledOnce();
+  });
+
+  it('uses the plain sign-out label when authenticated identity is unavailable', () => {
+    authMocks.useSession.mockReturnValue({
+      data: { user: {} },
+      status: 'authenticated',
+    });
+
+    render(<AuthButton />);
+
+    const signOutButton = screen.getByRole('button', { name: 'Одјави се' });
+
+    expect(signOutButton).toHaveTextContent('Одјави се');
   });
 });


### PR DESCRIPTION
## Summary

- Keep the authenticated user identity visible beside the sign-out icon on mobile and desktop.
- Reflow the narrow mobile header so the full product title and primary controls remain visible.
- Truncate long identity labels with an ellipsis while keeping the complete sign-out label when name and email are unavailable.
- Include the visible identity in the accessible name and preserve 44px mobile touch targets.

## Verification

- `npm run check`
- `npm run lint` (0 errors; 15 pre-existing warnings)
- `npm run test` (355 passed)
- `npm run e2e -- e2e/mobile-chat.spec.ts` (5 passed)
- `npm run build`
- Browser QA at 320px, 375px, and 1280px, including long-name and missing-identity states
- GitHub Actions: TypeScript, ESLint, Vitest, Playwright, CodeQL, and Docker checks passed