### PR TITLE
fix: allow retracting message feedback

### DIFF
--- a/api/app/api/feedback.py
+++ b/api/app/api/feedback.py
@@ -5,11 +5,16 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from app.data.connection import Database
 from app.data.db import get_db
 from app.data.feedback import (
-    server_owned_web_feedback,
-    set_web_chat_message_feedback,
+    retract_web_feedback,
     upsert_feedback,
+    upsert_web_feedback,
 )
-from app.schemas.feedback import FeedbackAckSchema, FeedbackSchema
+from app.schemas.feedback import (
+    FeedbackAckSchema,
+    FeedbackRetractionAckSchema,
+    FeedbackRetractionSchema,
+    FeedbackSchema,
+)
 from app.utils.auth import verify_api_key
 from app.utils.posthog_client import capture
 
@@ -47,27 +52,18 @@ async def submit_feedback(
     db: Database = db_dep,
 ) -> FeedbackAckSchema:
     feedback = payload
+    ack: FeedbackAckSchema | None
     if payload.client == "web":
-        owned = await server_owned_web_feedback(db, payload)
-        if owned is None:
+        stored = await upsert_web_feedback(db, payload)
+        if stored is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Response not found",
             )
-        updated = await set_web_chat_message_feedback(
-            db,
-            feedback_type=payload.feedback_type,
-            response_id=payload.response_id,
-            user_id=payload.user_id,
-        )
-        if not updated:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Response not found",
-            )
-        feedback = owned
-
-    ack = await upsert_feedback(db, feedback)
+        feedback = stored.feedback
+        ack = stored.ack
+    else:
+        ack = await upsert_feedback(db, feedback)
 
     if ack is None:
         raise HTTPException(
@@ -96,3 +92,50 @@ async def submit_feedback(
     )
 
     return ack
+
+
+@router.delete(
+    "/feedback",
+    summary="Retract response feedback",
+    description="Remove the authenticated web user's feedback for an owned response.",
+    status_code=status.HTTP_200_OK,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid or missing API Key",
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Response not found",
+        },
+    },
+    dependencies=[api_key_dep],
+    operation_id="retractFeedback",
+)
+async def retract_feedback(
+    payload: FeedbackRetractionSchema,
+    db: Database = db_dep,
+) -> FeedbackRetractionAckSchema:
+    retracted = await retract_web_feedback(
+        db,
+        response_id=payload.response_id,
+        user_id=payload.user_id,
+    )
+    if not retracted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Response not found",
+        )
+
+    capture(
+        payload.user_id,
+        "chat_feedback_retracted",
+        {
+            "response_id": str(payload.response_id),
+            "client": payload.client,
+        },
+    )
+    logger.info(
+        "Retracted feedback from %s for response %s",
+        payload.client,
+        payload.response_id,
+    )
+    return FeedbackRetractionAckSchema(response_id=payload.response_id)

--- a/api/app/data/feedback.py
+++ b/api/app/data/feedback.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from dataclasses import dataclass
 from uuid import UUID
 
 from app.data.connection import Database
@@ -9,45 +9,112 @@ def _optional_text(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
-async def server_owned_web_feedback(
+@dataclass(frozen=True, slots=True)
+class StoredWebFeedback:
+    ack: FeedbackAckSchema
+    feedback: FeedbackSchema
+
+
+async def upsert_web_feedback(
     db: Database,
     feedback: FeedbackSchema,
-) -> FeedbackSchema | None:
+) -> StoredWebFeedback | None:
     row = await db.fetchrow(
         """
+        WITH owned_response AS (
+            SELECT
+                assistant.id AS message_id,
+                assistant.content AS answer_text,
+                assistant.metadata ->> 'inferenceModel' AS inference_model,
+                (
+                    SELECT user_message.content
+                    FROM chat_message user_message
+                    WHERE user_message.conversation_id = assistant.conversation_id
+                      AND user_message.role = 'user'
+                      AND user_message.created_at <= assistant.created_at
+                    ORDER BY user_message.created_at DESC
+                    LIMIT 1
+                ) AS question_text
+            FROM chat_message assistant
+            JOIN chat_conversation conversation
+              ON conversation.id = assistant.conversation_id
+            WHERE assistant.response_id = $1
+              AND assistant.role = 'assistant'
+              AND conversation.user_id::text = $2
+            ORDER BY assistant.updated_at DESC
+            LIMIT 1
+            FOR UPDATE OF assistant
+        ),
+        updated_message AS (
+            UPDATE chat_message AS assistant
+            SET metadata = jsonb_set(
+                    COALESCE(assistant.metadata, '{}'::jsonb),
+                    '{feedback}',
+                    to_jsonb($3::text),
+                    true
+                ),
+                updated_at = NOW()
+            FROM owned_response
+            WHERE assistant.id = owned_response.message_id
+            RETURNING assistant.id
+        ),
+        stored_feedback AS (
+            INSERT INTO feedback (
+                response_id, client, user_id, feedback_type, client_ref,
+                channel_id, guild_id, question_text, answer_text,
+                inference_model, embeddings_model, query_transform_model
+            )
+            SELECT
+                $1, 'web', $2, $3, $4, $5, $6,
+                owned_response.question_text,
+                owned_response.answer_text,
+                owned_response.inference_model,
+                $7,
+                $8
+            FROM owned_response
+            JOIN updated_message ON TRUE
+            ON CONFLICT (response_id, client, user_id)
+            DO UPDATE SET feedback_type = EXCLUDED.feedback_type, updated_at = NOW()
+            RETURNING id, response_id, feedback_type
+        )
         SELECT
+            stored_feedback.id,
+            stored_feedback.response_id,
+            stored_feedback.feedback_type,
             assistant.content AS answer_text,
-            assistant.metadata ->> 'inferenceModel' AS inference_model,
-            (
-                SELECT user_message.content
-                FROM chat_message user_message
-                WHERE user_message.conversation_id = assistant.conversation_id
-                  AND user_message.role = 'user'
-                  AND user_message.created_at <= assistant.created_at
-                ORDER BY user_message.created_at DESC
-                LIMIT 1
-            ) AS question_text
-        FROM chat_message assistant
-        JOIN chat_conversation conversation
-          ON conversation.id = assistant.conversation_id
-        WHERE assistant.response_id = $1
-          AND assistant.role = 'assistant'
-          AND conversation.user_id::text = $2
-        ORDER BY assistant.updated_at DESC
-        LIMIT 1
+            owned_response.inference_model,
+            owned_response.question_text
+        FROM stored_feedback
+        JOIN owned_response ON TRUE
+        JOIN chat_message assistant
+          ON assistant.id = owned_response.message_id
         """,
         feedback.response_id,
         feedback.user_id,
+        feedback.feedback_type,
+        feedback.client_ref,
+        feedback.channel_id,
+        feedback.guild_id,
+        feedback.embeddings_model,
+        feedback.query_transform_model,
     )
     if row is None:
         return None
 
-    return feedback.model_copy(
+    stored_feedback = feedback.model_copy(
         update={
             "answer_text": _optional_text(row["answer_text"]),
             "inference_model": _optional_text(row["inference_model"]),
             "question_text": _optional_text(row["question_text"]),
         },
+    )
+    return StoredWebFeedback(
+        ack=FeedbackAckSchema(
+            id=row["id"],
+            response_id=row["response_id"],
+            feedback_type=row["feedback_type"],
+        ),
+        feedback=stored_feedback,
     )
 
 
@@ -92,32 +159,41 @@ async def upsert_feedback(
     )
 
 
-async def set_web_chat_message_feedback(
+async def retract_web_feedback(
     db: Database,
     *,
-    feedback_type: Literal["like", "dislike"],
     response_id: UUID,
     user_id: str,
 ) -> bool:
     row = await db.fetchrow(
         """
+        WITH owned_response AS (
+            SELECT assistant.id
+            FROM chat_message AS assistant
+            JOIN chat_conversation AS conversation
+              ON conversation.id = assistant.conversation_id
+            WHERE assistant.response_id = $1
+              AND assistant.role = 'assistant'
+              AND conversation.user_id::text = $2
+            FOR UPDATE OF assistant
+        ),
+        deleted_feedback AS (
+            DELETE FROM feedback AS stored
+            USING owned_response
+            WHERE stored.response_id = $1
+              AND stored.client = 'web'
+              AND stored.user_id = $2
+            RETURNING stored.id
+        )
         UPDATE chat_message AS assistant
-        SET metadata = jsonb_set(
-                COALESCE(assistant.metadata, '{}'::jsonb),
-                '{feedback}',
-                to_jsonb($3::text),
-                true
-            ),
+        SET metadata = COALESCE(assistant.metadata, '{}'::jsonb) - 'feedback',
             updated_at = NOW()
-        FROM chat_conversation AS conversation
-        WHERE conversation.id = assistant.conversation_id
-          AND assistant.response_id = $1
-          AND assistant.role = 'assistant'
-          AND conversation.user_id::text = $2
+        FROM owned_response
+        LEFT JOIN deleted_feedback ON TRUE
+        WHERE assistant.id = owned_response.id
         RETURNING assistant.id
         """,
         response_id,
         user_id,
-        feedback_type,
     )
     return row is not None

--- a/api/app/schemas/feedback.py
+++ b/api/app/schemas/feedback.py
@@ -70,3 +70,30 @@ class FeedbackAckSchema(BaseModel):
         examples=["like"],
         description="The recorded rating after the upsert.",
     )
+
+
+class FeedbackRetractionSchema(BaseModel):
+    response_id: UUID = Field(
+        examples=["3fa85f64-5717-4562-b3fc-2c963f66afa6"],
+        description="Canonical id of the response whose feedback should be removed.",
+    )
+    client: Literal["web"] = Field(
+        examples=["web"],
+        description="The authenticated web client retracting its feedback.",
+    )
+    user_id: str = Field(
+        min_length=1,
+        examples=["198249751001563136"],
+        description="Id of the web user retracting feedback.",
+    )
+
+
+class FeedbackRetractionAckSchema(BaseModel):
+    response_id: UUID = Field(
+        examples=["3fa85f64-5717-4562-b3fc-2c963f66afa6"],
+        description="The response whose feedback was removed.",
+    )
+    feedback_type: None = Field(
+        default=None,
+        description="The resulting empty feedback state.",
+    )

--- a/api/tests/feedback_fake.py
+++ b/api/tests/feedback_fake.py
@@ -1,0 +1,105 @@
+import json
+from uuid import uuid4
+
+from tests.chat_persistence_fake import FakeChatDatabase
+
+
+class FakeFeedbackDatabase(FakeChatDatabase):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fetchrow_calls = 0
+
+    async def fetchrow(
+        self,
+        query: str,
+        *args: object,
+    ) -> dict[str, object] | None:
+        self.fetchrow_calls += 1
+        if "WITH owned_response AS" in query and "INSERT INTO feedback" in query:
+            (
+                response_id,
+                user_id,
+                feedback_type,
+                client_ref,
+                channel_id,
+                guild_id,
+                embeddings_model,
+                query_transform_model,
+            ) = args
+            for assistant in self.messages.values():
+                conversation = self.conversations.get(assistant["conversation_id"])
+                if (
+                    assistant["response_id"] != response_id
+                    or assistant["role"] != "assistant"
+                    or conversation is None
+                    or str(conversation["user_id"]) != user_id
+                ):
+                    continue
+                prior_questions = [
+                    message
+                    for message in self.messages.values()
+                    if message["conversation_id"] == assistant["conversation_id"]
+                    and message["role"] == "user"
+                    and self._created_at(message) <= self._created_at(assistant)
+                ]
+                question = max(prior_questions, key=self._created_at, default=None)
+                metadata = assistant["metadata"]
+                parsed = json.loads(metadata) if isinstance(metadata, str) else metadata
+                if not isinstance(parsed, dict):
+                    parsed = {}
+                inference_model = parsed.get("inferenceModel")
+                parsed["feedback"] = feedback_type
+                assistant["metadata"] = parsed
+                assistant["updated_at"] = self.now
+                feedback_key = (response_id, "web", user_id)
+                current = self.feedback.get(feedback_key)
+                if current is None:
+                    current = {
+                        "answer_text": assistant["content"],
+                        "channel_id": channel_id,
+                        "client": "web",
+                        "client_ref": client_ref,
+                        "created_at": self.now,
+                        "embeddings_model": embeddings_model,
+                        "feedback_type": feedback_type,
+                        "guild_id": guild_id,
+                        "id": uuid4(),
+                        "inference_model": inference_model,
+                        "query_transform_model": query_transform_model,
+                        "question_text": None
+                        if question is None
+                        else question["content"],
+                        "response_id": response_id,
+                        "updated_at": self.now,
+                        "user_id": user_id,
+                    }
+                    self.feedback[feedback_key] = current
+                else:
+                    current["feedback_type"] = feedback_type
+                    current["updated_at"] = self.now
+                return current
+            return None
+
+        if "DELETE FROM feedback AS stored" not in query:
+            return await super().fetchrow(query, *args)
+
+        response_id, user_id = args
+        for assistant in self.messages.values():
+            conversation = self.conversations.get(assistant["conversation_id"])
+            if (
+                assistant["response_id"] != response_id
+                or assistant["role"] != "assistant"
+                or conversation is None
+                or str(conversation["user_id"]) != user_id
+            ):
+                continue
+            self.feedback.pop((response_id, "web", user_id), None)
+            metadata = assistant["metadata"]
+            parsed = json.loads(metadata) if isinstance(metadata, str) else metadata
+            if not isinstance(parsed, dict):
+                parsed = {}
+            parsed.pop("feedback", None)
+            assistant["metadata"] = parsed
+            assistant["updated_at"] = self.now
+            return {"id": assistant["id"]}
+        return None

--- a/api/tests/feedback_fake.py
+++ b/api/tests/feedback_fake.py
@@ -9,6 +9,28 @@ class FakeFeedbackDatabase(FakeChatDatabase):
         super().__init__()
         self.fetchrow_calls = 0
 
+    def _owned_assistant(
+        self,
+        response_id: object,
+        user_id: object,
+    ) -> dict[str, object] | None:
+        return next(
+            (
+                assistant
+                for assistant in self.messages.values()
+                if assistant["response_id"] == response_id
+                and assistant["role"] == "assistant"
+                and (
+                    conversation := self.conversations.get(
+                        assistant["conversation_id"],
+                    )
+                )
+                is not None
+                and str(conversation["user_id"]) == user_id
+            ),
+            None,
+        )
+
     async def fetchrow(
         self,
         query: str,
@@ -26,80 +48,61 @@ class FakeFeedbackDatabase(FakeChatDatabase):
                 embeddings_model,
                 query_transform_model,
             ) = args
-            for assistant in self.messages.values():
-                conversation = self.conversations.get(assistant["conversation_id"])
-                if (
-                    assistant["response_id"] != response_id
-                    or assistant["role"] != "assistant"
-                    or conversation is None
-                    or str(conversation["user_id"]) != user_id
-                ):
-                    continue
-                prior_questions = [
-                    message
-                    for message in self.messages.values()
-                    if message["conversation_id"] == assistant["conversation_id"]
-                    and message["role"] == "user"
-                    and self._created_at(message) <= self._created_at(assistant)
-                ]
-                question = max(prior_questions, key=self._created_at, default=None)
-                metadata = assistant["metadata"]
-                parsed = json.loads(metadata) if isinstance(metadata, str) else metadata
-                if not isinstance(parsed, dict):
-                    parsed = {}
-                inference_model = parsed.get("inferenceModel")
-                parsed["feedback"] = feedback_type
-                assistant["metadata"] = parsed
-                assistant["updated_at"] = self.now
-                feedback_key = (response_id, "web", user_id)
-                current = self.feedback.get(feedback_key)
-                if current is None:
-                    current = {
-                        "answer_text": assistant["content"],
-                        "channel_id": channel_id,
-                        "client": "web",
-                        "client_ref": client_ref,
-                        "created_at": self.now,
-                        "embeddings_model": embeddings_model,
-                        "feedback_type": feedback_type,
-                        "guild_id": guild_id,
-                        "id": uuid4(),
-                        "inference_model": inference_model,
-                        "query_transform_model": query_transform_model,
-                        "question_text": None
-                        if question is None
-                        else question["content"],
-                        "response_id": response_id,
-                        "updated_at": self.now,
-                        "user_id": user_id,
-                    }
-                    self.feedback[feedback_key] = current
-                else:
-                    current["feedback_type"] = feedback_type
-                    current["updated_at"] = self.now
-                return current
-            return None
+            assistant = self._owned_assistant(response_id, user_id)
+            owned = await super().fetchrow(
+                "SELECT assistant.content AS answer_text",
+                response_id,
+                user_id,
+            )
+            if assistant is None or owned is None:
+                return None
+
+            metadata = assistant["metadata"]
+            parsed = json.loads(metadata) if isinstance(metadata, str) else metadata
+            if not isinstance(parsed, dict):
+                parsed = {}
+            parsed["feedback"] = feedback_type
+            assistant["metadata"] = parsed
+            assistant["updated_at"] = self.now
+            feedback_key = (response_id, "web", user_id)
+            current = self.feedback.get(feedback_key)
+            if current is None:
+                current = {
+                    "answer_text": owned["answer_text"],
+                    "channel_id": channel_id,
+                    "client": "web",
+                    "client_ref": client_ref,
+                    "created_at": self.now,
+                    "embeddings_model": embeddings_model,
+                    "feedback_type": feedback_type,
+                    "guild_id": guild_id,
+                    "id": uuid4(),
+                    "inference_model": owned["inference_model"],
+                    "query_transform_model": query_transform_model,
+                    "question_text": owned["question_text"],
+                    "response_id": response_id,
+                    "updated_at": self.now,
+                    "user_id": user_id,
+                }
+                self.feedback[feedback_key] = current
+            else:
+                current["feedback_type"] = feedback_type
+                current["updated_at"] = self.now
+            return current
 
         if "DELETE FROM feedback AS stored" not in query:
             return await super().fetchrow(query, *args)
 
         response_id, user_id = args
-        for assistant in self.messages.values():
-            conversation = self.conversations.get(assistant["conversation_id"])
-            if (
-                assistant["response_id"] != response_id
-                or assistant["role"] != "assistant"
-                or conversation is None
-                or str(conversation["user_id"]) != user_id
-            ):
-                continue
-            self.feedback.pop((response_id, "web", user_id), None)
-            metadata = assistant["metadata"]
-            parsed = json.loads(metadata) if isinstance(metadata, str) else metadata
-            if not isinstance(parsed, dict):
-                parsed = {}
-            parsed.pop("feedback", None)
-            assistant["metadata"] = parsed
-            assistant["updated_at"] = self.now
-            return {"id": assistant["id"]}
-        return None
+        assistant = self._owned_assistant(response_id, user_id)
+        if assistant is None:
+            return None
+        self.feedback.pop((response_id, "web", user_id), None)
+        metadata = assistant["metadata"]
+        parsed = json.loads(metadata) if isinstance(metadata, str) else metadata
+        if not isinstance(parsed, dict):
+            parsed = {}
+        parsed.pop("feedback", None)
+        assistant["metadata"] = parsed
+        assistant["updated_at"] = self.now
+        return {"id": assistant["id"]}

--- a/api/tests/feedback_test_support.py
+++ b/api/tests/feedback_test_support.py
@@ -1,0 +1,63 @@
+import json
+from uuid import UUID, uuid4
+
+from fastapi.testclient import TestClient
+
+from app.data.db import get_db
+from app.main import make_app
+from app.utils.settings import Settings
+from tests.feedback_fake import FakeFeedbackDatabase
+
+OWNER_ID = "00000000-0000-4000-8000-000000000001"
+INTRUDER_ID = "00000000-0000-4000-8000-000000000002"
+
+
+def make_client(db: FakeFeedbackDatabase) -> TestClient:
+    app = make_app(Settings(API_KEY="test-api-key", MCP_API_KEY="test-mcp-key"))
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def auth_headers() -> dict[str, str]:
+    return {"x-api-key": "test-api-key"}
+
+
+def seed_owned_response(db: FakeFeedbackDatabase) -> tuple[UUID, UUID]:
+    conversation_id = uuid4()
+    response_id = uuid4()
+    db.conversations[conversation_id] = {
+        "active_response_id": None,
+        "active_status": None,
+        "active_stream_id": None,
+        "created_at": db.now,
+        "id": conversation_id,
+        "model": "claude-sonnet-5",
+        "title": "Enrollment",
+        "updated_at": db.now,
+        "user_id": UUID(OWNER_ID),
+    }
+    db.messages[uuid4()] = {
+        "content": "Server question",
+        "conversation_id": conversation_id,
+        "created_at": db.now,
+        "id": uuid4(),
+        "metadata": {},
+        "response_id": None,
+        "role": "user",
+        "updated_at": db.now,
+    }
+    db.messages[uuid4()] = {
+        "content": "Server answer",
+        "conversation_id": conversation_id,
+        "created_at": db.now,
+        "id": uuid4(),
+        "metadata": json.dumps({"inferenceModel": "server-model"}),
+        "parts": [
+            {"state": "done", "text": "Stored reasoning", "type": "reasoning"},
+            {"state": "done", "text": "Server answer", "type": "text"},
+        ],
+        "response_id": response_id,
+        "role": "assistant",
+        "updated_at": db.now,
+    }
+    return conversation_id, response_id

--- a/api/tests/test_feedback_api.py
+++ b/api/tests/test_feedback_api.py
@@ -1,78 +1,23 @@
-import json
-from uuid import UUID, uuid4
-
-from fastapi.testclient import TestClient
-
-from app.data.db import get_db
-from app.main import make_app
-from app.utils.settings import Settings
-from tests.chat_persistence_fake import FakeChatDatabase
-
-OWNER_ID = "00000000-0000-4000-8000-000000000001"
-INTRUDER_ID = "00000000-0000-4000-8000-000000000002"
-
-
-def _client(db: FakeChatDatabase) -> TestClient:
-    app = make_app(Settings(API_KEY="test-api-key", MCP_API_KEY="test-mcp-key"))
-    app.dependency_overrides[get_db] = lambda: db
-    return TestClient(app)
-
-
-def _auth_headers() -> dict[str, str]:
-    return {"x-api-key": "test-api-key"}
-
-
-def _seed_owned_response(db: FakeChatDatabase) -> tuple[UUID, UUID]:
-    conversation_id = uuid4()
-    response_id = uuid4()
-    db.conversations[conversation_id] = {
-        "active_response_id": None,
-        "active_status": None,
-        "active_stream_id": None,
-        "created_at": db.now,
-        "id": conversation_id,
-        "model": "claude-sonnet-5",
-        "title": "Enrollment",
-        "updated_at": db.now,
-        "user_id": UUID(OWNER_ID),
-    }
-    db.messages[uuid4()] = {
-        "content": "Server question",
-        "conversation_id": conversation_id,
-        "created_at": db.now,
-        "id": uuid4(),
-        "metadata": {},
-        "response_id": None,
-        "role": "user",
-        "updated_at": db.now,
-    }
-    db.messages[uuid4()] = {
-        "content": "Server answer",
-        "conversation_id": conversation_id,
-        "created_at": db.now,
-        "id": uuid4(),
-        "metadata": json.dumps({"inferenceModel": "server-model"}),
-        "parts": [
-            {"state": "done", "text": "Stored reasoning", "type": "reasoning"},
-            {"state": "done", "text": "Server answer", "type": "text"},
-        ],
-        "response_id": response_id,
-        "role": "assistant",
-        "updated_at": db.now,
-    }
-    return conversation_id, response_id
+from tests.feedback_fake import FakeFeedbackDatabase
+from tests.feedback_test_support import (
+    INTRUDER_ID,
+    OWNER_ID,
+    auth_headers,
+    make_client,
+    seed_owned_response,
+)
 
 
 def test_web_feedback_uses_server_owned_message_context() -> None:
     # Given: persisted chat state for a web-owned response.
-    db = FakeChatDatabase()
-    client = _client(db)
-    _, response_id = _seed_owned_response(db)
+    db = FakeFeedbackDatabase()
+    client = make_client(db)
+    _, response_id = seed_owned_response(db)
 
     # When: the browser submits feedback with forged metadata fields.
     response = client.post(
         "/chat/feedback",
-        headers=_auth_headers(),
+        headers=auth_headers(),
         json={
             "answer_text": "forged answer",
             "client": "web",
@@ -105,14 +50,14 @@ def test_web_feedback_uses_server_owned_message_context() -> None:
 
 def test_web_feedback_rejects_unowned_response_id() -> None:
     # Given: persisted chat state owned by another web user.
-    db = FakeChatDatabase()
-    client = _client(db)
-    _, response_id = _seed_owned_response(db)
+    db = FakeFeedbackDatabase()
+    client = make_client(db)
+    _, response_id = seed_owned_response(db)
 
     # When: a different user submits feedback for that response id.
     response = client.post(
         "/chat/feedback",
-        headers=_auth_headers(),
+        headers=auth_headers(),
         json={
             "client": "web",
             "feedback_type": "like",

--- a/api/tests/test_feedback_retraction_api.py
+++ b/api/tests/test_feedback_retraction_api.py
@@ -1,0 +1,146 @@
+from tests.feedback_fake import FakeFeedbackDatabase
+from tests.feedback_test_support import (
+    INTRUDER_ID,
+    OWNER_ID,
+    auth_headers,
+    make_client,
+    seed_owned_response,
+)
+
+
+def test_web_feedback_is_persisted_with_one_database_statement() -> None:
+    # Given: persisted chat state for a web-owned response.
+    db = FakeFeedbackDatabase()
+    client = make_client(db)
+    _, response_id = seed_owned_response(db)
+
+    # When: the browser submits feedback.
+    response = client.post(
+        "/chat/feedback",
+        headers=auth_headers(),
+        json={
+            "client": "web",
+            "feedback_type": "like",
+            "response_id": str(response_id),
+            "user_id": OWNER_ID,
+        },
+    )
+
+    # Then: ownership, metadata, and the feedback row are handled atomically.
+    assert response.status_code == 200
+    assert db.fetchrow_calls == 1
+
+
+def test_web_feedback_can_be_retracted() -> None:
+    # Given: an owned response with persisted feedback and unrelated metadata.
+    db = FakeFeedbackDatabase()
+    client = make_client(db)
+    _, response_id = seed_owned_response(db)
+    submitted = client.post(
+        "/chat/feedback",
+        headers=auth_headers(),
+        json={
+            "client": "web",
+            "feedback_type": "like",
+            "response_id": str(response_id),
+            "user_id": OWNER_ID,
+        },
+    )
+    assert submitted.status_code == 200
+
+    # When: the owner retracts the feedback.
+    response = client.request(
+        "DELETE",
+        "/chat/feedback",
+        headers=auth_headers(),
+        json={
+            "client": "web",
+            "response_id": str(response_id),
+            "user_id": OWNER_ID,
+        },
+    )
+
+    # Then: the row and only the feedback metadata are removed.
+    assert response.status_code == 200
+    assert response.json() == {
+        "feedback_type": None,
+        "response_id": str(response_id),
+    }
+    assert db.feedback == {}
+    assistant = next(
+        row for row in db.messages.values() if row["response_id"] == response_id
+    )
+    assert assistant["metadata"] == {"inferenceModel": "server-model"}
+
+
+def test_web_feedback_retraction_rejects_unowned_response_id() -> None:
+    # Given: an owned response with persisted feedback.
+    db = FakeFeedbackDatabase()
+    client = make_client(db)
+    _, response_id = seed_owned_response(db)
+    submitted = client.post(
+        "/chat/feedback",
+        headers=auth_headers(),
+        json={
+            "client": "web",
+            "feedback_type": "dislike",
+            "response_id": str(response_id),
+            "user_id": OWNER_ID,
+        },
+    )
+    assert submitted.status_code == 200
+
+    # When: a different user tries to retract the feedback.
+    response = client.request(
+        "DELETE",
+        "/chat/feedback",
+        headers=auth_headers(),
+        json={
+            "client": "web",
+            "response_id": str(response_id),
+            "user_id": INTRUDER_ID,
+        },
+    )
+
+    # Then: the response is hidden and both persisted representations remain.
+    assert response.status_code == 404
+    stored = next(iter(db.feedback.values()))
+    assert stored["feedback_type"] == "dislike"
+    assistant = next(
+        row for row in db.messages.values() if row["response_id"] == response_id
+    )
+    assert assistant["metadata"] == {
+        "feedback": "dislike",
+        "inferenceModel": "server-model",
+    }
+
+
+def test_web_feedback_retraction_is_idempotent() -> None:
+    # Given: an owned response without a feedback row.
+    db = FakeFeedbackDatabase()
+    client = make_client(db)
+    _, response_id = seed_owned_response(db)
+
+    # When: the owner retracts feedback that is already absent.
+    response = client.request(
+        "DELETE",
+        "/chat/feedback",
+        headers=auth_headers(),
+        json={
+            "client": "web",
+            "response_id": str(response_id),
+            "user_id": OWNER_ID,
+        },
+    )
+
+    # Then: the empty state is confirmed without disturbing other metadata.
+    assert response.status_code == 200
+    assert response.json() == {
+        "feedback_type": None,
+        "response_id": str(response_id),
+    }
+    assert db.feedback == {}
+    assistant = next(
+        row for row in db.messages.values() if row["response_id"] == response_id
+    )
+    assert assistant["metadata"] == {"inferenceModel": "server-model"}

--- a/api/tests/test_feedback_retraction_api.py
+++ b/api/tests/test_feedback_retraction_api.py
@@ -1,3 +1,8 @@
+from uuid import UUID
+
+from fastapi.testclient import TestClient
+from httpx import Response
+
 from tests.feedback_fake import FakeFeedbackDatabase
 from tests.feedback_test_support import (
     INTRUDER_ID,
@@ -6,6 +11,41 @@ from tests.feedback_test_support import (
     make_client,
     seed_owned_response,
 )
+
+
+def _retract_feedback(
+    client: TestClient,
+    response_id: UUID,
+    *,
+    user_id: str = OWNER_ID,
+) -> Response:
+    return client.request(
+        "DELETE",
+        "/chat/feedback",
+        headers=auth_headers(),
+        json={
+            "client": "web",
+            "response_id": str(response_id),
+            "user_id": user_id,
+        },
+    )
+
+
+def _assert_retracted(
+    db: FakeFeedbackDatabase,
+    response_id: UUID,
+    response: Response,
+) -> None:
+    assert response.status_code == 200
+    assert response.json() == {
+        "feedback_type": None,
+        "response_id": str(response_id),
+    }
+    assert db.feedback == {}
+    assistant = next(
+        row for row in db.messages.values() if row["response_id"] == response_id
+    )
+    assert assistant["metadata"] == {"inferenceModel": "server-model"}
 
 
 def test_web_feedback_is_persisted_with_one_database_statement() -> None:
@@ -49,28 +89,10 @@ def test_web_feedback_can_be_retracted() -> None:
     assert submitted.status_code == 200
 
     # When: the owner retracts the feedback.
-    response = client.request(
-        "DELETE",
-        "/chat/feedback",
-        headers=auth_headers(),
-        json={
-            "client": "web",
-            "response_id": str(response_id),
-            "user_id": OWNER_ID,
-        },
-    )
+    response = _retract_feedback(client, response_id)
 
     # Then: the row and only the feedback metadata are removed.
-    assert response.status_code == 200
-    assert response.json() == {
-        "feedback_type": None,
-        "response_id": str(response_id),
-    }
-    assert db.feedback == {}
-    assistant = next(
-        row for row in db.messages.values() if row["response_id"] == response_id
-    )
-    assert assistant["metadata"] == {"inferenceModel": "server-model"}
+    _assert_retracted(db, response_id, response)
 
 
 def test_web_feedback_retraction_rejects_unowned_response_id() -> None:
@@ -91,16 +113,7 @@ def test_web_feedback_retraction_rejects_unowned_response_id() -> None:
     assert submitted.status_code == 200
 
     # When: a different user tries to retract the feedback.
-    response = client.request(
-        "DELETE",
-        "/chat/feedback",
-        headers=auth_headers(),
-        json={
-            "client": "web",
-            "response_id": str(response_id),
-            "user_id": INTRUDER_ID,
-        },
-    )
+    response = _retract_feedback(client, response_id, user_id=INTRUDER_ID)
 
     # Then: the response is hidden and both persisted representations remain.
     assert response.status_code == 404
@@ -122,25 +135,7 @@ def test_web_feedback_retraction_is_idempotent() -> None:
     _, response_id = seed_owned_response(db)
 
     # When: the owner retracts feedback that is already absent.
-    response = client.request(
-        "DELETE",
-        "/chat/feedback",
-        headers=auth_headers(),
-        json={
-            "client": "web",
-            "response_id": str(response_id),
-            "user_id": OWNER_ID,
-        },
-    )
+    response = _retract_feedback(client, response_id)
 
     # Then: the empty state is confirmed without disturbing other metadata.
-    assert response.status_code == 200
-    assert response.json() == {
-        "feedback_type": None,
-        "response_id": str(response_id),
-    }
-    assert db.feedback == {}
-    assistant = next(
-        row for row in db.messages.values() if row["response_id"] == response_id
-    )
-    assert assistant["metadata"] == {"inferenceModel": "server-model"}
+    _assert_retracted(db, response_id, response)

--- a/web/app/api/feedback/route.ts
+++ b/web/app/api/feedback/route.ts
@@ -1,6 +1,9 @@
 import type {
   FeedbackAck,
   FeedbackClientPayload,
+  FeedbackRetractionAck,
+  FeedbackRetractionClientPayload,
+  FeedbackRetractionSchema,
   FeedbackSchema,
   FeedbackType,
 } from '@/lib/api-types';
@@ -45,6 +48,32 @@ const toSchema = (
   client: 'web',
   /* eslint-disable camelcase -- snake_case mirrors the Python API wire contract */
   feedback_type: payload.feedbackType,
+  response_id: payload.responseId,
+  user_id: userId,
+  /* eslint-enable camelcase -- snake_case mirrors the Python API wire contract */
+});
+
+const parseRetractionPayload = (
+  value: unknown,
+): FeedbackRetractionClientPayload | null => {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const { responseId } = candidate;
+  if (typeof responseId !== 'string' || responseId.length === 0) {
+    return null;
+  }
+  return { responseId };
+};
+
+const toRetractionSchema = (
+  payload: FeedbackRetractionClientPayload,
+  userId: string,
+): FeedbackRetractionSchema => ({
+  client: 'web',
+  /* eslint-disable camelcase -- snake_case mirrors the Python API wire contract */
   response_id: payload.responseId,
   user_id: userId,
   /* eslint-enable camelcase -- snake_case mirrors the Python API wire contract */
@@ -117,6 +146,63 @@ export const POST = async (req: Request): Promise<Response> => {
 
   try {
     ack = (await upstream.json()) as FeedbackAck;
+  } catch {
+    return jsonError('The feedback service returned an invalid response.', 502);
+  }
+
+  return Response.json(ack, {
+    headers: { 'content-type': 'application/json' },
+    status: 200,
+  });
+};
+
+export const DELETE = async (req: Request): Promise<Response> => {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return jsonError('Invalid JSON body', 400);
+  }
+
+  const payload = parseRetractionPayload(raw);
+  if (payload === null) {
+    return jsonError('Invalid feedback payload: responseId is required.', 400);
+  }
+
+  let userId: string;
+  try {
+    userId = await getAuthenticatedChatUserId();
+  } catch (error) {
+    if (error instanceof AuthenticationRequiredError) {
+      return unauthenticated();
+    }
+    throw error;
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${API_BASE_URL}/chat/feedback`, {
+      body: JSON.stringify(toRetractionSchema(payload, userId)),
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': CHAT_API_KEY,
+      },
+      method: 'DELETE',
+    });
+  } catch {
+    return jsonError('Failed to reach the feedback service.', 502);
+  }
+
+  if (upstream.status === 404) {
+    return jsonError('Feedback response not found.', 404);
+  }
+  if (!upstream.ok) {
+    return jsonError('The feedback service rejected the request.', 502);
+  }
+
+  let ack: FeedbackRetractionAck;
+  try {
+    ack = (await upstream.json()) as FeedbackRetractionAck;
   } catch {
     return jsonError('The feedback service returned an invalid response.', 502);
   }

--- a/web/components/chat/answer-actions.tsx
+++ b/web/components/chat/answer-actions.tsx
@@ -1,8 +1,12 @@
 import { Check, Copy, RotateCcw, ThumbsDown, ThumbsUp } from 'lucide-react';
 import { posthog } from 'posthog-js';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
-import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
+import type {
+  FeedbackSelection,
+  FeedbackType,
+  MyUIMessage,
+} from '@/lib/api-types';
 
 import { ControlTooltip } from '@/components/ui/icon-controls';
 import { t } from '@/lib/i18n';
@@ -12,7 +16,7 @@ import { cn } from '@/lib/utils';
 export type AnswerActionsProps = {
   message: MyUIMessage;
   onRegenerate?: () => void;
-  onVote?: (vote: FeedbackType) => void;
+  onVote?: (vote: FeedbackSelection) => void;
   pending?: boolean;
   regenerateDisabled?: boolean;
 };
@@ -32,12 +36,15 @@ export const AnswerActions = ({
   const [vote, setVote] = useState<FeedbackType | null>(
     message.metadata?.feedback ?? null,
   );
+  const [submittingFeedback, setSubmittingFeedback] = useState(false);
+  const feedbackPendingRef = useRef(false);
 
   if (!responseId) {
     return null;
   }
 
   const text = lastText(message) ?? '';
+  const votingDisabled = pending || submittingFeedback;
 
   const copy = async (): Promise<void> => {
     await navigator.clipboard.writeText(text);
@@ -54,27 +61,36 @@ export const AnswerActions = ({
   };
 
   const sendFeedback = async (feedbackType: FeedbackType): Promise<void> => {
-    if (pending) {
+    const pendingRequest = feedbackPendingRef;
+    if (pending || pendingRequest.current) {
       return;
     }
+    pendingRequest.current = true;
+    setSubmittingFeedback(true);
     const previous = vote;
-    setVote(feedbackType);
+    const nextVote: FeedbackSelection =
+      vote === feedbackType ? null : feedbackType;
+    setVote(nextVote);
     try {
       const res = await fetch('/api/feedback', {
-        body: JSON.stringify({
-          feedbackType,
-          responseId,
-        }),
+        body: JSON.stringify(
+          nextVote === null
+            ? { responseId }
+            : { feedbackType: nextVote, responseId },
+        ),
         headers: { 'content-type': 'application/json' },
-        method: 'POST',
+        method: nextVote === null ? 'DELETE' : 'POST',
       });
       if (!res.ok) {
         setVote(previous);
         return;
       }
-      onVote?.(feedbackType);
+      onVote?.(nextVote);
     } catch {
       setVote(previous);
+    } finally {
+      pendingRequest.current = false;
+      setSubmittingFeedback(false);
     }
   };
 
@@ -129,6 +145,7 @@ export const AnswerActions = ({
         label={t('actions.like')}
       >
         <button
+          aria-busy={submittingFeedback || undefined}
           aria-label={t('actions.like')}
           aria-pressed={vote === 'like'}
           className={cn(
@@ -137,7 +154,7 @@ export const AnswerActions = ({
               'bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground',
           )}
           data-testid="like-button"
-          disabled={pending}
+          disabled={votingDisabled}
           onClick={() => {
             void sendFeedback('like');
           }}
@@ -154,6 +171,7 @@ export const AnswerActions = ({
         label={t('actions.dislike')}
       >
         <button
+          aria-busy={submittingFeedback || undefined}
           aria-label={t('actions.dislike')}
           aria-pressed={vote === 'dislike'}
           className={cn(
@@ -162,7 +180,7 @@ export const AnswerActions = ({
               'bg-destructive text-destructive-foreground hover:bg-destructive/90 hover:text-destructive-foreground',
           )}
           data-testid="dislike-button"
-          disabled={pending}
+          disabled={votingDisabled}
           onClick={() => {
             void sendFeedback('dislike');
           }}

--- a/web/e2e/chat.spec.ts
+++ b/web/e2e/chat.spec.ts
@@ -19,7 +19,7 @@ const DIAGNOSTICS_LABEL = /Дијагностика/u;
 const OBSERVABLE_STAGE_GAP_MS = 1_500;
 
 test.describe('chat streaming (mocked BFF)', () => {
-  test('shows the search chip, drops the preamble, renders the answer, and likes', async ({
+  test('shows the search chip, drops the preamble, renders the answer, and toggles like feedback', async ({
     page,
   }) => {
     const chatChunks = toolRunChunks({
@@ -65,13 +65,20 @@ test.describe('chat streaming (mocked BFF)', () => {
 
     await installMockChatState(page, { streamUrl: chatServer.url });
 
-    let feedbackBody: null | Record<string, unknown> = null;
+    const feedbackRequests: Array<{
+      readonly body: Record<string, unknown>;
+      readonly method: string;
+    }> = [];
     await page.route('**/api/feedback', async (route) => {
-      feedbackBody = route.request().postDataJSON() as Record<string, unknown>;
+      const request = route.request();
+      feedbackRequests.push({
+        body: request.postDataJSON() as Record<string, unknown>,
+        method: request.method(),
+      });
       await route.fulfill({
         body: JSON.stringify({
           /* eslint-disable camelcase -- snake_case mirrors the FeedbackAck wire contract */
-          feedback_type: 'like',
+          feedback_type: request.method() === 'DELETE' ? null : 'like',
           id: RESPONSE_ID,
           response_id: RESPONSE_ID,
           /* eslint-enable camelcase -- re-enable past the wire-shaped ack */
@@ -120,12 +127,26 @@ test.describe('chat streaming (mocked BFF)', () => {
     await page.keyboard.press('Escape');
     await expect(page.getByText('trace ID')).toHaveCount(0);
 
-    await page.getByTestId('like-button').click();
-    await expect.poll(() => feedbackBody).not.toBeNull();
-    expect(feedbackBody).toMatchObject({
-      feedbackType: 'like',
-      responseId: RESPONSE_ID,
-    });
+    const like = page.getByTestId('like-button');
+    await like.click();
+    await expect(like).toHaveAttribute('aria-pressed', 'true');
+    await like.click();
+    await expect(like).toHaveAttribute('aria-pressed', 'false');
+    await expect.poll(() => feedbackRequests).toHaveLength(2);
+    expect(feedbackRequests).toStrictEqual([
+      {
+        body: { feedbackType: 'like', responseId: RESPONSE_ID },
+        method: 'POST',
+      },
+      {
+        body: { responseId: RESPONSE_ID },
+        method: 'DELETE',
+      },
+    ]);
+    await expect(page.getByTestId('dislike-button')).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
 
     await chatServer.close();
   });

--- a/web/lib/api-types.ts
+++ b/web/lib/api-types.ts
@@ -107,6 +107,21 @@ export type FeedbackClientPayload = {
   readonly responseId: string;
 };
 
+export type FeedbackRetractionAck = {
+  readonly feedback_type: null;
+  readonly response_id: string;
+};
+
+export type FeedbackRetractionClientPayload = {
+  readonly responseId: string;
+};
+
+export type FeedbackRetractionSchema = {
+  readonly client: 'web';
+  readonly response_id: string;
+  readonly user_id: string;
+};
+
 export type FeedbackSchema = {
   answer_text?: string;
   channel_id?: string;
@@ -121,6 +136,7 @@ export type FeedbackSchema = {
   response_id: string;
   user_id: string;
 };
+export type FeedbackSelection = FeedbackType | null;
 export type FeedbackType = 'dislike' | 'like';
 
 // Every field is optional: a `meta` frame carries only part of it (timing vs tokens),

--- a/web/lib/conversation-actions.tsx
+++ b/web/lib/conversation-actions.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 
 import { posthog } from 'posthog-js';
 
-import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
+import type { FeedbackSelection, MyUIMessage } from '@/lib/api-types';
 
 import { AnswerActions } from '@/components/chat/answer-actions';
 import { hasText } from '@/lib/message-parts';
@@ -12,7 +12,7 @@ import { hasText } from '@/lib/message-parts';
 export type AnswerActionsContext = {
   disabled: boolean;
   messages: MyUIMessage[];
-  onVote: (messageId: string, vote: FeedbackType) => void;
+  onVote: (messageId: string, vote: FeedbackSelection) => void;
   regenerate: (options: { messageId: string }) => void;
   status: ChatStatus;
 };

--- a/web/lib/conversation-message-state.ts
+++ b/web/lib/conversation-message-state.ts
@@ -1,4 +1,4 @@
-import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
+import type { FeedbackSelection, MyUIMessage } from '@/lib/api-types';
 
 type FinishedReplacement = {
   readonly pruneAfterReplacement: boolean;
@@ -85,13 +85,19 @@ export const replaceFinishedMessage =
   };
 
 export const applyFeedback =
-  (messageId: string, feedback: FeedbackType) =>
+  (messageId: string, feedback: FeedbackSelection) =>
   (messages: MyUIMessage[]): MyUIMessage[] =>
-    messages.map((message) =>
-      message.id === messageId
-        ? { ...message, metadata: { ...message.metadata, feedback } }
-        : message,
-    );
+    messages.map((message) => {
+      if (message.id !== messageId) {
+        return message;
+      }
+      if (feedback !== null) {
+        return { ...message, metadata: { ...message.metadata, feedback } };
+      }
+      const metadata = { ...message.metadata };
+      Reflect.deleteProperty(metadata, 'feedback');
+      return { ...message, metadata };
+    });
 
 export const previewRegeneration = (
   messages: MyUIMessage[],

--- a/web/lib/use-conversations.tsx
+++ b/web/lib/use-conversations.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useRef } from 'react';
 
-import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
+import type { FeedbackSelection, MyUIMessage } from '@/lib/api-types';
 
 import { fireAndForget } from '@/lib/async';
 import { renderAnswerActions } from '@/lib/conversation-actions';
@@ -111,7 +111,7 @@ export const useConversations = (
   );
 
   const recordFeedback = useCallback(
-    (messageId: string, vote: FeedbackType) => {
+    (messageId: string, vote: FeedbackSelection) => {
       setMessages(applyFeedback(messageId, vote));
     },
     [setMessages],

--- a/web/test/answer-actions-toggle.test.tsx
+++ b/web/test/answer-actions-toggle.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
+
+import { AnswerActions } from '@/components/chat/answer-actions';
+
+const LIKE_LABEL = 'Ми се допаѓа';
+const DISLIKE_LABEL = 'Не ми се допаѓа';
+const FEEDBACK_CASES: ReadonlyArray<readonly [FeedbackType, string]> = [
+  ['like', LIKE_LABEL],
+  ['dislike', DISLIKE_LABEL],
+];
+
+const assistant = (feedback: FeedbackType): MyUIMessage => ({
+  id: 'a1',
+  metadata: { feedback, responseId: 'resp-9' },
+  parts: [{ text: 'Одговор', type: 'text' }],
+  role: 'assistant',
+});
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>().mockResolvedValue(
+      Response.json(
+        {
+          // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+          feedback_type: null,
+          // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+          response_id: 'resp-9',
+        },
+        { status: 200 },
+      ),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('AnswerActions feedback toggles', () => {
+  it.each(FEEDBACK_CASES)(
+    'retracts an already selected %s',
+    async (feedback, label) => {
+      const onVote = vi.fn<(vote: FeedbackType | null) => void>();
+      render(
+        <AnswerActions
+          message={assistant(feedback)}
+          onVote={onVote}
+        />,
+      );
+      const button = screen.getByRole('button', { name: label });
+
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(button).toHaveAttribute('aria-pressed', 'false');
+      });
+      const fetchMock = fetch as unknown as ReturnType<
+        typeof vi.fn<typeof fetch>
+      >;
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+      expect(url).toBe('/api/feedback');
+      expect(init.method).toBe('DELETE');
+      expect(JSON.parse(init.body as string)).toStrictEqual({
+        responseId: 'resp-9',
+      });
+      expect(onVote).toHaveBeenCalledWith(null);
+    },
+  );
+
+  it('still switches from like to dislike', async () => {
+    const onVote = vi.fn<(vote: FeedbackType | null) => void>();
+    render(
+      <AnswerActions
+        message={assistant('like')}
+        onVote={onVote}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: DISLIKE_LABEL }));
+
+    await waitFor(() => {
+      expect(onVote).toHaveBeenCalledWith('dislike');
+    });
+    const fetchMock = fetch as unknown as ReturnType<
+      typeof vi.fn<typeof fetch>
+    >;
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toStrictEqual({
+      feedbackType: 'dislike',
+      responseId: 'resp-9',
+    });
+  });
+
+  it('restores the selected feedback when retraction fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response('{}', { status: 500 })),
+    );
+    const onVote = vi.fn<(vote: FeedbackType | null) => void>();
+    render(
+      <AnswerActions
+        message={assistant('like')}
+        onVote={onVote}
+      />,
+    );
+    const like = screen.getByRole('button', { name: LIKE_LABEL });
+
+    fireEvent.click(like);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledOnce();
+    });
+
+    expect(like).toHaveAttribute('aria-pressed', 'true');
+    expect(onVote).not.toHaveBeenCalled();
+  });
+
+  it('serializes feedback mutations while a request is pending', async () => {
+    const request = Promise.withResolvers<Response>();
+    const fetchMock = vi.fn<typeof fetch>().mockReturnValue(request.promise);
+    vi.stubGlobal('fetch', fetchMock);
+    const onVote = vi.fn<(vote: FeedbackType | null) => void>();
+    render(
+      <AnswerActions
+        message={assistant('like')}
+        onVote={onVote}
+      />,
+    );
+    const like = screen.getByRole('button', { name: LIKE_LABEL });
+    const dislike = screen.getByRole('button', { name: DISLIKE_LABEL });
+
+    fireEvent.click(like);
+    fireEvent.click(dislike);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(like).toBeDisabled();
+    expect(dislike).toBeDisabled();
+
+    request.resolve(Response.json({}));
+    await waitFor(() => {
+      expect(onVote).toHaveBeenCalledWith(null);
+    });
+
+    expect(like).toBeEnabled();
+    expect(dislike).toBeEnabled();
+  });
+});

--- a/web/test/answer-actions.test.tsx
+++ b/web/test/answer-actions.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
+import type { FeedbackSelection, MyUIMessage } from '@/lib/api-types';
 
 import { AnswerActions } from '@/components/chat/answer-actions';
 import { createMemoryStorage } from '@/test/helpers/dom-stubs';
@@ -128,7 +128,7 @@ describe('AnswerActions feedback', () => {
   });
 
   it('reports the vote to onVote once the request succeeds', async () => {
-    const onVote = vi.fn<(vote: FeedbackType) => void>();
+    const onVote = vi.fn<(vote: FeedbackSelection) => void>();
     render(
       <AnswerActions
         message={assistant('resp-9')}
@@ -149,7 +149,7 @@ describe('AnswerActions feedback', () => {
         .fn<typeof fetch>()
         .mockResolvedValue(new Response('{}', { status: 500 })),
     );
-    const onVote = vi.fn<(vote: FeedbackType) => void>();
+    const onVote = vi.fn<(vote: FeedbackSelection) => void>();
     render(
       <AnswerActions
         message={assistant('resp-9')}
@@ -167,7 +167,7 @@ describe('AnswerActions feedback', () => {
   });
 
   it('disables voting while the answer is still streaming', () => {
-    const onVote = vi.fn<(vote: FeedbackType) => void>();
+    const onVote = vi.fn<(vote: FeedbackSelection) => void>();
     render(
       <AnswerActions
         message={assistant('resp-9')}

--- a/web/test/api-feedback-delete.route.test.ts
+++ b/web/test/api-feedback-delete.route.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DELETE } from '@/app/api/feedback/route';
+
+const { getAuthenticatedChatUserIdMock } = vi.hoisted(() => ({
+  getAuthenticatedChatUserIdMock: vi
+    .fn<() => Promise<string>>()
+    .mockResolvedValue('api-user-1'),
+}));
+
+vi.mock('@/lib/env', () => ({
+  API_BASE_URL: 'https://api:8880',
+  CHAT_API_KEY: 'super-secret-key',
+  env: {
+    API_BASE_URL: 'https://api:8880',
+    CHAT_API_KEY: 'super-secret-key',
+  },
+}));
+
+vi.mock('@/lib/authenticated-chat-user', () => {
+  class AuthenticationRequiredError extends Error {
+    constructor() {
+      super('Authentication required');
+      this.name = 'AuthenticationRequiredError';
+    }
+  }
+
+  return {
+    AuthenticationRequiredError,
+    getAuthenticatedChatUserId: getAuthenticatedChatUserIdMock,
+  };
+});
+
+const deleteRequest = (body: unknown): Request =>
+  new Request('https://localhost/api/feedback', {
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+    method: 'DELETE',
+  });
+
+describe('DELETE /api/feedback', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    getAuthenticatedChatUserIdMock.mockResolvedValue('api-user-1');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('injects the authenticated user and forwards only the response id', async () => {
+    const ack = {
+      // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+      feedback_type: null,
+      // eslint-disable-next-line camelcase -- snake_case mirrors the Python API wire contract
+      response_id: 'r-123',
+    };
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(Response.json(ack, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await DELETE(
+      deleteRequest({
+        feedbackType: 'like',
+        responseId: 'r-123',
+        userId: 'forged-user',
+      }),
+    );
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe('https://api:8880/chat/feedback');
+    expect(init.method).toBe('DELETE');
+    expect(new Headers(init.headers).get('x-api-key')).toBe('super-secret-key');
+    /* eslint-disable camelcase -- snake_case mirrors the Python API wire contract */
+    expect(JSON.parse(init.body as string)).toStrictEqual({
+      client: 'web',
+      response_id: 'r-123',
+      user_id: 'api-user-1',
+    });
+    /* eslint-enable camelcase -- snake_case mirrors the Python API wire contract */
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual(ack);
+  });
+
+  it('returns 400 when responseId is missing', async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await DELETE(deleteRequest({ feedbackType: 'like' }));
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when the browser is not authenticated', async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal('fetch', fetchMock);
+    const { AuthenticationRequiredError } =
+      await import('@/lib/authenticated-chat-user');
+    getAuthenticatedChatUserIdMock.mockRejectedValueOnce(
+      new AuthenticationRequiredError(),
+    );
+
+    const response = await DELETE(deleteRequest({ responseId: 'r-123' }));
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves an upstream not-found response', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('{}', { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await DELETE(deleteRequest({ responseId: 'missing' }));
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/web/test/conversation-actions.test.tsx
+++ b/web/test/conversation-actions.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { AnswerActionsProps } from '@/components/chat/answer-actions';
-import type { FeedbackType, MyUIMessage } from '@/lib/api-types';
+import type { FeedbackSelection, MyUIMessage } from '@/lib/api-types';
 
 import {
   type ChatStatus,
@@ -30,7 +30,7 @@ const renderFor = (
   return renderAnswerActions({
     disabled,
     messages: [message],
-    onVote: vi.fn<(messageId: string, vote: FeedbackType) => void>(),
+    onVote: vi.fn<(messageId: string, vote: FeedbackSelection) => void>(),
     regenerate: vi.fn<(options: { messageId: string }) => void>(),
     status,
   })(message) as ReactElement<AnswerActionsProps>;
@@ -72,7 +72,7 @@ describe('renderAnswerActions', () => {
     const node = renderAnswerActions({
       disabled: false,
       messages: [message],
-      onVote: vi.fn<(messageId: string, vote: FeedbackType) => void>(),
+      onVote: vi.fn<(messageId: string, vote: FeedbackSelection) => void>(),
       regenerate: vi.fn<(options: { messageId: string }) => void>(),
       status: 'ready',
     })(message);

--- a/web/test/conversation-message-state.test.ts
+++ b/web/test/conversation-message-state.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import type { MyUIMessage } from '@/lib/api-types';
 
-import { replaceFinishedMessage } from '@/lib/conversation-message-state';
+import {
+  applyFeedback,
+  replaceFinishedMessage,
+} from '@/lib/conversation-message-state';
 
 const assistantMessage = (
   id: string,
@@ -37,5 +40,25 @@ describe('replaceFinishedMessage', () => {
       { text: 'new complete', type: 'text' },
     ]);
     expect(next.at(1)?.metadata?.responseId).toBe('resp-1');
+  });
+});
+
+describe('applyFeedback', () => {
+  it('removes only the feedback metadata when the vote is cleared', () => {
+    const message: MyUIMessage = {
+      ...assistantMessage('a1', 'resp-1', 'Одговор'),
+      metadata: {
+        feedback: 'like',
+        inferenceModel: 'claude-sonnet-5',
+        responseId: 'resp-1',
+      },
+    };
+
+    const [updated] = applyFeedback('a1', null)([message]);
+
+    expect(updated?.metadata).toStrictEqual({
+      inferenceModel: 'claude-sonnet-5',
+      responseId: 'resp-1',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- make web feedback set, switch, and retraction atomic in the API
- proxy authenticated DELETE feedback requests and clear persisted message metadata
- toggle the selected answer action off, serialize rapid mutations, and roll back failed requests

## Validation
- API: 213 tests passed; Ruff and mypy passed
- Web: 412 tests passed; TypeScript and production build passed
- ESLint: 0 errors (18 pre-existing warnings)
- Playwright: Chromium feedback flow passed
- Manual QA: set, switch, retract, rapid-click serialization, and responsive layouts passed with no console errors