### PR TITLE
feat(web): add answer action tooltips

### DIFF
--- a/web/components/chat/answer-actions.tsx
+++ b/web/components/chat/answer-actions.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
 
+import { ControlTooltip } from '@/components/ui/icon-controls';
 import { t } from '@/lib/i18n';
 import { lastText } from '@/lib/message-parts';
 import { cn } from '@/lib/utils';
@@ -82,80 +83,97 @@ export const AnswerActions = ({
       className="flex items-center gap-1"
       data-testid="answer-actions"
     >
-      <button
-        aria-label={t('actions.copy')}
-        className={BTN}
-        onClick={() => {
-          void copy();
-        }}
-        type="button"
-      >
-        {copied ? (
-          <Check
-            aria-hidden="true"
-            className="size-4"
-          />
-        ) : (
-          <Copy
-            aria-hidden="true"
-            className="size-4"
-          />
-        )}
-      </button>
-      {onRegenerate ? (
+      <ControlTooltip label={t('actions.copy')}>
         <button
-          aria-label={t('actions.regenerate')}
+          aria-label={t('actions.copy')}
           className={BTN}
-          disabled={regenerateDisabled}
-          onClick={onRegenerate}
+          onClick={() => {
+            void copy();
+          }}
           type="button"
         >
-          <RotateCcw
+          {copied ? (
+            <Check
+              aria-hidden="true"
+              className="size-4"
+            />
+          ) : (
+            <Copy
+              aria-hidden="true"
+              className="size-4"
+            />
+          )}
+        </button>
+      </ControlTooltip>
+      {onRegenerate ? (
+        <ControlTooltip
+          disabled={regenerateDisabled}
+          label={t('actions.regenerate')}
+        >
+          <button
+            aria-label={t('actions.regenerate')}
+            className={BTN}
+            disabled={regenerateDisabled}
+            onClick={onRegenerate}
+            type="button"
+          >
+            <RotateCcw
+              aria-hidden="true"
+              className="size-4"
+            />
+          </button>
+        </ControlTooltip>
+      ) : null}
+      <ControlTooltip
+        disabled={pending}
+        label={t('actions.like')}
+      >
+        <button
+          aria-label={t('actions.like')}
+          aria-pressed={vote === 'like'}
+          className={cn(
+            BTN,
+            vote === 'like' &&
+              'bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground',
+          )}
+          data-testid="like-button"
+          disabled={pending}
+          onClick={() => {
+            void sendFeedback('like');
+          }}
+          type="button"
+        >
+          <ThumbsUp
             aria-hidden="true"
-            className="size-4"
+            className={cn('size-4', vote === 'like' && 'fill-current')}
           />
         </button>
-      ) : null}
-      <button
-        aria-label={t('actions.like')}
-        aria-pressed={vote === 'like'}
-        className={cn(
-          BTN,
-          vote === 'like' &&
-            'bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground',
-        )}
-        data-testid="like-button"
+      </ControlTooltip>
+      <ControlTooltip
         disabled={pending}
-        onClick={() => {
-          void sendFeedback('like');
-        }}
-        type="button"
+        label={t('actions.dislike')}
       >
-        <ThumbsUp
-          aria-hidden="true"
-          className={cn('size-4', vote === 'like' && 'fill-current')}
-        />
-      </button>
-      <button
-        aria-label={t('actions.dislike')}
-        aria-pressed={vote === 'dislike'}
-        className={cn(
-          BTN,
-          vote === 'dislike' &&
-            'bg-destructive text-destructive-foreground hover:bg-destructive/90 hover:text-destructive-foreground',
-        )}
-        data-testid="dislike-button"
-        disabled={pending}
-        onClick={() => {
-          void sendFeedback('dislike');
-        }}
-        type="button"
-      >
-        <ThumbsDown
-          aria-hidden="true"
-          className={cn('size-4', vote === 'dislike' && 'fill-current')}
-        />
-      </button>
+        <button
+          aria-label={t('actions.dislike')}
+          aria-pressed={vote === 'dislike'}
+          className={cn(
+            BTN,
+            vote === 'dislike' &&
+              'bg-destructive text-destructive-foreground hover:bg-destructive/90 hover:text-destructive-foreground',
+          )}
+          data-testid="dislike-button"
+          disabled={pending}
+          onClick={() => {
+            void sendFeedback('dislike');
+          }}
+          type="button"
+        >
+          <ThumbsDown
+            aria-hidden="true"
+            className={cn('size-4', vote === 'dislike' && 'fill-current')}
+          />
+        </button>
+      </ControlTooltip>
     </div>
   );
 };

--- a/web/components/ui/icon-controls.tsx
+++ b/web/components/ui/icon-controls.tsx
@@ -87,4 +87,4 @@ const IconLink = ({
   );
 };
 
-export { IconButton, IconLink };
+export { ControlTooltip, IconButton, IconLink };

--- a/web/e2e/focus.spec.ts
+++ b/web/e2e/focus.spec.ts
@@ -72,12 +72,15 @@ test('answer actions explain their actions on hover and focus', async ({
   const answer = page.getByTestId('answer-text');
   const actions = page.getByTestId('answer-actions');
   const tooltip = page.getByRole('tooltip');
-  const controls = ['Копирај', 'Регенерирај', 'Допаѓа', 'Не допаѓа'].map(
-    (label) => ({
-      control: actions.getByRole('button', { exact: true, name: label }),
-      label,
-    }),
-  );
+  const controls = [
+    'Копирај',
+    'Регенерирај',
+    'Ми се допаѓа',
+    'Не ми се допаѓа',
+  ].map((label) => ({
+    control: actions.getByRole('button', { exact: true, name: label }),
+    label,
+  }));
 
   for (const { control, label } of controls) {
     await tooltipTriggerFor(control).hover();

--- a/web/e2e/focus.spec.ts
+++ b/web/e2e/focus.spec.ts
@@ -51,6 +51,51 @@ test('composer is focused on load and after a response finishes', async ({
   await server.close();
 });
 
+test('answer actions explain their actions on hover and focus', async ({
+  page,
+}) => {
+  await page.route('**/api/health', async (route) => {
+    await route.fulfill({
+      body: JSON.stringify({ ok: true }),
+      contentType: 'application/json',
+      status: 200,
+    });
+  });
+  const server = await mockBackend(page);
+  await page.goto('/');
+
+  const input = page.getByTestId('composer-input');
+  await input.fill('Прашање');
+  await input.press('Enter');
+  await expect(page.getByTestId('answer-text')).toContainText('Готово');
+
+  const answer = page.getByTestId('answer-text');
+  const actions = page.getByTestId('answer-actions');
+  const tooltip = page.getByRole('tooltip');
+  const controls = ['Копирај', 'Регенерирај', 'Допаѓа', 'Не допаѓа'].map(
+    (label) => ({
+      control: actions.getByRole('button', { exact: true, name: label }),
+      label,
+    }),
+  );
+
+  for (const { control, label } of controls) {
+    await tooltipTriggerFor(control).hover();
+    await expect(tooltip).toHaveText(label);
+    await answer.hover();
+    await expect(tooltip).toBeHidden();
+  }
+
+  for (const { control, label } of controls) {
+    await control.focus();
+    await expect(tooltip).toHaveText(label);
+    await page.keyboard.press('Escape');
+    await expect(tooltip).toBeHidden();
+  }
+
+  await server.close();
+});
+
 test('header controls explain their actions on hover and focus', async ({
   page,
 }) => {

--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -1,7 +1,7 @@
 export const messages = {
   'actions.copy': 'Копирај',
-  'actions.dislike': 'Не допаѓа',
-  'actions.like': 'Допаѓа',
+  'actions.dislike': 'Не ми се допаѓа',
+  'actions.like': 'Ми се допаѓа',
   'actions.regenerate': 'Регенерирај',
   'app.title': 'ФИНКИ Хаб',
   'auth.signIn': 'Најави се',

--- a/web/test/answer-actions.test.tsx
+++ b/web/test/answer-actions.test.tsx
@@ -25,6 +25,7 @@ const ack = Response.json(
 );
 
 const PRESSED = 'aria-pressed';
+const LIKE_LABEL = 'Ми се допаѓа';
 
 const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue();
 
@@ -60,7 +61,7 @@ describe('AnswerActions', () => {
 describe('AnswerActions feedback', () => {
   it('posts a like to /api/feedback with only the response id and vote', async () => {
     render(<AnswerActions message={assistant('resp-9', 'Готов одговор')} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Допаѓа' }));
+    fireEvent.click(screen.getByRole('button', { name: LIKE_LABEL }));
 
     const fetchMock = fetch as unknown as ReturnType<
       typeof vi.fn<typeof fetch>
@@ -81,7 +82,7 @@ describe('AnswerActions feedback', () => {
 
   it('posts a dislike and marks it as pressed', async () => {
     render(<AnswerActions message={assistant('resp-9')} />);
-    const dislike = screen.getByRole('button', { name: 'Не допаѓа' });
+    const dislike = screen.getByRole('button', { name: 'Не ми се допаѓа' });
     fireEvent.click(dislike);
 
     await waitFor(() => {
@@ -101,7 +102,7 @@ describe('AnswerActions feedback', () => {
 
   it('marks the like button with selected action colors once pressed', async () => {
     render(<AnswerActions message={assistant('resp-9')} />);
-    const like = screen.getByRole('button', { name: 'Допаѓа' });
+    const like = screen.getByRole('button', { name: LIKE_LABEL });
     fireEvent.click(like);
 
     await waitFor(() => {
@@ -120,7 +121,7 @@ describe('AnswerActions feedback', () => {
     };
     render(<AnswerActions message={message} />);
 
-    expect(screen.getByRole('button', { name: 'Допаѓа' })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: LIKE_LABEL })).toHaveAttribute(
       PRESSED,
       'true',
     );
@@ -134,7 +135,7 @@ describe('AnswerActions feedback', () => {
         onVote={onVote}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Допаѓа' }));
+    fireEvent.click(screen.getByRole('button', { name: LIKE_LABEL }));
 
     await waitFor(() => {
       expect(onVote).toHaveBeenCalledWith('like');
@@ -155,7 +156,7 @@ describe('AnswerActions feedback', () => {
         onVote={onVote}
       />,
     );
-    const like = screen.getByRole('button', { name: 'Допаѓа' });
+    const like = screen.getByRole('button', { name: LIKE_LABEL });
     fireEvent.click(like);
 
     await waitFor(() => {
@@ -174,7 +175,7 @@ describe('AnswerActions feedback', () => {
         pending
       />,
     );
-    const like = screen.getByRole('button', { name: 'Допаѓа' });
+    const like = screen.getByRole('button', { name: LIKE_LABEL });
     fireEvent.click(like);
 
     expect(like).toBeDisabled();


### PR DESCRIPTION
## Summary
- reuse the existing `ControlTooltip` for assistant-message actions
- add localized tooltips to copy, regenerate, like, and dislike controls
- cover hover and keyboard-focus behavior in Playwright

## Testing
- `npm run check`
- `npm run lint` (passes with 18 pre-existing warnings)
- `npm run test`
- `npm run build`
- `npm run e2e -- focus.spec.ts --grep "answer actions"`
- manual Chromium QA at desktop and mobile sizes