### PR TITLE
chore: generalize sponsored model references

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It's highly recommended to do this in Docker.
 To run the chat bot:
 
 1. Download [`compose.prod.yaml`](./compose.prod.yaml)
-2. Download [`.env.sample`](.env.sample), rename it to `.env`, and set the required values. At minimum, set a non-default `API_KEY` before exposing the service. Sponsored Luna remains disabled unless its separate rollout settings are deliberately configured; never use `API_KEY` as its provider credential. If you configure MCP servers, set non-default per-server `api_key` values in `MCP_SERVERS`.
+2. Download [`.env.sample`](.env.sample), rename it to `.env`, and set the required values. At minimum, set a non-default `API_KEY` before exposing the service. The sponsored model remains disabled unless its separate rollout settings are deliberately configured; never use `API_KEY` as its provider credential. If you configure MCP servers, set non-default per-server `api_key` values in `MCP_SERVERS`.
 3. Run `docker compose -f compose.prod.yaml up -d`
 
 The API runs on port `8880`, the GPU API on `8888`, and the web front-end on `3000`. This also brings up a `pgAdmin` instance on port `5555` by default.
@@ -33,7 +33,7 @@ Requires Python 3.14 (`>=3.14,<3.15`) and [`uv`](https://github.com/astral-sh/uv
 
 1. Clone the repository: `git clone https://github.com/finki-hub/chat-bot.git`
 2. Install dependencies: in each directory (`api` and `gpu-api`), run `uv sync`
-3. Prepare env. variables by copying `.env.sample` to `.env`. The sample database values work for local Docker, but set `API_KEY` to use authenticated write/feedback endpoints. OpenAI, Google, Anthropic, and Ollama models use per-user credentials saved from the web settings dialog; sponsored Luna is a separate, disabled-by-default server feature.
+3. Prepare env. variables by copying `.env.sample` to `.env`. The sample database values work for local Docker, but set `API_KEY` to use authenticated write/feedback endpoints. OpenAI, Google, Anthropic, and Ollama models use per-user credentials saved from the web settings dialog; the sponsored model is a separate, disabled-by-default server feature.
 4. Run it: `docker compose up -d`. Unlike production, the dev compose builds the `api`, `gpu-api` and `web` images locally from source (it does not pull from ghcr), so the first run builds the containers. The per-directory `uv sync` from step 2 is for local/IDE tooling only — the containers build their own environment.
 
 This also brings up the API Swagger UI (OpenAPI docs) at `localhost:8880/docs`, the GPU API docs at `localhost:8888/docs`, and pgAdmin at `localhost:5550`.
@@ -62,7 +62,7 @@ The root [`.env.sample`](.env.sample) contains the main variables used by the Do
 - `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_PORT` - used by the database service and by the API `DATABASE_URL`
 - `DATABASE_POOL_MIN_SIZE`, `DATABASE_POOL_MAX_SIZE` - asyncpg pool sizing per API worker
 - `GPU_API_URL` - API-to-GPU-API base URL; Docker defaults to `http://gpu-api:8888`
-- OpenAI, Google, Anthropic, and Ollama models are BYOK-only and do not use deployment credentials, except for the explicitly isolated sponsored Luna path below. Ollama defaults to `https://ollama.com`; custom Ollama endpoints must be HTTPS and allowed by `BYOK_ALLOWED_BASE_URLS`.
+- OpenAI, Google, Anthropic, and Ollama models are BYOK-only and do not use deployment credentials, except for the explicitly isolated sponsored model path below. Ollama defaults to `https://ollama.com`; custom Ollama endpoints must be HTTPS and allowed by `BYOK_ALLOWED_BASE_URLS`.
 - `RESUMABLE_STREAM_REDIS_URL` - server-only Redis/Valkey URL used by the web BFF for resumable chat streams
 - `RERANKER_MIN_SCORE`, `SOURCE_RERANKER_MIN_SCORE`, `CHAT_HISTORY_MAX_TURNS` - retrieval and chat tuning
 
@@ -135,8 +135,8 @@ curl --fail-with-body --no-buffer --silent --show-error \
   -H "x-api-key: ${API_KEY}" \
   -H 'content-type: application/json' \
   --data '{"user_id":"00000000-0000-4000-8000-000000000016","interface":"web","inference_model":"gpt-5.6-luna","query_transform_mode":"raw","messages":[{"role":"user","content":"deployment preflight"}],"max_tokens":1024}' \
-  "${CHATBOT_URL:-http://127.0.0.1:8880}/chat/" | tee /tmp/sponsored-luna-preflight.sse
-/bin/sh scripts/verify-sponsored-model-preflight.sh /tmp/sponsored-luna-preflight.sse
+  "${CHATBOT_URL:-http://127.0.0.1:8880}/chat/" | tee /tmp/sponsored-model-preflight.sse
+/bin/sh scripts/verify-sponsored-model-preflight.sh /tmp/sponsored-model-preflight.sse
 ```
 
 Do not run that command with placeholder credentials and do not report live

--- a/api/tests/test_security_settings.py
+++ b/api/tests/test_security_settings.py
@@ -151,7 +151,7 @@ def test_sponsored_model_defaults_are_disabled_and_safe():
     assert settings.SPONSORED_REQUEST_LEASE_SECONDS == 600
 
 
-def test_disabled_sponsored_luna_treats_blank_global_limit_as_unset(monkeypatch):
+def test_disabled_sponsored_model_treats_blank_global_limit_as_unset(monkeypatch):
     monkeypatch.setenv("SPONSORED_DAILY_GLOBAL_LIMIT", "")
 
     settings = Settings(SPONSORED_MODEL_ENABLED=False)

--- a/web/e2e/chat.spec.ts
+++ b/web/e2e/chat.spec.ts
@@ -44,8 +44,6 @@ const SPONSORED_CATALOG: ModelCatalog = {
   version: 1,
 };
 /* eslint-enable camelcase -- end catalog wire fixture. */
-const EVIDENCE_DIR = `${process.cwd()}/../.omo/evidence/ulw/ses_08b75c4cdffe8g6tX0apGLd65d/task-12-cross-surface-sponsored-luna`;
-
 const errorStream = (code: string, message: string) =>
   startChatStreamServer({
     gapMs: 0,
@@ -240,7 +238,7 @@ test.describe('chat streaming (mocked BFF)', () => {
 
   test('shows quota exhaustion actions and preserves the prior conversation', async ({
     page,
-  }) => {
+  }, testInfo) => {
     await page.setViewportSize({ height: 812, width: 375 });
     const conversationId = 'sponsored-preserved-conversation';
     const history = {
@@ -327,7 +325,9 @@ test.describe('chat streaming (mocked BFF)', () => {
     await expect(page.getByText('Претходен одговор')).toBeVisible();
     await page.screenshot({
       animations: 'disabled',
-      path: `${EVIDENCE_DIR}/sponsored-exhaustion-preserved-conversation.png`,
+      path: testInfo.outputPath(
+        'sponsored-exhaustion-preserved-conversation.png',
+      ),
     });
 
     await page.getByRole('button', { name: 'Почекај до ресетирањето' }).click();

--- a/web/e2e/chat.spec.ts
+++ b/web/e2e/chat.spec.ts
@@ -260,79 +260,83 @@ test.describe('chat streaming (mocked BFF)', () => {
       'free_quota_exhausted',
       'backend quota detail must not render',
     );
-
-    await page.route('**/api/health', async (route) => {
-      await route.fulfill({
-        body: '{}',
-        contentType: 'application/json',
-        status: 200,
+    try {
+      await page.route('**/api/health', async (route) => {
+        await route.fulfill({
+          body: '{}',
+          contentType: 'application/json',
+          status: 200,
+        });
       });
-    });
-    await page.route('**/api/auth/session', async (route) => {
-      await route.fulfill({
-        body: JSON.stringify({
-          expires: '2099-01-01T00:00:00.000Z',
-          user: { email: 'student@example.com', name: 'Student' },
-        }),
-        contentType: 'application/json',
-        status: 200,
+      await page.route('**/api/auth/session', async (route) => {
+        await route.fulfill({
+          body: JSON.stringify({
+            expires: '2099-01-01T00:00:00.000Z',
+            user: { email: 'student@example.com', name: 'Student' },
+          }),
+          contentType: 'application/json',
+          status: 200,
+        });
       });
-    });
-    await mockModels(page, {
-      catalog: SPONSORED_CATALOG,
-      credentialProviders: [],
-    });
-    await installMockChatState(page, {
-      conversations: [
-        {
-          id: conversationId,
-          model: SPONSORED_MODEL,
-          title: 'Постоечки разговор',
-        },
-      ],
-      histories: { [conversationId]: history },
-      streamUrl: chatServer.url,
-    });
-    await page.goto('/');
-    await page
-      .getByRole('button', { name: 'Прикажи/сокриј странична лента' })
-      .click();
-    await page
-      .getByRole('button', { exact: true, name: 'Постоечки разговор' })
-      .click();
-    await expect(page.getByText('Претходен одговор')).toBeVisible({
-      timeout: 15_000,
-    });
-    await expect(page.getByTestId('composer-model')).toContainText(
-      'Gemini 3.5 Flash',
-    );
-    await expect(page.getByTestId('composer-input')).toBeEnabled();
-    await page.getByTestId('composer-input').fill('Ново прашање');
-    await page.getByTestId('composer-submit').click();
+      await mockModels(page, {
+        catalog: SPONSORED_CATALOG,
+        credentialProviders: [],
+      });
+      await installMockChatState(page, {
+        conversations: [
+          {
+            id: conversationId,
+            model: SPONSORED_MODEL,
+            title: 'Постоечки разговор',
+          },
+        ],
+        histories: { [conversationId]: history },
+        streamUrl: chatServer.url,
+      });
+      await page.goto('/');
+      await page
+        .getByRole('button', { name: 'Прикажи/сокриј странична лента' })
+        .click();
+      await page
+        .getByRole('button', { exact: true, name: 'Постоечки разговор' })
+        .click();
+      await expect(page.getByText('Претходен одговор')).toBeVisible({
+        timeout: 15_000,
+      });
+      await expect(page.getByTestId('composer-model')).toContainText(
+        'Gemini 3.5 Flash',
+      );
+      await expect(page.getByTestId('composer-input')).toBeEnabled();
+      await page.getByTestId('composer-input').fill('Ново прашање');
+      await page.getByTestId('composer-submit').click();
 
-    await expect(
-      page.getByText('Бесплатната квота е искористена.'),
-    ).toBeVisible();
-    await expect(
-      page.getByText('backend quota detail must not render'),
-    ).toHaveCount(0);
-    await expect(
-      page.getByRole('button', { name: 'Додај API клуч' }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: 'Почекај до ресетирањето' }),
-    ).toBeVisible();
-    await expect(page.getByText('Претходен одговор')).toBeVisible();
-    await page.screenshot({
-      animations: 'disabled',
-      path: testInfo.outputPath(
-        'sponsored-exhaustion-preserved-conversation.png',
-      ),
-    });
+      await expect(
+        page.getByText('Бесплатната квота е искористена.'),
+      ).toBeVisible();
+      await expect(
+        page.getByText('backend quota detail must not render'),
+      ).toHaveCount(0);
+      await expect(
+        page.getByRole('button', { name: 'Додај API клуч' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Почекај до ресетирањето' }),
+      ).toBeVisible();
+      await expect(page.getByText('Претходен одговор')).toBeVisible();
+      await page.screenshot({
+        animations: 'disabled',
+        path: testInfo.outputPath(
+          'sponsored-exhaustion-preserved-conversation.png',
+        ),
+      });
 
-    await page.getByRole('button', { name: 'Почекај до ресетирањето' }).click();
-    await expect(page.getByText('Претходен одговор')).toBeVisible();
-    await chatServer.close();
+      await page
+        .getByRole('button', { name: 'Почекај до ресетирањето' })
+        .click();
+      await expect(page.getByText('Претходен одговор')).toBeVisible();
+    } finally {
+      await chatServer.close();
+    }
   });
 
   test('renders global sponsored unavailability without exposing backend details', async ({

--- a/web/e2e/helpers/sse.ts
+++ b/web/e2e/helpers/sse.ts
@@ -125,6 +125,7 @@ const closeServer = (server: Server): Promise<void> =>
     server.close(() => {
       resolve();
     });
+    server.closeAllConnections();
   });
 
 export const startChatStreamServer = (opts: {

--- a/web/e2e/mobile-chat.spec.ts
+++ b/web/e2e/mobile-chat.spec.ts
@@ -35,8 +35,6 @@ const SPONSORED_CATALOG: ModelCatalog = {
   source: 'live',
   version: 1,
 };
-const EVIDENCE_DIR = `${process.cwd()}/../.omo/evidence/ulw/ses_08b75c4cdffe8g6tX0apGLd65d/task-12-cross-surface-sponsored-luna`;
-
 const mockSession = async (
   page: Page,
   user: MockSessionUser = DEFAULT_SESSION_USER,
@@ -209,7 +207,7 @@ test('mobile keeps the account menu available when authenticated identity is una
 
 test('mobile model selector exposes the sponsored badge and remaining quota', async ({
   page,
-}) => {
+}, testInfo) => {
   await page.setViewportSize({ height: 812, width: 375 });
   await mockSession(page);
   await mockModels(page, {
@@ -229,7 +227,7 @@ test('mobile model selector exposes the sponsored badge and remaining quota', as
   await expect(badge).toContainText('3/5');
   await page.screenshot({
     animations: 'disabled',
-    path: `${EVIDENCE_DIR}/sponsored-selector-mobile.png`,
+    path: testInfo.outputPath('sponsored-selector-mobile.png'),
   });
 });
 

--- a/web/e2e/model-catalog.spec.ts
+++ b/web/e2e/model-catalog.spec.ts
@@ -6,6 +6,7 @@ import type { ModelCatalog } from '@/lib/api-types';
 /* eslint-disable sonarjs/no-duplicate-string -- repeated selectors define the E2E surface. */
 import { installMockChatState } from './helpers/chat-state';
 import { mockModels } from './helpers/models';
+import { startChatStreamServer } from './helpers/sse';
 
 const STORAGE_KEY = 'finkiHub.ui';
 // A model id that is no longer served by the catalog, to exercise stale recovery.
@@ -19,8 +20,6 @@ const LUNA_ID = 'gpt-5.6-luna';
 const LUNA_NAME = 'GPT-5.6 Luna';
 const EMPTY_JSON = '{}';
 const LUNA_OPTION_PATTERN = /GPT-5\.6 Luna/u;
-const EVIDENCE_DIR = `${process.cwd()}/../.omo/evidence/ulw/ses_08b75c4cdffe8g6tX0apGLd65d/task-12-cross-surface-sponsored-luna`;
-
 const lunaCatalog = (
   remaining: number,
   availability: 'both' | 'byok' | 'sponsored' = 'sponsored',
@@ -278,7 +277,7 @@ test.describe('model catalog selector (typed, mocked BFF)', () => {
 
   test('renders the sponsored badge and updates the quota from five to zero', async ({
     page,
-  }) => {
+  }, testInfo) => {
     let catalog = lunaCatalog(5);
     await mockModels(page, {
       catalog: () => catalog,
@@ -291,12 +290,26 @@ test.describe('model catalog selector (typed, mocked BFF)', () => {
         status: 200,
       });
     });
-    const streamUrl = 'http://127.0.0.1:9/sponsored-quota';
+    const chatServer = await startChatStreamServer({
+      gapMs: 0,
+      head: [
+        { messageMetadata: { inferenceModel: LUNA_ID }, type: 'start' },
+        { id: 'sponsored-answer', type: 'text-start' },
+        {
+          delta: 'Квотата е ажурирана.',
+          id: 'sponsored-answer',
+          type: 'text-delta',
+        },
+        { id: 'sponsored-answer', type: 'text-end' },
+        { type: 'finish' },
+      ],
+      tail: [],
+    });
     await installMockChatState(page, {
       onCreate: () => {
         catalog = lunaCatalog(0);
       },
-      streamUrl,
+      streamUrl: chatServer.url,
     });
 
     await page.goto('/');
@@ -309,7 +322,7 @@ test.describe('model catalog selector (typed, mocked BFF)', () => {
     await expect(badge).toContainText('5/5');
     await page.screenshot({
       animations: 'disabled',
-      path: `${EVIDENCE_DIR}/sponsored-quota-five.png`,
+      path: testInfo.outputPath('sponsored-quota-five.png'),
     });
     await page.keyboard.press('Escape');
 
@@ -323,8 +336,9 @@ test.describe('model catalog selector (typed, mocked BFF)', () => {
     await expect(badge).toContainText('0/5');
     await page.screenshot({
       animations: 'disabled',
-      path: `${EVIDENCE_DIR}/sponsored-quota-zero.png`,
+      path: testInfo.outputPath('sponsored-quota-zero.png'),
     });
+    await chatServer.close();
   });
 
   test('refreshes sponsored availability after credentials change without a reload', async ({

--- a/web/e2e/model-catalog.spec.ts
+++ b/web/e2e/model-catalog.spec.ts
@@ -305,40 +305,43 @@ test.describe('model catalog selector (typed, mocked BFF)', () => {
       ],
       tail: [],
     });
-    await installMockChatState(page, {
-      onCreate: () => {
-        catalog = lunaCatalog(0);
-      },
-      streamUrl: chatServer.url,
-    });
+    try {
+      await installMockChatState(page, {
+        onCreate: () => {
+          catalog = lunaCatalog(0);
+        },
+        streamUrl: chatServer.url,
+      });
 
-    await page.goto('/');
-    const trigger = page.getByTestId('composer-model');
-    await expect(trigger).toContainText(LUNA_NAME);
-    await trigger.click();
+      await page.goto('/');
+      const trigger = page.getByTestId('composer-model');
+      await expect(trigger).toContainText(LUNA_NAME);
+      await trigger.click();
 
-    const badge = page.getByTestId(`model-free-badge-${LUNA_ID}`);
-    await expect(badge).toContainText('Бесплатно');
-    await expect(badge).toContainText('5/5');
-    await page.screenshot({
-      animations: 'disabled',
-      path: testInfo.outputPath('sponsored-quota-five.png'),
-    });
-    await page.keyboard.press('Escape');
+      const badge = page.getByTestId(`model-free-badge-${LUNA_ID}`);
+      await expect(badge).toContainText('Бесплатно');
+      await expect(badge).toContainText('5/5');
+      await page.screenshot({
+        animations: 'disabled',
+        path: testInfo.outputPath('sponsored-quota-five.png'),
+      });
+      await page.keyboard.press('Escape');
 
-    await page.getByTestId('composer-input').fill('Провери квота');
-    await page.getByTestId('composer-submit').click();
-    await expect
-      .poll(() => catalog.models[0]?.sponsored_quota?.remaining)
-      .toBe(0);
+      await page.getByTestId('composer-input').fill('Провери квота');
+      await page.getByTestId('composer-submit').click();
+      await expect
+        .poll(() => catalog.models[0]?.sponsored_quota?.remaining)
+        .toBe(0);
 
-    await trigger.click();
-    await expect(badge).toContainText('0/5');
-    await page.screenshot({
-      animations: 'disabled',
-      path: testInfo.outputPath('sponsored-quota-zero.png'),
-    });
-    await chatServer.close();
+      await trigger.click();
+      await expect(badge).toContainText('0/5');
+      await page.screenshot({
+        animations: 'disabled',
+        path: testInfo.outputPath('sponsored-quota-zero.png'),
+      });
+    } finally {
+      await chatServer.close();
+    }
   });
 
   test('refreshes sponsored availability after credentials change without a reload', async ({

--- a/web/e2e/resumable-chat.spec.ts
+++ b/web/e2e/resumable-chat.spec.ts
@@ -13,7 +13,6 @@ const FINAL_TOKEN = ' и продолжение по освежување.';
 const STOP_TOKEN = 'Делумен одговор';
 const LONG_GAP_MS = 30_000;
 const CHAT_STREAM_URL_PATTERN = /\/api\/chat\/[^/]+\/stream$/u;
-const EVIDENCE_DIR = `${process.cwd()}/../.omo/evidence/ulw/ses_08b75c4cdffe8g6tX0apGLd65d/task-12-cross-surface-sponsored-luna`;
 const SPONSORED_CATALOG: ModelCatalog = {
   models: [
     {
@@ -109,7 +108,7 @@ const installHealthRoute = async (page: Page): Promise<void> => {
 test.describe('resumable chat lifecycle (mocked BFF)', () => {
   test('resumes after refresh and persists the completed assistant response', async ({
     page,
-  }) => {
+  }, testInfo) => {
     // Given: the initial POST emits one token slowly while the resume endpoint can replay the full stream.
     await installHealthRoute(page);
     await installModelRoute(page);
@@ -266,7 +265,7 @@ test.describe('resumable chat lifecycle (mocked BFF)', () => {
     ).toContainText('5/5');
     await page.screenshot({
       animations: 'disabled',
-      path: `${EVIDENCE_DIR}/sponsored-conversation-preserved.png`,
+      path: testInfo.outputPath('sponsored-conversation-preserved.png'),
     });
     await page.keyboard.press('Escape');
     expect(historyRequests).toBeGreaterThan(0);

--- a/web/e2e/resumable-chat.spec.ts
+++ b/web/e2e/resumable-chat.spec.ts
@@ -117,160 +117,162 @@ test.describe('resumable chat lifecycle (mocked BFF)', () => {
       head: chunksForAnswer(FIRST_TOKEN).slice(0, 3),
       tail: [],
     });
-    let conversationId: null | string = null;
-    let historyRequests = 0;
-    let resumeRequests = 0;
-    let allowResumeReplay = false;
-    let allowServerHistory = false;
-    const conversations: ConversationRow[] = [];
+    try {
+      let conversationId: null | string = null;
+      let historyRequests = 0;
+      let resumeRequests = 0;
+      let allowResumeReplay = false;
+      let allowServerHistory = false;
+      const conversations: ConversationRow[] = [];
 
-    await page.route('**/api/chat', async (route) => {
-      if (route.request().method() === 'GET') {
-        await route.fulfill({
-          body: JSON.stringify(conversations),
-          contentType: 'application/json',
-          status: 200,
-        });
-        return;
-      }
-      conversationId = parseConversationId(route.request().postData());
-      await route.fulfill({
-        headers: { location: firstLegServer.url },
-        status: 307,
-      });
-    });
-    await page.route('**/api/chat/*', async (route) => {
-      if (route.request().method() === 'PATCH') {
-        conversationId = conversationIdFrom(route.request().url());
-        if (
-          conversations.every(
-            (conversation) => conversation.id !== conversationId,
-          )
-        ) {
-          conversations.unshift({
-            id: conversationId,
-            model: INFERENCE_MODEL,
-            title: 'Резимирај ми го условот за запишување.',
+      await page.route('**/api/chat', async (route) => {
+        if (route.request().method() === 'GET') {
+          await route.fulfill({
+            body: JSON.stringify(conversations),
+            contentType: 'application/json',
+            status: 200,
           });
+          return;
         }
-        await route.fulfill({ status: 204 });
-        return;
-      }
-      await route.fallback();
-    });
-    await page.route('**/api/chat/*/stream', async (route) => {
-      resumeRequests += 1;
-      if (!allowResumeReplay) {
-        await route.fulfill({ status: 204 });
-        return;
-      }
-      allowResumeReplay = false;
-      const body = chunksForAnswer(`${FIRST_TOKEN}${FINAL_TOKEN}`)
-        .map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`)
-        .join('');
-      await route.fulfill({
-        body: `${body}data: [DONE]\n\n`,
-        contentType: 'text/event-stream',
-        headers: { 'x-vercel-ai-ui-message-stream': 'v1' },
-        status: 200,
-      });
-    });
-    await page.route('**/api/chat/*/history', async (route) => {
-      historyRequests += 1;
-      if (!allowServerHistory) {
+        conversationId = parseConversationId(route.request().postData());
         await route.fulfill({
-          body: emptyHistoryBody(conversationId),
+          headers: { location: firstLegServer.url },
+          status: 307,
+        });
+      });
+      await page.route('**/api/chat/*', async (route) => {
+        if (route.request().method() === 'PATCH') {
+          conversationId = conversationIdFrom(route.request().url());
+          if (
+            conversations.every(
+              (conversation) => conversation.id !== conversationId,
+            )
+          ) {
+            conversations.unshift({
+              id: conversationId,
+              model: INFERENCE_MODEL,
+              title: 'Резимирај ми го условот за запишување.',
+            });
+          }
+          await route.fulfill({ status: 204 });
+          return;
+        }
+        await route.fallback();
+      });
+      await page.route('**/api/chat/*/stream', async (route) => {
+        resumeRequests += 1;
+        if (!allowResumeReplay) {
+          await route.fulfill({ status: 204 });
+          return;
+        }
+        allowResumeReplay = false;
+        const body = chunksForAnswer(`${FIRST_TOKEN}${FINAL_TOKEN}`)
+          .map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`)
+          .join('');
+        await route.fulfill({
+          body: `${body}data: [DONE]\n\n`,
+          contentType: 'text/event-stream',
+          headers: { 'x-vercel-ai-ui-message-stream': 'v1' },
+          status: 200,
+        });
+      });
+      await page.route('**/api/chat/*/history', async (route) => {
+        historyRequests += 1;
+        if (!allowServerHistory) {
+          await route.fulfill({
+            body: emptyHistoryBody(conversationId),
+            contentType: 'application/json',
+            status: 200,
+          });
+          return;
+        }
+        await route.fulfill({
+          body: JSON.stringify({
+            conversation: {
+              id: conversationId,
+              model: INFERENCE_MODEL,
+              title: 'Резимирај ми го условот за запишување.',
+            },
+            messages: [
+              {
+                id: 'u-history',
+                metadata: {},
+                parts: [
+                  {
+                    text: 'Резимирај ми го условот за запишување.',
+                    type: 'text',
+                  },
+                ],
+                role: 'user',
+              },
+              {
+                id: 'a-history',
+                metadata: {
+                  inferenceModel: INFERENCE_MODEL,
+                  responseId: RESPONSE_ID,
+                },
+                parts: [{ text: `${FIRST_TOKEN}${FINAL_TOKEN}`, type: 'text' }],
+                role: 'assistant',
+              },
+            ],
+          }),
           contentType: 'application/json',
           status: 200,
         });
-        return;
-      }
-      await route.fulfill({
-        body: JSON.stringify({
-          conversation: {
-            id: conversationId,
-            model: INFERENCE_MODEL,
-            title: 'Резимирај ми го условот за запишување.',
-          },
-          messages: [
-            {
-              id: 'u-history',
-              metadata: {},
-              parts: [
-                {
-                  text: 'Резимирај ми го условот за запишување.',
-                  type: 'text',
-                },
-              ],
-              role: 'user',
-            },
-            {
-              id: 'a-history',
-              metadata: {
-                inferenceModel: INFERENCE_MODEL,
-                responseId: RESPONSE_ID,
-              },
-              parts: [{ text: `${FIRST_TOKEN}${FINAL_TOKEN}`, type: 'text' }],
-              role: 'assistant',
-            },
-          ],
-        }),
-        contentType: 'application/json',
-        status: 200,
       });
-    });
 
-    await page.goto('/');
-    await page.getByTestId('composer-model').click();
-    await expect(
-      page.getByTestId('model-free-badge-claude-sonnet-5'),
-    ).toContainText('5/5');
-    await page.keyboard.press('Escape');
-    await page
-      .getByTestId('composer-input')
-      .fill('Резимирај ми го условот за запишување.');
-    await page.getByTestId('composer-input').press('Enter');
-    await expect(page.getByTestId('answer-text')).toContainText(FIRST_TOKEN);
+      await page.goto('/');
+      await page.getByTestId('composer-model').click();
+      await expect(
+        page.getByTestId('model-free-badge-claude-sonnet-5'),
+      ).toContainText('5/5');
+      await page.keyboard.press('Escape');
+      await page
+        .getByTestId('composer-input')
+        .fill('Резимирај ми го условот за запишување.');
+      await page.getByTestId('composer-input').press('Enter');
+      await expect(page.getByTestId('answer-text')).toContainText(FIRST_TOKEN);
 
-    // When: the browser refreshes mid-generation and reconnects to the same chat.
-    allowResumeReplay = true;
-    const resumeResponse = page.waitForResponse(
-      (response) =>
-        CHAT_STREAM_URL_PATTERN.test(response.url()) &&
-        response.status() === 200,
-    );
-    await page.reload();
+      // When: the browser refreshes mid-generation and reconnects to the same chat.
+      allowResumeReplay = true;
+      const resumeResponse = page.waitForResponse(
+        (response) =>
+          CHAT_STREAM_URL_PATTERN.test(response.url()) &&
+          response.status() === 200,
+      );
+      await page.reload();
 
-    // Then: the UI consumes the resumed SSE and can reload the final answer from server history.
-    const resumed = await resumeResponse;
-    expect(resumed.status()).toBe(200);
-    await expect(page.getByTestId('answer-text').last()).toContainText(
-      `${FIRST_TOKEN}${FINAL_TOKEN}`,
-    );
-    expect(resumeRequests).toBeGreaterThan(0);
-    expect(conversationId).not.toBeNull();
+      // Then: the UI consumes the resumed SSE and can reload the final answer from server history.
+      const resumed = await resumeResponse;
+      expect(resumed.status()).toBe(200);
+      await expect(page.getByTestId('answer-text').last()).toContainText(
+        `${FIRST_TOKEN}${FINAL_TOKEN}`,
+      );
+      expect(resumeRequests).toBeGreaterThan(0);
+      expect(conversationId).not.toBeNull();
 
-    await page.unroute('**/api/chat/*/stream');
-    await page.route('**/api/chat/*/stream', async (route) => {
-      await route.fulfill({ status: 204 });
-    });
-    allowServerHistory = true;
-    await page.reload();
-    await expect(page.getByTestId('answer-text').last()).toContainText(
-      `${FIRST_TOKEN}${FINAL_TOKEN}`,
-    );
-    await page.getByTestId('composer-model').click();
-    await expect(
-      page.getByTestId('model-free-badge-claude-sonnet-5'),
-    ).toContainText('5/5');
-    await page.screenshot({
-      animations: 'disabled',
-      path: testInfo.outputPath('sponsored-conversation-preserved.png'),
-    });
-    await page.keyboard.press('Escape');
-    expect(historyRequests).toBeGreaterThan(0);
-
-    await firstLegServer.close();
+      await page.unroute('**/api/chat/*/stream');
+      await page.route('**/api/chat/*/stream', async (route) => {
+        await route.fulfill({ status: 204 });
+      });
+      allowServerHistory = true;
+      await page.reload();
+      await expect(page.getByTestId('answer-text').last()).toContainText(
+        `${FIRST_TOKEN}${FINAL_TOKEN}`,
+      );
+      await page.getByTestId('composer-model').click();
+      await expect(
+        page.getByTestId('model-free-badge-claude-sonnet-5'),
+      ).toContainText('5/5');
+      await page.screenshot({
+        animations: 'disabled',
+        path: testInfo.outputPath('sponsored-conversation-preserved.png'),
+      });
+      await page.keyboard.press('Escape');
+      expect(historyRequests).toBeGreaterThan(0);
+    } finally {
+      await firstLegServer.close();
+    }
   });
 
   test('explicit stop prevents a later refresh from resuming the stream', async ({

--- a/web/test/chat-stream-server.test.ts
+++ b/web/test/chat-stream-server.test.ts
@@ -1,0 +1,35 @@
+import { get, type IncomingMessage } from 'node:http';
+import { setTimeout as delay } from 'node:timers/promises';
+import { describe, expect, it } from 'vitest';
+
+import { startChatStreamServer } from '../e2e/helpers/sse';
+
+describe('startChatStreamServer', () => {
+  it('closes while an SSE response is active', async () => {
+    // Given: a client holds an in-progress SSE response open.
+    const server = await startChatStreamServer({
+      gapMs: 30_000,
+      head: [{ type: 'start' }],
+      tail: [],
+    });
+    const response = await new Promise<IncomingMessage>((resolve, reject) => {
+      get(server.url, resolve).once('error', reject);
+    });
+
+    // When: test teardown closes the server before the stream completes.
+    const closePromise = server.close();
+    const result = await Promise.race([
+      (async () => {
+        await closePromise;
+        return 'closed' as const;
+      })(),
+      delay(500, 'timed-out' as const, { ref: false }),
+    ]);
+
+    // Then: teardown finishes without waiting for the client to disconnect.
+    response.destroy();
+    await closePromise;
+
+    expect(result).toBe('closed');
+  });
+});

--- a/web/test/composer.test.tsx
+++ b/web/test/composer.test.tsx
@@ -266,7 +266,7 @@ describe('Composer', () => {
     expect(screen.getByTestId('composer-submit')).toBeDisabled();
   });
 
-  it('submits with sponsored Luna without an OpenAI credential', async () => {
+  it('submits with a sponsored model without its provider credential', async () => {
     const { onSubmit } = setup({
       availableProviders: new Set(),
       model: LUNA_ID,


### PR DESCRIPTION
## Summary
- generalize sponsored-model rollout and test wording without changing the Luna catalog identity
- write sponsored E2E screenshots to Playwright-owned per-test output paths
- use the local SSE fixture for clean quota-transition evidence

## Testing
- `uv run pytest tests/test_security_settings.py tests/test_sponsored_preflight.py`
- `uv run ruff check tests/test_security_settings.py`
- `npm run check`
- targeted ESLint and Vitest checks
- five sponsored-model Playwright scenarios in Chromium
- five-lane goal, QA, code-quality, security, and context review