### PR TITLE
feat(web): add sidebar action tooltips

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,7 +25,7 @@ The chat UI is an operational product surface: fast, quiet, and readable for stu
 ## 5. Components
 
 - Sidebar conversation row: selectable title button plus compact row-action icon buttons that reveal on hover/focus for desktop and stay visible on mobile.
-- Row action button: Lucide icon, `size-3.5`, semantic aria label, focus-visible ring, muted default color, stronger hover color matching the action intent.
+- Row action button: Lucide icon, `size-3.5`, semantic aria label, focus-visible ring, muted default color, stronger hover color matching the action intent, and the existing Radix tooltip using the same localized label on hover or keyboard focus.
 - Destructive row action: use destructive hover color only for delete.
 - Auth sign-in panel: card surface using `card`, `border`, `background`, `primary`, and `muted-foreground` tokens, with provider buttons that visibly change border/background on hover and use `focus-visible:ring-ring`.
 - Auth sign-in content: limit the supporting value list to 2 concise benefits so the primary action remains visible on small screens. The panel uses `Започни разговор`, and provider actions follow `Продолжи со {provider.name}`.

--- a/web/components/shell/conversation-action-tooltip.tsx
+++ b/web/components/shell/conversation-action-tooltip.tsx
@@ -1,0 +1,34 @@
+import type { ReactElement } from 'react';
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+type ConversationActionTooltipProps = {
+  readonly children: ReactElement;
+  readonly disabled?: boolean;
+  readonly label: string;
+};
+
+export const ConversationActionTooltip = ({
+  children,
+  disabled = false,
+  label,
+}: ConversationActionTooltipProps) => (
+  <TooltipProvider>
+    <Tooltip disableHoverableContent>
+      <TooltipTrigger asChild>
+        {disabled ? <span className="inline-flex">{children}</span> : children}
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        sideOffset={4}
+      >
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);

--- a/web/components/shell/conversation-list.tsx
+++ b/web/components/shell/conversation-list.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import type { MaybeAsyncAction } from '@/lib/action-result';
 import type { ConversationRow } from '@/lib/conversation-types';
 
+import { ConversationActionTooltip } from '@/components/shell/conversation-action-tooltip';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
@@ -105,55 +106,64 @@ export const ConversationList = ({
                 data-testid="row-actions"
               >
                 {onGenerateTitle ? (
-                  <button
-                    aria-busy={isGeneratingTitle || undefined}
-                    aria-label={t('conversation.generateTitle')}
-                    className="inline-flex size-11 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-background hover:text-primary focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-60 sm:pointer-fine:size-6"
+                  <ConversationActionTooltip
                     disabled={isGeneratingAnyTitle}
+                    label={t('conversation.generateTitle')}
+                  >
+                    <button
+                      aria-busy={isGeneratingTitle || undefined}
+                      aria-label={t('conversation.generateTitle')}
+                      className="inline-flex size-11 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-background hover:text-primary focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-60 sm:pointer-fine:size-6"
+                      disabled={isGeneratingAnyTitle}
+                      onClick={() => {
+                        onGenerateTitle(c.id);
+                      }}
+                      type="button"
+                    >
+                      {isGeneratingTitle ? (
+                        <LoaderCircle
+                          aria-hidden="true"
+                          className="size-3.5 animate-spin"
+                        />
+                      ) : (
+                        <WandSparkles
+                          aria-hidden="true"
+                          className="size-3.5"
+                        />
+                      )}
+                    </button>
+                  </ConversationActionTooltip>
+                ) : null}
+                <ConversationActionTooltip label={t('conversation.rename')}>
+                  <button
+                    aria-label={t('conversation.rename')}
+                    className="inline-flex size-11 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-background hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 sm:pointer-fine:size-6"
                     onClick={() => {
-                      onGenerateTitle(c.id);
+                      openRename(c);
                     }}
                     type="button"
                   >
-                    {isGeneratingTitle ? (
-                      <LoaderCircle
-                        aria-hidden="true"
-                        className="size-3.5 animate-spin"
-                      />
-                    ) : (
-                      <WandSparkles
-                        aria-hidden="true"
-                        className="size-3.5"
-                      />
-                    )}
+                    <Pencil
+                      aria-hidden="true"
+                      className="size-3.5"
+                    />
                   </button>
-                ) : null}
-                <button
-                  aria-label={t('conversation.rename')}
-                  className="inline-flex size-11 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-background hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 sm:pointer-fine:size-6"
-                  onClick={() => {
-                    openRename(c);
-                  }}
-                  type="button"
-                >
-                  <Pencil
-                    aria-hidden="true"
-                    className="size-3.5"
-                  />
-                </button>
-                <button
-                  aria-label={t('conversation.delete')}
-                  className="inline-flex size-11 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-background hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring/50 sm:pointer-fine:size-6"
-                  onClick={() => {
-                    setPendingDelete(c);
-                  }}
-                  type="button"
-                >
-                  <Trash2
-                    aria-hidden="true"
-                    className="size-3.5"
-                  />
-                </button>
+                </ConversationActionTooltip>
+                <ConversationActionTooltip label={t('conversation.delete')}>
+                  <button
+                    aria-label={t('conversation.delete')}
+                    className="inline-flex size-11 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-background hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring/50 sm:pointer-fine:size-6"
+                    onClick={() => {
+                      setPendingDelete(c);
+                    }}
+                    type="button"
+                  >
+                    <Trash2
+                      aria-hidden="true"
+                      className="size-3.5"
+                    />
+                  </button>
+                </ConversationActionTooltip>
               </span>
             </li>
           );

--- a/web/e2e/focus.spec.ts
+++ b/web/e2e/focus.spec.ts
@@ -108,3 +108,42 @@ test('header controls explain their actions on hover and focus', async ({
     await expect(tooltip).toBeHidden();
   }
 });
+
+test('sidebar conversation actions explain their actions on hover and focus', async ({
+  page,
+}) => {
+  await mockModels(page);
+  await installMockChatState(page, {
+    conversations: [
+      {
+        id: 'c1',
+        model: MODEL,
+        title: 'Прв разговор',
+      },
+    ],
+    streamUrl: 'http://127.0.0.1:9/stream',
+  });
+  await page.goto('/');
+
+  const item = page.getByTestId('conversation-c1');
+  const conversationTitle = item.getByRole('button', { name: 'Прв разговор' });
+  const tooltip = page.getByRole('tooltip');
+  const controls = ['Генерирај име', 'Преименувај', 'Избриши'].map((label) => ({
+    control: item.getByRole('button', { name: label }),
+    label,
+  }));
+
+  for (const { control, label } of controls) {
+    await tooltipTriggerFor(control).hover();
+    await expect(tooltip).toHaveText(label);
+    await conversationTitle.hover();
+    await expect(tooltip).toBeHidden();
+  }
+
+  for (const { control, label } of controls) {
+    await control.focus();
+    await expect(tooltip).toHaveText(label);
+    await page.keyboard.press('Escape');
+    await expect(tooltip).toBeHidden();
+  }
+});

--- a/web/test/conversation-list-tooltip.test.tsx
+++ b/web/test/conversation-list-tooltip.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ConversationRow } from '@/lib/conversation-types';
+
+import { ConversationList } from '@/components/shell/conversation-list';
+
+const conversations: ConversationRow[] = [
+  {
+    id: 'c1',
+    model: 'claude-sonnet-5',
+    title: 'Прв разговор',
+  },
+];
+
+const actionLabels = ['Генерирај име', 'Преименувај', 'Избриши'] as const;
+
+describe('ConversationList action tooltips', () => {
+  it.each(actionLabels)(
+    'shows “%s” when its action is hovered',
+    async (label) => {
+      const user = userEvent.setup();
+      const onDelete = vi.fn<(id: string) => void>();
+      const onGenerateTitle = vi.fn<(id: string) => void>();
+      const onRename = vi.fn<(id: string, title: string) => void>();
+      const onSelect = vi.fn<(id: string) => void>();
+
+      render(
+        <ConversationList
+          activeId={null}
+          conversations={conversations}
+          onDelete={onDelete}
+          onGenerateTitle={onGenerateTitle}
+          onRename={onRename}
+          onSelect={onSelect}
+        />,
+      );
+
+      const item = screen.getByTestId('conversation-c1');
+      await user.hover(within(item).getByRole('button', { name: label }));
+
+      await expect(screen.findByRole('tooltip')).resolves.toHaveTextContent(
+        label,
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add localized Radix tooltips to regenerate-title, rename, and delete sidebar actions
- preserve disabled-state hover help, keyboard focus behavior, and coarse-pointer touch targets
- add component and Chromium regression coverage and document the row-action contract

## Verification
- `npm test` (402 tests)
- `npm run check`
- `npm run lint`
- production `npm run build` with required server environment
- `npm run e2e -- e2e/focus.spec.ts --project=chromium`
- manual Chromium QA at desktop and mobile sizes
- dual visual QA and five-lane pre-PR review passed