### PR TITLE
fix(api): restore PostHog SDK exception capture

### DIFF
--- a/api/app/utils/posthog_client.py
+++ b/api/app/utils/posthog_client.py
@@ -12,8 +12,6 @@ from app.utils.settings import Settings
 logger = logging.getLogger(__name__)
 
 _SERVICE = "chat-bot-api"
-_EXCEPTION_EVENT = "$exception"
-_SAFE_EXCEPTION_MESSAGE = "Unhandled server exception."
 
 _DISTINCT_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
 _SESSION_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
@@ -129,15 +127,10 @@ def capture_exception(
         return
 
     try:
-        client.capture(
-            event=_EXCEPTION_EVENT,
+        client.capture_exception(
+            exc,
             distinct_id=distinct_id,
-            properties={
-                "service": _SERVICE,
-                **(properties or {}),
-                "$exception_type": type(exc).__name__,
-                "$exception_message": _SAFE_EXCEPTION_MESSAGE,
-            },
+            properties={"service": _SERVICE, **(properties or {})},
         )
     except Exception:
         logger.exception("PostHog capture_exception failed")

--- a/api/tests/test_posthog_client.py
+++ b/api/tests/test_posthog_client.py
@@ -1,4 +1,3 @@
-from types import SimpleNamespace
 from unittest.mock import create_autospec
 
 import pytest
@@ -12,7 +11,7 @@ def test_capture_exception_forwards_the_original_exception(
 ) -> None:
     # Given: an initialized PostHog client and an exception with debugging context.
     client = create_autospec(Posthog, instance=True)
-    monkeypatch.setattr(posthog_client, "_state", SimpleNamespace(client=client))
+    monkeypatch.setattr("app.utils.posthog_client._state.client", client)
     exception = RuntimeError("database unavailable")
 
     # When: the application reports the handled exception.

--- a/api/tests/test_posthog_client.py
+++ b/api/tests/test_posthog_client.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+from unittest.mock import create_autospec
+
+import pytest
+from posthog import Posthog
+
+from app.utils import posthog_client
+
+
+def test_capture_exception_forwards_the_original_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given: an initialized PostHog client and an exception with debugging context.
+    client = create_autospec(Posthog, instance=True)
+    monkeypatch.setattr(posthog_client, "_state", SimpleNamespace(client=client))
+    exception = RuntimeError("database unavailable")
+
+    # When: the application reports the handled exception.
+    posthog_client.capture_exception(
+        exception,
+        distinct_id="user-123",
+        properties={"path": "/chat/{chat_id}"},
+    )
+
+    # Then: the SDK receives the original exception and its safe request metadata.
+    client.capture_exception.assert_called_once_with(
+        exception,
+        distinct_id="user-123",
+        properties={
+            "service": "chat-bot-api",
+            "path": "/chat/{chat_id}",
+        },
+    )


### PR DESCRIPTION
Restores the original PostHog SDK exception capture behavior that was changed in PR #675.

## What changed in PR #675
Commit `79282b4` replaced `client.capture_exception(exc, ...)` with a sanitized generic `$exception` event containing only the exception type name and a fixed safe message. This removed the original exception object, message, and stacktrace from PostHog error tracking.

## What this PR restores
- Removes `_EXCEPTION_EVENT` and `_SAFE_EXCEPTION_MESSAGE` constants
- Calls `client.capture_exception(exc, distinct_id=..., properties=...)` again
- Forwards the original exception object with its full debugging context
- Preserves all existing telemetry boundaries (route templates only, no request bodies)

## What's preserved
- `capture_sponsored_event` and all sponsored aggregate telemetry
- PostHog initialization, key, host, and configuration
- Safe request metadata (matched route template + HTTP method only)
- SDK failure containment (try/except + logging)

## Verification
- Full API pytest suite: 303 passed, 4 skipped
- Ruff: passed
- MyPy: passed (172 files)
- New regression test: `test_capture_exception_forwards_the_original_exception`
- Manual driver: confirmed original exception identity is forwarded