### PR TITLE
feat(web): add header control tooltips

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -36,6 +36,7 @@ The chat UI is an operational product surface: fast, quiet, and readable for stu
 - Conversation loading state: preserve the current list/thread during transient failures and present an inline alert with a retry action. Only a confirmed missing conversation clears the selection.
 - Composer submission failure: retain the draft and show an inline retryable error; clear the draft only after the message is accepted.
 - Conversation share action: a header `IconButton` using the existing control tokens and Lucide icons. It is disabled without an active conversation and exposes distinct pending, copied, and failed states without adding a toast system.
+- Header control tooltip: compact header actions reuse the existing Radix `Tooltip` primitive below the control with a 4px offset. Tooltip copy matches the localized accessible name, updates with action state, opens on hover or keyboard focus, and remains hoverable for disabled controls through the documented wrapper pattern.
 - Shared conversation view: a read-only shell with the standard border/background header, brand mark, conversation title, and existing thread renderer. It omits sidebar, composer, credentials, feedback, and regeneration controls.
 
 ## 6. Accessibility

--- a/web/components/shell/auth-button.tsx
+++ b/web/components/shell/auth-button.tsx
@@ -22,7 +22,7 @@ export const AuthButton = () => {
         onClick={() => {
           void signOut();
         }}
-        title={userLabel ?? signOutLabel}
+        title={accessibleLabel}
       >
         <LogOut
           aria-hidden="true"

--- a/web/components/shell/theme-toggle.tsx
+++ b/web/components/shell/theme-toggle.tsx
@@ -93,6 +93,7 @@ export const ThemeToggle = () => {
           return activeTheme === 'dark' ? 'light' : 'dark';
         });
       }}
+      title={t('header.theme')}
     >
       {displayedTheme === 'dark' ? (
         <SunIcon

--- a/web/components/ui/icon-controls.tsx
+++ b/web/components/ui/icon-controls.tsx
@@ -1,33 +1,90 @@
-import type { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react';
+import type {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  ReactElement,
+} from 'react';
 
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
 const iconControlClass =
-  'inline-flex size-11 cursor-pointer items-center justify-center rounded-md border border-input bg-background text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:size-9';
+  'inline-flex size-11 cursor-pointer items-center justify-center rounded-md border border-input bg-background text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none sm:size-9';
+
+const ControlTooltip = ({
+  children,
+  disabled = false,
+  label,
+}: {
+  readonly children: ReactElement;
+  readonly disabled?: boolean;
+  readonly label: string;
+}) => (
+  <TooltipProvider>
+    <Tooltip disableHoverableContent>
+      <TooltipTrigger asChild>
+        {disabled ? <span className="inline-flex">{children}</span> : children}
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        sideOffset={4}
+      >
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
 
 const IconButton = ({
   className,
+  disabled = false,
+  title,
   type = 'button',
   ...props
-}: ButtonHTMLAttributes<HTMLButtonElement>) => (
-  <button
-    className={cn(iconControlClass, className)}
-    type={type}
-    {...props}
-  />
-);
+}: ButtonHTMLAttributes<HTMLButtonElement>) => {
+  const control = (
+    <button
+      className={cn(iconControlClass, className)}
+      disabled={disabled}
+      type={type}
+      {...props}
+    />
+  );
+
+  return title ? (
+    <ControlTooltip
+      disabled={disabled}
+      label={title}
+    >
+      {control}
+    </ControlTooltip>
+  ) : (
+    control
+  );
+};
 
 const IconLink = ({
   className,
   title,
   ...props
-}: AnchorHTMLAttributes<HTMLAnchorElement>) => (
-  <a
-    aria-label={title}
-    className={cn(iconControlClass, className)}
-    title={title}
-    {...props}
-  />
-);
+}: AnchorHTMLAttributes<HTMLAnchorElement>) => {
+  const control = (
+    <a
+      aria-label={title}
+      className={cn(iconControlClass, className)}
+      {...props}
+    />
+  );
+
+  return title ? (
+    <ControlTooltip label={title}>{control}</ControlTooltip>
+  ) : (
+    control
+  );
+};
 
 export { IconButton, IconLink };

--- a/web/e2e/focus.spec.ts
+++ b/web/e2e/focus.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from '@playwright/test';
+import { expect, type Locator, type Page, test } from '@playwright/test';
 
 import { installMockChatState } from './helpers/chat-state';
 import { mockModels } from './helpers/models';
@@ -30,6 +30,9 @@ const mockBackend = async (
   return server;
 };
 
+const tooltipTriggerFor = (control: Locator): Locator =>
+  control.locator('xpath=ancestor-or-self::*[@data-slot="tooltip-trigger"][1]');
+
 test('composer is focused on load and after a response finishes', async ({
   page,
 }) => {
@@ -46,4 +49,66 @@ test('composer is focused on load and after a response finishes', async ({
   await expect(input).toBeFocused();
 
   await server.close();
+});
+
+test('header controls explain their actions on hover and focus', async ({
+  page,
+}) => {
+  await page.route('**/api/auth/session', async (route) => {
+    await route.fulfill({
+      body: 'null',
+      contentType: 'application/json',
+      status: 200,
+    });
+  });
+  await mockModels(page);
+  await installMockChatState(page, {
+    streamUrl: 'http://127.0.0.1:9/stream',
+  });
+  await page.goto('/');
+
+  const shareControl = page.getByRole('button', { name: 'Сподели разговор' });
+  const credentialsControl = page.getByRole('button', { name: 'API клучеви' });
+  const signInControl = page.getByRole('button', { name: 'Најави се' });
+  const githubControl = page.getByRole('link', {
+    name: 'GitHub репозиториум',
+  });
+  const headerTitle = page.getByRole('heading', { name: 'ФИНКИ Хаб' });
+  const tooltip = page.getByRole('tooltip');
+
+  await expect(shareControl).toBeDisabled();
+
+  const controls = [
+    {
+      control: shareControl,
+      label: 'Сподели разговор',
+    },
+    {
+      control: credentialsControl,
+      label: 'API клучеви',
+    },
+    {
+      control: signInControl,
+      label: 'Најави се',
+    },
+    {
+      control: githubControl,
+      label: 'GitHub репозиториум',
+    },
+  ];
+
+  for (const { control, label } of controls) {
+    await tooltipTriggerFor(control).hover();
+    await expect(tooltip).toHaveText(label);
+    await headerTitle.hover();
+    await expect(tooltip).toBeHidden();
+  }
+
+  for (const { control, label } of controls.slice(1)) {
+    await expect(control).toBeEnabled();
+    await control.focus();
+    await expect(tooltip).toHaveText(label);
+    await page.keyboard.press('Escape');
+    await expect(tooltip).toBeHidden();
+  }
 });

--- a/web/e2e/focus.spec.ts
+++ b/web/e2e/focus.spec.ts
@@ -73,6 +73,7 @@ test('header controls explain their actions on hover and focus', async ({
   const githubControl = page.getByRole('link', {
     name: 'GitHub репозиториум',
   });
+  const themeControl = page.getByRole('button', { name: 'Промени тема' });
   const headerTitle = page.getByRole('heading', { name: 'ФИНКИ Хаб' });
   const tooltip = page.getByRole('tooltip');
 
@@ -94,6 +95,10 @@ test('header controls explain their actions on hover and focus', async ({
     {
       control: githubControl,
       label: 'GitHub репозиториум',
+    },
+    {
+      control: themeControl,
+      label: 'Промени тема',
     },
   ];
 


### PR DESCRIPTION
## Summary
- reuse the existing Radix tooltip primitive for top-right header controls
- keep tooltip labels synchronized with accessible and dynamic action labels, including disabled controls
- add Playwright coverage and document the tooltip pattern in the design system

## Verification
- `npm run check`
- `npm run test` (378 tests)
- `npm run lint` (0 errors; existing warnings only)
- `PLAYWRIGHT_AUTH_BYPASS=1 RESUMABLE_STREAM_REDIS_URL=redis://127.0.0.1:6379 npm run build`
- `npx playwright test e2e/focus.spec.ts --project=chromium --grep "header controls explain"`
- visual QA at 375px, 768px, and 1280px