### PR TITLE
fix: resume generation and regeneration after refresh

### DIFF
--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -4,10 +4,11 @@ import json
 import logging
 from collections.abc import AsyncGenerator, AsyncIterable
 from datetime import UTC, datetime, timedelta
+from typing import Annotated
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Header, Request, status
 from fastapi.responses import StreamingResponse
 
 from app.api.provider_credentials import (
@@ -868,9 +869,13 @@ async def _chat_response_stream(
 async def chat(
     payload: ChatSchema,
     request: Request,
+    x_response_id: Annotated[
+        UUID | None,
+        Header(alias="X-Response-Id"),
+    ] = None,
     db: Database = db_dep,
 ) -> StreamingResponse:
-    response_id = uuid4()
+    response_id = x_response_id or uuid4()
     record_response_id(str(response_id))
     stream = _chat_response_stream(payload, request, db, response_id)
     response = StreamingResponse(stream, media_type="text/event-stream")

--- a/api/app/api/chat_state.py
+++ b/api/app/api/chat_state.py
@@ -24,6 +24,7 @@ from app.data.chat_persistence import (
 )
 from app.data.chat_state import (
     mark_active_stream_stopped_if_current,
+    mark_active_stream_streaming_if_pending,
     replace_assistant_message_and_prune_after,
     upsert_assistant_message_by_response_id,
 )
@@ -380,6 +381,7 @@ async def set_active_stream_state(
         user_id=payload.user_id,
         active_stream_id=payload.active_stream_id,
         active_response_id=payload.active_response_id,
+        active_replacement_message_id=payload.active_replacement_message_id,
         active_status=payload.active_status,
     )
     if updated is None:
@@ -402,6 +404,28 @@ async def clear_active_stream_state(
         db,
         conversation_id=conversation_id,
         user_id=user_id,
+        active_stream_id=active_stream_id,
+    )
+    if updated is None:
+        raise _not_found()
+    return updated
+
+
+@router.post(
+    "/conversations/{conversation_id}/active-stream/{active_stream_id}/streaming",
+    status_code=status.HTTP_200_OK,
+    operation_id="markChatStateActiveStreamStreamingIfPending",
+)
+async def mark_active_stream_streaming_state(
+    conversation_id: UUID,
+    active_stream_id: UUID,
+    payload: UserScopedRequest,
+    db: ChatPersistenceDatabase = db_dep,
+) -> ChatConversation:
+    updated = await mark_active_stream_streaming_if_pending(
+        db,
+        conversation_id=conversation_id,
+        user_id=payload.user_id,
         active_stream_id=active_stream_id,
     )
     if updated is None:

--- a/api/app/api/chat_state.py
+++ b/api/app/api/chat_state.py
@@ -314,8 +314,7 @@ async def upsert_assistant_message_state(
     payload: AssistantMessageUpsertRequest,
     db: ChatPersistenceDatabase = db_dep,
 ) -> ChatMessage:
-    await _ensure_owned(db, conversation_id=conversation_id, user_id=payload.user_id)
-    return await upsert_assistant_message_by_response_id(
+    updated = await upsert_assistant_message_by_response_id(
         db,
         ChatMessageUpsert(
             id=payload.id,
@@ -326,7 +325,12 @@ async def upsert_assistant_message_state(
             metadata=payload.metadata,
             parts=payload.parts,
         ),
+        active_stream_id=payload.active_stream_id or response_id,
+        user_id=payload.user_id,
     )
+    if updated is None:
+        raise _not_found()
+    return updated
 
 
 @router.put(
@@ -357,6 +361,7 @@ async def replace_assistant_message_state(
             metadata=payload.metadata,
             parts=payload.parts,
         ),
+        active_stream_id=payload.active_stream_id or response_id,
         retained_message_ids=payload.retained_message_ids,
         user_id=payload.user_id,
     )

--- a/api/app/data/chat_persistence.py
+++ b/api/app/data/chat_persistence.py
@@ -203,6 +203,7 @@ async def set_active_stream(
     user_id: UUID,
     active_stream_id: UUID,
     active_response_id: UUID,
+    active_replacement_message_id: UUID | None,
     active_status: ActiveStreamStatus,
 ) -> ChatConversation | None:
     row = await db.fetchrow(
@@ -210,7 +211,8 @@ async def set_active_stream(
         UPDATE chat_conversation
         SET active_stream_id = $3,
             active_response_id = $4,
-            active_status = $5,
+            active_replacement_message_id = $5,
+            active_status = $6,
             updated_at = NOW()
         WHERE id = $1 AND user_id = $2
         RETURNING *
@@ -219,6 +221,7 @@ async def set_active_stream(
         user_id,
         active_stream_id,
         active_response_id,
+        active_replacement_message_id,
         active_status.value,
     )
     return None if row is None else conversation_from_row(row)
@@ -236,6 +239,7 @@ async def clear_active_stream_if_current(
         UPDATE chat_conversation
         SET active_stream_id = NULL,
             active_response_id = NULL,
+            active_replacement_message_id = NULL,
             active_status = NULL,
             updated_at = NOW()
         WHERE id = $1 AND user_id = $2 AND active_stream_id = $3
@@ -259,6 +263,7 @@ async def clear_stale_active_streams(
             UPDATE chat_conversation
             SET active_stream_id = NULL,
                 active_response_id = NULL,
+                active_replacement_message_id = NULL,
                 active_status = NULL
             WHERE active_stream_id IS NOT NULL AND updated_at < $1
             RETURNING id

--- a/api/app/data/chat_state.py
+++ b/api/app/data/chat_state.py
@@ -13,11 +13,19 @@ from app.schemas.chat_persistence import (
 async def upsert_assistant_message_by_response_id(
     db: ChatPersistenceDatabase,
     message: ChatMessageUpsert,
-) -> ChatMessage:
+    *,
+    active_stream_id: UUID,
+    user_id: UUID,
+) -> ChatMessage | None:
     row = await db.fetchrow(
         """
         INSERT INTO chat_message (id, conversation_id, role, content, response_id, metadata, parts)
-        VALUES ($3, $1, 'assistant', $4, $2, $5::jsonb, $6::jsonb)
+        SELECT $3, conversation.id, 'assistant', $4, $2, $5::jsonb, $6::jsonb
+        FROM chat_conversation conversation
+        WHERE conversation.id = $1
+          AND conversation.user_id = $7
+          AND conversation.active_stream_id = $8
+        FOR UPDATE OF conversation
         ON CONFLICT (conversation_id, response_id)
         WHERE response_id IS NOT NULL AND role = 'assistant'
         DO UPDATE SET
@@ -33,16 +41,17 @@ async def upsert_assistant_message_by_response_id(
         message.content,
         json.dumps(message.metadata),
         None if message.parts is None else json.dumps(message.parts),
+        user_id,
+        active_stream_id,
     )
-    if row is None:
-        raise RuntimeError("assistant chat_message upsert returned no row")
-    return message_from_row(row)
+    return None if row is None else message_from_row(row)
 
 
 async def replace_assistant_message_and_prune_after(
     db: ChatPersistenceDatabase,
     message: ChatMessageUpsert,
     *,
+    active_stream_id: UUID,
     retained_message_ids: list[UUID],
     user_id: UUID,
 ) -> ChatMessage | None:
@@ -57,12 +66,14 @@ async def replace_assistant_message_and_prune_after(
               AND assistant.conversation_id = $2
               AND assistant.role = 'assistant'
               AND conversation.user_id = $3
+              AND conversation.active_stream_id = $4
+            FOR UPDATE OF conversation
         ), updated AS (
             UPDATE chat_message assistant
-            SET content = $4,
-                response_id = $5,
-                metadata = $6::jsonb,
-                parts = $7::jsonb,
+            SET content = $5,
+                response_id = $6,
+                metadata = $7::jsonb,
+                parts = $8::jsonb,
                 updated_at = NOW()
             FROM target
             WHERE assistant.id = target.id
@@ -72,7 +83,7 @@ async def replace_assistant_message_and_prune_after(
             USING target
             WHERE stale.conversation_id = target.conversation_id
               AND stale.created_at > target.created_at
-              AND NOT (stale.id = ANY($8::uuid[]))
+              AND NOT (stale.id = ANY($9::uuid[]))
             RETURNING stale.id
         )
         SELECT * FROM updated
@@ -80,6 +91,7 @@ async def replace_assistant_message_and_prune_after(
         message.id,
         message.conversation_id,
         user_id,
+        active_stream_id,
         message.content,
         message.response_id,
         json.dumps(message.metadata),

--- a/api/app/data/chat_state.py
+++ b/api/app/data/chat_state.py
@@ -109,3 +109,28 @@ async def mark_active_stream_stopped_if_current(
         active_stream_id,
     )
     return None if row is None else conversation_from_row(row)
+
+
+async def mark_active_stream_streaming_if_pending(
+    db: ChatPersistenceDatabase,
+    *,
+    conversation_id: UUID,
+    user_id: UUID,
+    active_stream_id: UUID,
+) -> ChatConversation | None:
+    row = await db.fetchrow(
+        """
+        UPDATE chat_conversation
+        SET active_status = 'streaming',
+            updated_at = NOW()
+        WHERE id = $1
+          AND user_id = $2
+          AND active_stream_id = $3
+          AND active_status = 'pending'
+        RETURNING *
+        """,
+        conversation_id,
+        user_id,
+        active_stream_id,
+    )
+    return None if row is None else conversation_from_row(row)

--- a/api/app/schemas/chat_persistence.py
+++ b/api/app/schemas/chat_persistence.py
@@ -68,6 +68,7 @@ class ChatConversation(BaseModel):
     user_id: UUID
     active_stream_id: UUID | None = None
     active_response_id: UUID | None = None
+    active_replacement_message_id: UUID | None = None
     active_status: ActiveStreamStatus | None = None
     model: str | None = None
     title: str | None = None

--- a/api/app/schemas/chat_state.py
+++ b/api/app/schemas/chat_state.py
@@ -13,6 +13,7 @@ class UserScopedRequest(BaseModel):
 class SetActiveStreamRequest(UserScopedRequest):
     active_stream_id: UUID
     active_response_id: UUID
+    active_replacement_message_id: UUID | None = None
     active_status: ActiveStreamStatus
 
 

--- a/api/app/schemas/chat_state.py
+++ b/api/app/schemas/chat_state.py
@@ -48,10 +48,11 @@ class UserMessageUpsertRequest(UserScopedRequest):
 
 
 class AssistantMessageUpsertRequest(UserMessageUpsertRequest):
-    pass
+    active_stream_id: UUID | None = None
 
 
 class AssistantMessageReplacementRequest(UserScopedRequest):
+    active_stream_id: UUID | None = None
     content: str = Field(min_length=1)
     metadata: dict[str, JsonValue] = Field(default_factory=dict)
     parts: list[JsonValue] | None = None

--- a/api/resources/migrations/0009_add_active_chat_replacement.sql
+++ b/api/resources/migrations/0009_add_active_chat_replacement.sql
@@ -1,0 +1,2 @@
+ALTER TABLE chat_conversation
+ADD COLUMN IF NOT EXISTS active_replacement_message_id UUID;

--- a/api/tests/chat_persistence_fake.py
+++ b/api/tests/chat_persistence_fake.py
@@ -160,6 +160,7 @@ class FakeChatDatabase:
                 user_id=user_id,
                 active_stream_id=None,
                 active_response_id=None,
+                active_replacement_message_id=None,
                 active_status=None,
                 model=model,
                 title=title,
@@ -178,20 +179,43 @@ class FakeChatDatabase:
                 return None
             current["active_stream_id"] = None
             current["active_response_id"] = None
+            current["active_replacement_message_id"] = None
             current["active_status"] = None
             current["updated_at"] = self.now
             return current
 
         if "UPDATE chat_conversation" in query and "SET active_stream_id = $3" in query:
-            conversation_id, user_id, active_stream_id, active_response_id, status = (
-                args
-            )
+            (
+                conversation_id,
+                user_id,
+                active_stream_id,
+                active_response_id,
+                active_replacement_message_id,
+                status,
+            ) = args
             current = self._owned_conversation(conversation_id, user_id)
             if current is None:
                 return None
             current["active_stream_id"] = active_stream_id
             current["active_response_id"] = active_response_id
+            current["active_replacement_message_id"] = active_replacement_message_id
             current["active_status"] = status
+            current["updated_at"] = self.now
+            return current
+
+        if (
+            "UPDATE chat_conversation" in query
+            and "active_status = 'streaming'" in query
+        ):
+            conversation_id, user_id, active_stream_id = args
+            current = self._owned_conversation(conversation_id, user_id)
+            if (
+                current is None
+                or current["active_stream_id"] != active_stream_id
+                or current["active_status"] != "pending"
+            ):
+                return None
+            current["active_status"] = "streaming"
             current["updated_at"] = self.now
             return current
 
@@ -415,6 +439,7 @@ class FakeChatDatabase:
             ):
                 row["active_stream_id"] = None
                 row["active_response_id"] = None
+                row["active_replacement_message_id"] = None
                 row["active_status"] = None
                 cleared += 1
         return cleared
@@ -447,6 +472,7 @@ class FakeChatDatabase:
         user_id: object,
         active_stream_id: object,
         active_response_id: object,
+        active_replacement_message_id: object,
         active_status: object,
         model: object,
         title: object,
@@ -457,6 +483,7 @@ class FakeChatDatabase:
             "user_id": user_id,
             "active_stream_id": active_stream_id,
             "active_response_id": active_response_id,
+            "active_replacement_message_id": active_replacement_message_id,
             "active_status": active_status,
             "model": model,
             "title": title,

--- a/api/tests/chat_persistence_fake.py
+++ b/api/tests/chat_persistence_fake.py
@@ -267,6 +267,8 @@ class FakeChatDatabase:
             return deleted
 
         if "ON CONFLICT (conversation_id, response_id)" in query:
+            if "FOR UPDATE OF conversation" not in query:
+                raise AssertionError("assistant upsert must lock stream ownership")
             (
                 conversation_id,
                 response_id,
@@ -274,7 +276,15 @@ class FakeChatDatabase:
                 content,
                 metadata_json,
                 parts_json,
+                user_id,
+                active_stream_id,
             ) = args
+            conversation = self._owned_conversation(conversation_id, user_id)
+            if (
+                conversation is None
+                or conversation["active_stream_id"] != active_stream_id
+            ):
+                return None
             for existing in self.messages.values():
                 if (
                     existing["conversation_id"] == conversation_id
@@ -301,10 +311,13 @@ class FakeChatDatabase:
             return inserted_assistant
 
         if "WITH target AS" in query and "DELETE FROM chat_message stale" in query:
+            if "FOR UPDATE OF conversation" not in query:
+                raise AssertionError("assistant replacement must lock stream ownership")
             (
                 message_id,
                 conversation_id,
                 user_id,
+                active_stream_id,
                 content,
                 response_id,
                 metadata_json,
@@ -317,6 +330,7 @@ class FakeChatDatabase:
                 target is None
                 or conversation is None
                 or conversation["user_id"] != user_id
+                or conversation["active_stream_id"] != active_stream_id
                 or target["conversation_id"] != conversation_id
                 or target["role"] != "assistant"
                 or not isinstance(retained_message_ids, list)

--- a/api/tests/test_api_endpoints.py
+++ b/api/tests/test_api_endpoints.py
@@ -1,3 +1,5 @@
+from uuid import UUID, uuid4
+
 from fastapi.testclient import TestClient
 
 from app.main import make_app
@@ -99,6 +101,60 @@ def test_chat_stream_requires_api_key(monkeypatch):
         )
 
     assert response.status_code == 401
+
+
+def test_chat_stream_echoes_a_caller_supplied_response_id(monkeypatch):
+    async def response_stream(*_args):
+        yield 'event: done\ndata: {"ok":true}\n\n'
+
+    response_id = uuid4()
+    monkeypatch.setattr("app.main.Database", HealthyDatabase)
+    monkeypatch.setattr("app.api.chat._chat_response_stream", response_stream)
+    app = make_app(
+        Settings(
+            API_KEY="test-api-key",
+            CREDENTIAL_ENCRYPTION_KEY="test-credential-key",
+            MCP_API_KEY="test-mcp-key",
+        ),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat/",
+            headers={
+                "x-api-key": "test-api-key",
+                "x-response-id": str(response_id),
+            },
+            json={"messages": [{"role": "user", "content": "hello"}]},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["x-response-id"] == str(response_id)
+
+
+def test_chat_stream_generates_a_response_id_when_header_is_absent(monkeypatch):
+    async def response_stream(*_args):
+        yield 'event: done\ndata: {"ok":true}\n\n'
+
+    monkeypatch.setattr("app.main.Database", HealthyDatabase)
+    monkeypatch.setattr("app.api.chat._chat_response_stream", response_stream)
+    app = make_app(
+        Settings(
+            API_KEY="test-api-key",
+            CREDENTIAL_ENCRYPTION_KEY="test-credential-key",
+            MCP_API_KEY="test-mcp-key",
+        ),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat/",
+            headers={"x-api-key": "test-api-key"},
+            json={"messages": [{"role": "user", "content": "hello"}]},
+        )
+
+    assert response.status_code == 200
+    assert UUID(response.headers["x-response-id"])
 
 
 def test_validation_errors_do_not_echo_raw_invalid_payload(monkeypatch):

--- a/api/tests/test_chat_persistence.py
+++ b/api/tests/test_chat_persistence.py
@@ -64,6 +64,7 @@ async def test_chat_persistence_happy_path_orders_messages_and_clears_current_st
         user_id=OWNER_ID,
         active_stream_id=response_id,
         active_response_id=response_id,
+        active_replacement_message_id=None,
         active_status=ActiveStreamStatus.STREAMING,
     )
 
@@ -126,6 +127,7 @@ async def test_chat_persistence_clear_with_stale_stream_id_keeps_newer_active_st
             user_id=OWNER_ID,
             active_stream_id=stream_id,
             active_response_id=stream_id,
+            active_replacement_message_id=None,
             active_status=ActiveStreamStatus.STREAMING,
         )
 
@@ -176,6 +178,7 @@ async def test_chat_persistence_lists_updates_owner_and_clears_stale_streams() -
         user_id=OWNER_ID,
         active_stream_id=uuid4(),
         active_response_id=uuid4(),
+        active_replacement_message_id=None,
         active_status=ActiveStreamStatus.STREAMING,
     )
     db.conversations[first.id]["updated_at"] = db.now - timedelta(hours=2)

--- a/api/tests/test_chat_state_api.py
+++ b/api/tests/test_chat_state_api.py
@@ -289,6 +289,7 @@ def test_chat_state_lifecycle_persists_messages_and_active_stream() -> None:
     assistant_message_id = uuid4()
     stream_id = uuid4()
     response_id = uuid4()
+    replacement_message_id = uuid4()
     final_parts = [
         {"state": "done", "text": "Check the rules.", "type": "reasoning"},
         {"state": "done", "text": "Final answer", "type": "text"},
@@ -318,6 +319,7 @@ def test_chat_state_lifecycle_persists_messages_and_active_stream() -> None:
             "user_id": OWNER_ID,
             "active_stream_id": str(stream_id),
             "active_response_id": str(response_id),
+            "active_replacement_message_id": str(replacement_message_id),
             "active_status": "streaming",
         },
     )
@@ -358,6 +360,9 @@ def test_chat_state_lifecycle_persists_messages_and_active_stream() -> None:
     body = loaded.json()
     assert body["conversation"]["active_stream_id"] == str(stream_id)
     assert body["conversation"]["active_response_id"] == str(response_id)
+    assert body["conversation"]["active_replacement_message_id"] == str(
+        replacement_message_id,
+    )
     assert [message["role"] for message in body["messages"]] == ["user", "assistant"]
     assert body["messages"][1]["id"] == str(assistant_message_id)
     assert body["messages"][1]["content"] == "Final answer"
@@ -776,6 +781,49 @@ def test_chat_state_clear_and_stop_are_current_stream_guarded() -> None:
     assert stopped.json()["active_stream_id"] == str(current_stream_id)
     assert cleared.status_code == 200
     assert cleared.json()["active_stream_id"] is None
+
+
+def test_chat_state_streaming_transition_is_pending_and_current_guarded() -> None:
+    # Given: a pending stream superseded by a newer pending stream.
+    db = FakeChatDatabase()
+    client = _client(db)
+    conversation_id = uuid4()
+    stale_stream_id = uuid4()
+    current_stream_id = uuid4()
+    client.post(
+        "/chat/state/conversations",
+        headers=_auth_headers(),
+        json={"id": str(conversation_id), "user_id": OWNER_ID},
+    )
+    for stream_id in (stale_stream_id, current_stream_id):
+        client.put(
+            f"/chat/state/conversations/{conversation_id}/active-stream",
+            headers=_auth_headers(),
+            json={
+                "user_id": OWNER_ID,
+                "active_stream_id": str(stream_id),
+                "active_response_id": str(stream_id),
+                "active_status": "pending",
+            },
+        )
+
+    # When: the stale stream finishes registering before the current stream.
+    stale_transition = client.post(
+        f"/chat/state/conversations/{conversation_id}/active-stream/{stale_stream_id}/streaming",
+        headers=_auth_headers(),
+        json={"user_id": OWNER_ID},
+    )
+    current_transition = client.post(
+        f"/chat/state/conversations/{conversation_id}/active-stream/{current_stream_id}/streaming",
+        headers=_auth_headers(),
+        json={"user_id": OWNER_ID},
+    )
+
+    # Then: the stale transition is rejected and the current identity is preserved.
+    assert stale_transition.status_code == 404
+    assert current_transition.status_code == 200
+    assert current_transition.json()["active_stream_id"] == str(current_stream_id)
+    assert current_transition.json()["active_status"] == "streaming"
 
 
 def test_chat_state_clear_stale_active_streams_uses_cutoff() -> None:

--- a/api/tests/test_chat_state_api.py
+++ b/api/tests/test_chat_state_api.py
@@ -327,6 +327,7 @@ def test_chat_state_lifecycle_persists_messages_and_active_stream() -> None:
         f"/chat/state/conversations/{conversation_id}/messages/assistant/{response_id}",
         headers=_auth_headers(),
         json={
+            "active_stream_id": str(stream_id),
             "id": str(assistant_message_id),
             "user_id": OWNER_ID,
             "content": "First draft",
@@ -337,6 +338,7 @@ def test_chat_state_lifecycle_persists_messages_and_active_stream() -> None:
         f"/chat/state/conversations/{conversation_id}/messages/assistant/{response_id}",
         headers=_auth_headers(),
         json={
+            "active_stream_id": str(stream_id),
             "id": str(uuid4()),
             "user_id": OWNER_ID,
             "content": "Final answer",
@@ -416,6 +418,7 @@ def test_chat_state_replaces_regenerated_assistant_and_prunes_later_messages() -
     second_user_id = uuid4()
     second_assistant_id = uuid4()
     new_response_id = uuid4()
+    stream_id = uuid4()
     client.post(
         "/chat/state/conversations",
         headers=_auth_headers(),
@@ -439,11 +442,24 @@ def test_chat_state_replaces_regenerated_assistant_and_prunes_later_messages() -
             "updated_at": db.now,
         }
 
+    client.put(
+        f"/chat/state/conversations/{conversation_id}/active-stream",
+        headers=_auth_headers(),
+        json={
+            "active_replacement_message_id": str(first_assistant_id),
+            "active_response_id": str(new_response_id),
+            "active_status": "streaming",
+            "active_stream_id": str(stream_id),
+            "user_id": OWNER_ID,
+        },
+    )
+
     # When: the first assistant answer is regenerated.
     replaced = client.put(
         f"/chat/state/conversations/{conversation_id}/messages/assistant/{first_assistant_id}/replacement/{new_response_id}",
         headers=_auth_headers(),
         json={
+            "active_stream_id": str(stream_id),
             "content": "New first answer",
             "metadata": {"responseId": str(new_response_id)},
             "parts": [
@@ -781,6 +797,136 @@ def test_chat_state_clear_and_stop_are_current_stream_guarded() -> None:
     assert stopped.json()["active_stream_id"] == str(current_stream_id)
     assert cleared.status_code == 200
     assert cleared.json()["active_stream_id"] is None
+
+
+def test_chat_state_rejects_assistant_completion_from_superseded_stream() -> None:
+    # Given: a normal response stream was superseded before it completed.
+    db = FakeChatDatabase()
+    client = _client(db)
+    conversation_id = uuid4()
+    stale_stream_id = uuid4()
+    current_stream_id = uuid4()
+    stale_message_id = uuid4()
+    current_message_id = uuid4()
+    client.post(
+        "/chat/state/conversations",
+        headers=_auth_headers(),
+        json={"id": str(conversation_id), "user_id": OWNER_ID},
+    )
+    for stream_id in (stale_stream_id, current_stream_id):
+        client.put(
+            f"/chat/state/conversations/{conversation_id}/active-stream",
+            headers=_auth_headers(),
+            json={
+                "active_response_id": str(stream_id),
+                "active_status": "streaming",
+                "active_stream_id": str(stream_id),
+                "user_id": OWNER_ID,
+            },
+        )
+
+    # When: the stale stream completes before the current stream.
+    stale_completion = client.put(
+        f"/chat/state/conversations/{conversation_id}/messages/assistant/{stale_stream_id}",
+        headers=_auth_headers(),
+        json={
+            "active_stream_id": str(stale_stream_id),
+            "content": "Stale answer",
+            "id": str(stale_message_id),
+            "user_id": OWNER_ID,
+        },
+    )
+    current_completion = client.put(
+        f"/chat/state/conversations/{conversation_id}/messages/assistant/{current_stream_id}",
+        headers=_auth_headers(),
+        json={
+            "active_stream_id": str(current_stream_id),
+            "content": "Current answer",
+            "id": str(current_message_id),
+            "user_id": OWNER_ID,
+        },
+    )
+
+    # Then: only the completion that still owns the conversation is persisted.
+    assert stale_completion.status_code == 404
+    assert current_completion.status_code == 200
+    assert stale_message_id not in db.messages
+    assert db.messages[current_message_id]["content"] == "Current answer"
+
+
+def test_chat_state_rejects_regeneration_completion_from_superseded_stream() -> None:
+    # Given: regeneration was superseded while the original answer and later turn exist.
+    db = FakeChatDatabase()
+    client = _client(db)
+    conversation_id = uuid4()
+    target_message_id = uuid4()
+    later_message_id = uuid4()
+    stale_stream_id = uuid4()
+    current_stream_id = uuid4()
+    client.post(
+        "/chat/state/conversations",
+        headers=_auth_headers(),
+        json={"id": str(conversation_id), "user_id": OWNER_ID},
+    )
+    for index, (message_id, role, content) in enumerate(
+        (
+            (target_message_id, "assistant", "Original answer"),
+            (later_message_id, "user", "Later question"),
+        ),
+    ):
+        db.messages[message_id] = {
+            "content": content,
+            "conversation_id": conversation_id,
+            "created_at": db.now + timedelta(seconds=index),
+            "id": message_id,
+            "metadata": {},
+            "response_id": None,
+            "role": role,
+            "updated_at": db.now,
+        }
+    for stream_id in (stale_stream_id, current_stream_id):
+        client.put(
+            f"/chat/state/conversations/{conversation_id}/active-stream",
+            headers=_auth_headers(),
+            json={
+                "active_replacement_message_id": str(target_message_id),
+                "active_response_id": str(stream_id),
+                "active_status": "streaming",
+                "active_stream_id": str(stream_id),
+                "user_id": OWNER_ID,
+            },
+        )
+
+    # When: the stale regeneration finishes before the current regeneration.
+    stale_completion = client.put(
+        f"/chat/state/conversations/{conversation_id}/messages/assistant/{target_message_id}/replacement/{stale_stream_id}",
+        headers=_auth_headers(),
+        json={
+            "active_stream_id": str(stale_stream_id),
+            "content": "Stale replacement",
+            "retained_message_ids": [str(target_message_id)],
+            "user_id": OWNER_ID,
+        },
+    )
+
+    # Then: it neither replaces the target nor prunes later messages.
+    assert stale_completion.status_code == 404
+    assert db.messages[target_message_id]["content"] == "Original answer"
+    assert later_message_id in db.messages
+
+    current_completion = client.put(
+        f"/chat/state/conversations/{conversation_id}/messages/assistant/{target_message_id}/replacement/{current_stream_id}",
+        headers=_auth_headers(),
+        json={
+            "active_stream_id": str(current_stream_id),
+            "content": "Current replacement",
+            "retained_message_ids": [str(target_message_id)],
+            "user_id": OWNER_ID,
+        },
+    )
+    assert current_completion.status_code == 200
+    assert db.messages[target_message_id]["content"] == "Current replacement"
+    assert later_message_id not in db.messages
 
 
 def test_chat_state_streaming_transition_is_pending_and_current_guarded() -> None:

--- a/web/app/api/chat/[id]/history/route.ts
+++ b/web/app/api/chat/[id]/history/route.ts
@@ -10,6 +10,10 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 type HistoryConversation = {
+  readonly activeStream: null | {
+    readonly id: string;
+    readonly replacementMessageId: null | string;
+  };
   readonly id: string;
   readonly model: ModelId | null;
   readonly title: null | string;
@@ -38,6 +42,13 @@ export const GET = async (
     });
     const uiMessages = await parseChatStateMessages(messages);
     const historyConversation: HistoryConversation = {
+      activeStream:
+        conversation.active_stream_id === null
+          ? null
+          : {
+              id: conversation.active_stream_id,
+              replacementMessageId: conversation.active_replacement_message_id,
+            },
       id: conversation.id,
       model: conversation.model ?? null,
       title: conversation.title ?? null,

--- a/web/app/api/chat/[id]/stream/route.ts
+++ b/web/app/api/chat/[id]/stream/route.ts
@@ -1,5 +1,6 @@
 import { UI_MESSAGE_STREAM_HEADERS } from 'ai';
 import { after } from 'next/server';
+import { setTimeout as delay } from 'node:timers/promises';
 
 import {
   AuthenticationRequiredError,
@@ -20,6 +21,27 @@ type RouteContext = {
 
 const empty = (status: number): Response => new Response(null, { status });
 
+const REGISTRATION_RETRY_DELAYS_MS = [50, 100, 250, 500, 1_000, 2_000] as const;
+
+const resumeActiveStream = async (
+  activeStatus: null | string,
+  activeStreamId: string,
+  streamContext: ReturnType<typeof createChatResumableStreamContext>,
+) => {
+  let stream = await streamContext.resumeExistingStream(activeStreamId);
+  if (stream !== undefined || activeStatus !== 'pending') {
+    return stream;
+  }
+  for (const delayMs of REGISTRATION_RETRY_DELAYS_MS) {
+    await delay(delayMs);
+    stream = await streamContext.resumeExistingStream(activeStreamId);
+    if (stream !== undefined) {
+      return stream;
+    }
+  }
+  return stream;
+};
+
 export const GET = async (
   _request: Request,
   { params }: RouteContext,
@@ -39,9 +61,18 @@ export const GET = async (
       return empty(204);
     }
 
-    const stream = await createChatResumableStreamContext({
+    const streamContext = createChatResumableStreamContext({
       waitUntil: after,
-    }).resumeExistingStream(activeStreamId);
+    });
+    const stream = await resumeActiveStream(
+      conversation.active_status,
+      activeStreamId,
+      streamContext,
+    );
+
+    if (stream === undefined && conversation.active_status === 'pending') {
+      return empty(204);
+    }
 
     if (stream === null || stream === undefined) {
       try {

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -17,6 +17,7 @@ import {
   persistedTurns,
 } from '@/lib/chat-route-state';
 import {
+  type ChatStateClient,
   type ChatStateJsonValue,
   ChatStateRequestError,
   createChatStateClient,
@@ -44,6 +45,16 @@ export const dynamic = 'force-dynamic';
 
 const SSE_CONTENT_TYPE = 'text/event-stream';
 const USER_ID_FIELD = 'user_id';
+
+type AssistantPersistence = {
+  readonly chatState: ChatStateClient;
+  readonly conversationId: string;
+  readonly meta: UiStreamMeta;
+  readonly regenerationReplacement: null | RegenerationReplacement;
+  readonly responseMessage: MyUIMessage;
+  readonly streamId: string;
+  readonly userId: string;
+};
 
 type ConversationSummary = {
   readonly id: string;
@@ -146,6 +157,55 @@ const upstreamMessagesFor = (
   regenerationReplacement === null
     ? [...trustedHistory, ...currentMessages]
     : trustedHistory;
+
+const isStalePersistenceError = (error: unknown): boolean =>
+  error instanceof ChatStateRequestError && error.status === 404;
+
+const persistAssistantMessage = async ({
+  chatState,
+  conversationId,
+  meta,
+  regenerationReplacement,
+  responseMessage,
+  streamId,
+  userId,
+}: AssistantPersistence): Promise<void> => {
+  const content = joinText(responseMessage).trim();
+  if (content.length === 0) {
+    return;
+  }
+  const { metadata, parts } = assistantState(responseMessage, meta);
+
+  try {
+    if (regenerationReplacement === null) {
+      await chatState.upsertAssistantMessage({
+        content,
+        conversationId,
+        metadata,
+        parts,
+        responseId: streamId,
+        streamId,
+        userId,
+      });
+      return;
+    }
+    await chatState.replaceAssistantMessage({
+      content,
+      conversationId,
+      messageId: regenerationReplacement.messageId,
+      metadata,
+      parts,
+      responseId: streamId,
+      retainedMessageIds: regenerationReplacement.retainedMessageIds,
+      streamId,
+      userId,
+    });
+  } catch (error) {
+    if (!isStalePersistenceError(error)) {
+      throw error;
+    }
+  }
+};
 
 export const GET = async (): Promise<Response> => {
   const chatState = createChatStateClient();
@@ -298,16 +358,17 @@ export const POST = async (req: Request): Promise<Response> => {
       return errorResponse({ inferenceModel }, 'pre_stream', message);
     }
 
-    const responseId = upstream.headers.get('X-Response-Id') ?? undefined;
+    const upstreamResponseId = upstream.headers.get('X-Response-Id');
 
-    if (responseId !== streamId) {
+    if (upstreamResponseId !== null && upstreamResponseId !== streamId) {
       await cleanupPendingStream();
       return errorResponse(
-        { inferenceModel, responseId },
+        { inferenceModel, responseId: upstreamResponseId },
         'agent_error',
         'Request failed',
       );
     }
+    const responseId = streamId;
 
     const upstreamBody = upstream.body;
 
@@ -334,32 +395,15 @@ export const POST = async (req: Request): Promise<Response> => {
       },
       onEnd: async ({ responseMessage }) => {
         try {
-          const content = joinText(responseMessage).trim();
-
-          if (content.length > 0) {
-            const { metadata, parts } = assistantState(responseMessage, meta);
-            if (regenerationReplacement === null) {
-              await chatState.upsertAssistantMessage({
-                content,
-                conversationId,
-                metadata,
-                parts,
-                responseId: streamId,
-                userId,
-              });
-            } else {
-              await chatState.replaceAssistantMessage({
-                content,
-                conversationId,
-                messageId: regenerationReplacement.messageId,
-                metadata,
-                parts,
-                responseId: streamId,
-                retainedMessageIds: regenerationReplacement.retainedMessageIds,
-                userId,
-              });
-            }
-          }
+          await persistAssistantMessage({
+            chatState,
+            conversationId,
+            meta,
+            regenerationReplacement,
+            responseMessage,
+            streamId,
+            userId,
+          });
 
           await clearChatActiveStream({
             chatState,

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -22,19 +22,21 @@ import {
   createChatStateClient,
 } from '@/lib/chat-state-client';
 import {
+  clearChatActiveStream,
+  finishChatStream,
+  registerPendingChatStream,
+  startResumableChatStream,
+} from '@/lib/chat-stream-lifecycle';
+import {
   type ChatClientBody,
   currentUserMessageForRequest,
   toChatRequestBody,
   translateToUiStream,
   type UiStreamMeta,
 } from '@/lib/chat-translate';
-import { API_BASE_URL, CHAT_API_KEY } from '@/lib/env';
+import { requestUpstreamChatStream } from '@/lib/chat-upstream';
 import { joinText } from '@/lib/message-parts';
-import {
-  activeChatProducers,
-  createChatResumableStreamContext,
-  normalizePythonResponseStreamId,
-} from '@/lib/resumable-stream-context';
+import { activeChatProducers } from '@/lib/resumable-stream-context';
 import { parseProtocolV2 } from '@/lib/sse';
 
 export const runtime = 'nodejs';
@@ -92,18 +94,6 @@ const conversationSummary = (conversation: {
 
 const requiredText = (value: string | undefined): null | string =>
   value === undefined || value.length === 0 ? null : value;
-
-const ignoreMissing = async (operation: Promise<void>): Promise<void> => {
-  try {
-    await operation;
-  } catch (error) {
-    if (error instanceof ChatStateRequestError && error.status === 404) {
-      return;
-    }
-
-    throw error;
-  }
-};
 
 const regeneratedMessageId = (body: ResumableChatClientBody): null | string =>
   body.trigger === 'regenerate-message' &&
@@ -263,44 +253,66 @@ export const POST = async (req: Request): Promise<Response> => {
       userId,
     });
     const upstreamController = new AbortController();
+    const streamId = crypto.randomUUID();
+
+    await registerPendingChatStream({
+      chatState,
+      conversationId,
+      replacementMessageId: regenerationReplacement?.messageId ?? null,
+      streamId,
+      upstreamController,
+      userId,
+    });
+    const cleanupPendingStream = async (): Promise<void> => {
+      upstreamController.abort();
+      await finishChatStream({ chatState, conversationId, streamId, userId });
+    };
 
     const upstreamPayload = {
       ...chatBody,
       messages: upstreamMessages,
       [USER_ID_FIELD]: userId,
     } satisfies ChatRequestBody & { user_id: string };
-    const upstream = await fetch(`${API_BASE_URL}/chat/`, {
-      body: JSON.stringify(upstreamPayload),
-      headers: {
-        'content-type': 'application/json',
-        'x-api-key': CHAT_API_KEY,
-        'X-Distinct-Id':
-          typeof clientBody.posthogDistinctId === 'string' &&
-          clientBody.posthogDistinctId.length > 0
-            ? clientBody.posthogDistinctId
-            : userId,
-        ...(typeof clientBody.posthogSessionId === 'string' &&
-          clientBody.posthogSessionId.length > 0 && {
-            'X-PostHog-Session-Id': clientBody.posthogSessionId,
-          }),
-      },
-      method: 'POST',
-      signal: upstreamController.signal,
-    });
+    let upstream: Response;
+    try {
+      upstream = await requestUpstreamChatStream({
+        payload: upstreamPayload,
+        posthogDistinctId: clientBody.posthogDistinctId,
+        posthogSessionId: clientBody.posthogSessionId,
+        signal: upstreamController.signal,
+        streamId,
+        userId,
+      });
+    } catch (error) {
+      await cleanupPendingStream();
+      throw error;
+    }
 
     const contentType = upstream.headers.get('content-type') ?? '';
 
     if (!upstream.ok || !contentType.includes(SSE_CONTENT_TYPE)) {
       const message = readDetail();
 
+      await cleanupPendingStream();
+
       return errorResponse({ inferenceModel }, 'pre_stream', message);
     }
 
     const responseId = upstream.headers.get('X-Response-Id') ?? undefined;
-    const streamId = normalizePythonResponseStreamId(responseId);
+
+    if (responseId !== streamId) {
+      await cleanupPendingStream();
+      return errorResponse(
+        { inferenceModel, responseId },
+        'agent_error',
+        'Request failed',
+      );
+    }
+
     const upstreamBody = upstream.body;
 
     if (upstreamBody === null) {
+      await cleanupPendingStream();
       return errorResponse(
         { inferenceModel, responseId },
         'agent_error',
@@ -308,22 +320,13 @@ export const POST = async (req: Request): Promise<Response> => {
       );
     }
 
-    activeChatProducers.register(streamId, upstreamController);
-
-    try {
-      await chatState.setActiveStream({
-        activeResponseId: streamId,
-        activeStreamId: streamId,
-        conversationId,
-        userId,
-      });
-    } catch (error) {
-      upstreamController.abort();
-      activeChatProducers.unregister(streamId);
-      throw error;
-    }
-
-    const meta = { inferenceModel, responseId: streamId };
+    const meta = {
+      inferenceModel,
+      ...(regenerationReplacement !== null && {
+        replacementMessageId: regenerationReplacement.messageId,
+      }),
+      responseId: streamId,
+    };
 
     const stream = createUIMessageStream<MyUIMessage>({
       execute: async ({ writer }) => {
@@ -358,13 +361,12 @@ export const POST = async (req: Request): Promise<Response> => {
             }
           }
 
-          await ignoreMissing(
-            chatState.clearActiveStreamIfCurrent({
-              conversationId,
-              streamId,
-              userId,
-            }),
-          );
+          await clearChatActiveStream({
+            chatState,
+            conversationId,
+            streamId,
+            userId,
+          });
         } finally {
           activeChatProducers.unregister(streamId);
         }
@@ -375,24 +377,15 @@ export const POST = async (req: Request): Promise<Response> => {
 
     return createUIMessageStreamResponse({
       consumeSseStream: async ({ stream: sseStream }) => {
-        try {
-          await createChatResumableStreamContext({
-            waitUntil: after,
-          }).createNewResumableStream(streamId, () => sseStream);
-        } catch {
-          upstreamController.abort();
-          try {
-            await ignoreMissing(
-              chatState.clearActiveStreamIfCurrent({
-                conversationId,
-                streamId,
-                userId,
-              }),
-            );
-          } finally {
-            activeChatProducers.unregister(streamId);
-          }
-        }
+        await startResumableChatStream({
+          chatState,
+          conversationId,
+          sseStream,
+          streamId,
+          upstreamController,
+          userId,
+          waitUntil: after,
+        });
       },
       stream,
     });

--- a/web/e2e/chat.spec.ts
+++ b/web/e2e/chat.spec.ts
@@ -253,6 +253,7 @@ test.describe('chat streaming (mocked BFF)', () => {
     const conversationId = 'sponsored-preserved-conversation';
     const history = {
       conversation: {
+        activeStream: null,
         id: conversationId,
         model: SPONSORED_MODEL,
         title: 'Постоечки разговор',

--- a/web/e2e/helpers/sse.ts
+++ b/web/e2e/helpers/sse.ts
@@ -28,6 +28,15 @@ export type UiChunk =
   | { id: string; type: 'text-end' }
   | { id: string; type: 'text-start' }
   | {
+      messageId?: string;
+      messageMetadata?: {
+        inferenceModel?: string;
+        replacementMessageId?: string;
+        responseId?: string;
+      };
+      type: 'start';
+    }
+  | {
       messageMetadata: {
         diagnostics: {
           cost?: { inputUsd: number; outputUsd: number; totalUsd: number };
@@ -40,10 +49,6 @@ export type UiChunk =
         responseId?: string;
       };
       type: 'message-metadata';
-    }
-  | {
-      messageMetadata?: { inferenceModel?: string; responseId?: string };
-      type: 'start';
     }
   | { type: 'finish' };
 

--- a/web/e2e/reasoning.spec.ts
+++ b/web/e2e/reasoning.spec.ts
@@ -176,6 +176,7 @@ test.describe('reasoning streaming (mocked BFF)', () => {
       histories: {
         [firstId]: {
           conversation: {
+            activeStream: null,
             id: firstId,
             model: INFERENCE_MODEL,
             title: 'Reasoning history',
@@ -203,6 +204,7 @@ test.describe('reasoning streaming (mocked BFF)', () => {
         },
         [secondId]: {
           conversation: {
+            activeStream: null,
             id: secondId,
             model: INFERENCE_MODEL,
             title: 'Other history',

--- a/web/e2e/regeneration-refresh.spec.ts
+++ b/web/e2e/regeneration-refresh.spec.ts
@@ -1,0 +1,156 @@
+import { expect, test } from '@playwright/test';
+
+import type { MyUIMessage } from '@/lib/api-types';
+import type { ChatConversationHistory } from '@/lib/conversation-types';
+
+import { installMockChatState } from './helpers/chat-state';
+import { mockModels } from './helpers/models';
+import { startChatStreamServer, type UiChunk } from './helpers/sse';
+
+const CONVERSATION_ID = '11111111-2222-4333-8444-555555555555';
+const RESPONSE_ID = '22222222-3333-4444-8555-666666666666';
+const MODEL = 'claude-sonnet-5';
+const TARGET_MESSAGE_ID = 'assistant-first';
+const OLD_ANSWER = 'Стар прв одговор';
+const NEW_ANSWER = 'Регенериран прв одговор';
+const TRAILING_ANSWER = 'Стар втор одговор';
+
+const userMessage = (id: string, text: string): MyUIMessage => ({
+  id,
+  metadata: {},
+  parts: [{ text, type: 'text' }],
+  role: 'user',
+});
+
+const assistantMessage = (
+  id: string,
+  responseId: string,
+  text: string,
+): MyUIMessage => ({
+  id,
+  metadata: { inferenceModel: MODEL, responseId },
+  parts: [{ text, type: 'text' }],
+  role: 'assistant',
+});
+
+const regenerationChunks = (answer: string): UiChunk[] => [
+  {
+    messageId: TARGET_MESSAGE_ID,
+    messageMetadata: {
+      inferenceModel: MODEL,
+      replacementMessageId: TARGET_MESSAGE_ID,
+      responseId: RESPONSE_ID,
+    },
+    type: 'start',
+  },
+  { id: 'txt-answer', type: 'text-start' },
+  { delta: answer, id: 'txt-answer', type: 'text-delta' },
+  { id: 'txt-answer', type: 'text-end' },
+  { type: 'finish' },
+];
+
+test('refresh during regeneration replaces the target without restoring later turns', async ({
+  page,
+}) => {
+  await page.route('**/api/health', async (route) => {
+    await route.fulfill({
+      body: '{}',
+      contentType: 'application/json',
+      status: 200,
+    });
+  });
+  await mockModels(page);
+  const history: ChatConversationHistory = {
+    conversation: {
+      activeStream: null,
+      id: CONVERSATION_ID,
+      model: MODEL,
+      title: 'Повеќе пораки',
+    },
+    messages: [
+      userMessage('user-first', 'Прво прашање'),
+      assistantMessage(TARGET_MESSAGE_ID, 'response-old-first', OLD_ANSWER),
+      userMessage('user-second', 'Второ прашање'),
+      assistantMessage(
+        'assistant-second',
+        'response-old-second',
+        TRAILING_ANSWER,
+      ),
+    ],
+  };
+  const firstLegServer = await startChatStreamServer({
+    gapMs: 30_000,
+    head: regenerationChunks(NEW_ANSWER).slice(0, 3),
+    tail: [],
+  });
+
+  try {
+    let regenerationStarted = false;
+    await installMockChatState(page, {
+      conversations: [
+        { id: CONVERSATION_ID, model: MODEL, title: 'Повеќе пораки' },
+      ],
+      histories: { [CONVERSATION_ID]: history },
+      onCreate: () => {
+        regenerationStarted = true;
+      },
+      streamUrl: firstLegServer.url,
+    });
+    await page.route('**/api/chat/*/history', async (route) => {
+      await route.fulfill({
+        body: JSON.stringify({
+          ...history,
+          conversation: {
+            ...history.conversation,
+            activeStream: regenerationStarted
+              ? {
+                  id: RESPONSE_ID,
+                  replacementMessageId: TARGET_MESSAGE_ID,
+                }
+              : null,
+          },
+        }),
+        contentType: 'application/json',
+        status: 200,
+      });
+    });
+    let resumeRequests = 0;
+    await page.route('**/api/chat/*/stream', async (route) => {
+      resumeRequests += 1;
+      if (!regenerationStarted) {
+        await route.fulfill({ status: 204 });
+        return;
+      }
+      const body = regenerationChunks(NEW_ANSWER)
+        .map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`)
+        .join('');
+      await route.fulfill({
+        body: `${body}data: [DONE]\n\n`,
+        contentType: 'text/event-stream',
+        headers: { 'x-vercel-ai-ui-message-stream': 'v1' },
+        status: 200,
+      });
+    });
+
+    await page.goto('/');
+    await page
+      .getByRole('button', { exact: true, name: 'Повеќе пораки' })
+      .click();
+    await expect(page.getByText(OLD_ANSWER)).toBeVisible();
+    const regenerationRequest = page.waitForRequest(
+      (request) =>
+        request.url().endsWith('/api/chat') && request.method() === 'POST',
+    );
+    await page.getByRole('button', { name: 'Регенерирај' }).first().click();
+    await regenerationRequest;
+
+    await page.reload();
+
+    await expect(page.getByText(NEW_ANSWER)).toBeVisible();
+    await expect(page.getByText(OLD_ANSWER)).toHaveCount(0);
+    await expect(page.getByText(TRAILING_ANSWER)).toHaveCount(0);
+    expect(resumeRequests).toBeGreaterThan(0);
+  } finally {
+    await firstLegServer.close();
+  }
+});

--- a/web/lib/api-types.ts
+++ b/web/lib/api-types.ts
@@ -185,6 +185,7 @@ export type MyMetadata = {
   error?: ErrorNotice;
   feedback?: FeedbackType;
   inferenceModel?: string;
+  replacementMessageId?: string;
   responseId?: string;
   sources?: readonly RetrievedSource[];
   timing?: { totalMs: number; ttftMs: null | number };

--- a/web/lib/chat-state-client.ts
+++ b/web/lib/chat-state-client.ts
@@ -26,6 +26,9 @@ export type ChatStateClient = {
   readonly loadConversation: (
     input: LoadConversationInput,
   ) => Promise<ChatStateConversationWithMessages>;
+  readonly markActiveStreamStreamingIfPending: (
+    input: ClearActiveStreamInput,
+  ) => Promise<void>;
   readonly replaceAssistantMessage: (
     input: ReplaceAssistantMessageInput,
   ) => Promise<void>;
@@ -50,6 +53,7 @@ export type ChatStateClient = {
 };
 
 export type ChatStateConversation = {
+  readonly active_replacement_message_id: null | string;
   readonly active_response_id: null | string;
   readonly active_status: null | string;
   readonly active_stream_id: null | string;
@@ -122,8 +126,10 @@ type ReplaceAssistantMessageInput = {
 
 type SetActiveStreamInput = {
   readonly activeResponseId: string;
+  readonly activeStatus: 'pending' | 'streaming';
   readonly activeStreamId: string;
   readonly conversationId: string;
+  readonly replacementMessageId: null | string;
   readonly userId: string;
 };
 
@@ -279,6 +285,19 @@ export const createChatStateClient = (): ChatStateClient => ({
     readStateJson<ChatStateConversationWithMessages>(
       `/conversations/${conversationId}?user_id=${encodeURIComponent(userId)}`,
     ),
+  markActiveStreamStreamingIfPending: async ({
+    conversationId,
+    streamId,
+    userId,
+  }) => {
+    await sendStateRequest(
+      `/conversations/${conversationId}/active-stream/${streamId}/streaming`,
+      {
+        body: JSON.stringify({ user_id: userId }),
+        method: 'POST',
+      },
+    );
+  },
   replaceAssistantMessage: async ({
     content,
     conversationId,
@@ -305,14 +324,17 @@ export const createChatStateClient = (): ChatStateClient => ({
   },
   setActiveStream: async ({
     activeResponseId,
+    activeStatus,
     activeStreamId,
     conversationId,
+    replacementMessageId,
     userId,
   }) => {
     await sendStateRequest(`/conversations/${conversationId}/active-stream`, {
       body: JSON.stringify({
+        active_replacement_message_id: replacementMessageId,
         active_response_id: activeResponseId,
-        active_status: 'streaming',
+        active_status: activeStatus,
         active_stream_id: activeStreamId,
         user_id: userId,
       }),

--- a/web/lib/chat-state-client.ts
+++ b/web/lib/chat-state-client.ts
@@ -121,6 +121,7 @@ type ReplaceAssistantMessageInput = {
   readonly parts: readonly ChatStateJsonValue[];
   readonly responseId: string;
   readonly retainedMessageIds: readonly string[];
+  readonly streamId: string;
   readonly userId: string;
 };
 
@@ -146,6 +147,7 @@ type UpsertAssistantMessageInput = {
   readonly metadata: ChatStateMetadata;
   readonly parts: readonly ChatStateJsonValue[];
   readonly responseId: string;
+  readonly streamId: string;
   readonly userId: string;
 };
 
@@ -306,12 +308,14 @@ export const createChatStateClient = (): ChatStateClient => ({
     parts,
     responseId,
     retainedMessageIds,
+    streamId,
     userId,
   }) => {
     await sendStateRequest(
       `/conversations/${conversationId}/messages/assistant/${messageId}/replacement/${responseId}`,
       {
         body: JSON.stringify({
+          active_stream_id: streamId,
           content,
           metadata,
           parts,
@@ -366,12 +370,14 @@ export const createChatStateClient = (): ChatStateClient => ({
     metadata,
     parts,
     responseId,
+    streamId,
     userId,
   }) => {
     await sendStateRequest(
       `/conversations/${conversationId}/messages/assistant/${responseId}`,
       {
         body: JSON.stringify({
+          active_stream_id: streamId,
           content,
           id: crypto.randomUUID(),
           metadata,

--- a/web/lib/chat-stream-lifecycle.ts
+++ b/web/lib/chat-stream-lifecycle.ts
@@ -1,0 +1,115 @@
+import 'server-only';
+
+import {
+  type ChatStateClient,
+  ChatStateRequestError,
+} from '@/lib/chat-state-client';
+import {
+  activeChatProducers,
+  createChatResumableStreamContext,
+  type WaitUntil,
+} from '@/lib/resumable-stream-context';
+
+type ActiveStreamIdentity = {
+  readonly chatState: ChatStateClient;
+  readonly conversationId: string;
+  readonly streamId: string;
+  readonly userId: string;
+};
+
+type PendingStreamRegistration = ActiveStreamIdentity & {
+  readonly replacementMessageId: null | string;
+  readonly upstreamController: AbortController;
+};
+
+type ResumableStreamStart = ActiveStreamIdentity & {
+  readonly sseStream: ReadableStream<string>;
+  readonly upstreamController: AbortController;
+  readonly waitUntil: WaitUntil;
+};
+
+export const clearChatActiveStream = async ({
+  chatState,
+  conversationId,
+  streamId,
+  userId,
+}: ActiveStreamIdentity): Promise<void> => {
+  try {
+    await chatState.clearActiveStreamIfCurrent({
+      conversationId,
+      streamId,
+      userId,
+    });
+  } catch (error) {
+    if (error instanceof ChatStateRequestError && error.status === 404) {
+      return;
+    }
+    throw error;
+  }
+};
+
+export const finishChatStream = async (
+  identity: ActiveStreamIdentity,
+): Promise<void> => {
+  try {
+    await clearChatActiveStream(identity);
+  } finally {
+    activeChatProducers.unregister(identity.streamId);
+  }
+};
+
+export const registerPendingChatStream = async ({
+  chatState,
+  conversationId,
+  replacementMessageId,
+  streamId,
+  upstreamController,
+  userId,
+}: PendingStreamRegistration): Promise<void> => {
+  activeChatProducers.register(streamId, upstreamController);
+  try {
+    await chatState.setActiveStream({
+      activeResponseId: streamId,
+      activeStatus: 'pending',
+      activeStreamId: streamId,
+      conversationId,
+      replacementMessageId,
+      userId,
+    });
+  } catch (error) {
+    upstreamController.abort();
+    activeChatProducers.unregister(streamId);
+    throw error;
+  }
+};
+
+export const startResumableChatStream = async ({
+  chatState,
+  conversationId,
+  sseStream,
+  streamId,
+  upstreamController,
+  userId,
+  waitUntil,
+}: ResumableStreamStart): Promise<void> => {
+  try {
+    await createChatResumableStreamContext({
+      waitUntil,
+    }).createNewResumableStream(streamId, () => sseStream);
+    try {
+      await chatState.markActiveStreamStreamingIfPending({
+        conversationId,
+        streamId,
+        userId,
+      });
+    } catch (error) {
+      if (error instanceof ChatStateRequestError && error.status === 404) {
+        return;
+      }
+      throw error;
+    }
+  } catch {
+    upstreamController.abort();
+    await finishChatStream({ chatState, conversationId, streamId, userId });
+  }
+};

--- a/web/lib/chat-translate.ts
+++ b/web/lib/chat-translate.ts
@@ -27,7 +27,11 @@ export type ChatClientBody = {
   trigger?: string;
 };
 
-export type UiStreamMeta = { inferenceModel?: string; responseId?: string };
+export type UiStreamMeta = {
+  inferenceModel?: string;
+  replacementMessageId?: string;
+  responseId?: string;
+};
 
 export type UiStreamPart =
   | {
@@ -51,7 +55,7 @@ export type UiStreamPart =
   | { id: string; type: 'reasoning-start' }
   | { id: string; type: 'text-end' }
   | { id: string; type: 'text-start' }
-  | { messageMetadata: UiStreamMeta; type: 'start' }
+  | { messageId?: string; messageMetadata: UiStreamMeta; type: 'start' }
   | {
       messageMetadata: {
         diagnostics?: MessageDiagnostics;
@@ -174,7 +178,13 @@ export const translateToUiStream = async (
   idGen: () => string = () => crypto.randomUUID(),
 ): Promise<void> => {
   /* eslint-enable @typescript-eslint/max-params -- re-enable once past the declaration */
-  writer.write({ messageMetadata: meta, type: 'start' });
+  writer.write({
+    ...(meta.replacementMessageId !== undefined && {
+      messageId: meta.replacementMessageId,
+    }),
+    messageMetadata: meta,
+    type: 'start',
+  });
 
   const textPart = createStreamPart(writer, idGen, 'text');
   const reasoningPart = createStreamPart(writer, idGen, 'reasoning');

--- a/web/lib/chat-upstream.ts
+++ b/web/lib/chat-upstream.ts
@@ -1,0 +1,41 @@
+import 'server-only';
+
+import type { ChatRequestBody } from '@/lib/api-types';
+
+import { API_BASE_URL, CHAT_API_KEY } from '@/lib/env';
+
+type UpstreamChatRequest = {
+  readonly payload: ChatRequestBody & { readonly user_id: string };
+  readonly posthogDistinctId: string | undefined;
+  readonly posthogSessionId: string | undefined;
+  readonly signal: AbortSignal;
+  readonly streamId: string;
+  readonly userId: string;
+};
+
+export const requestUpstreamChatStream = async ({
+  payload,
+  posthogDistinctId,
+  posthogSessionId,
+  signal,
+  streamId,
+  userId,
+}: UpstreamChatRequest): Promise<Response> =>
+  fetch(`${API_BASE_URL}/chat/`, {
+    body: JSON.stringify(payload),
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': CHAT_API_KEY,
+      'X-Distinct-Id':
+        posthogDistinctId !== undefined && posthogDistinctId.length > 0
+          ? posthogDistinctId
+          : userId,
+      ...(posthogSessionId !== undefined &&
+        posthogSessionId.length > 0 && {
+          'X-PostHog-Session-Id': posthogSessionId,
+        }),
+      'X-Response-Id': streamId,
+    },
+    method: 'POST',
+    signal,
+  });

--- a/web/lib/conversation-message-state.ts
+++ b/web/lib/conversation-message-state.ts
@@ -1,9 +1,16 @@
 import type { FeedbackSelection, MyUIMessage } from '@/lib/api-types';
+import type { ActiveConversationStream } from '@/lib/conversation-types';
 
 type FinishedReplacement = {
   readonly pruneAfterReplacement: boolean;
   readonly replacement: MyUIMessage;
   readonly streamMessageId: string;
+};
+
+type HydrationReconciliation = {
+  readonly activeStream: ActiveConversationStream | null;
+  readonly current: readonly MyUIMessage[];
+  readonly persisted: readonly MyUIMessage[];
 };
 
 export const finalizeMessage = (
@@ -84,21 +91,6 @@ export const replaceFinishedMessage =
     });
   };
 
-export const applyFeedback =
-  (messageId: string, feedback: FeedbackSelection) =>
-  (messages: MyUIMessage[]): MyUIMessage[] =>
-    messages.map((message) => {
-      if (message.id !== messageId) {
-        return message;
-      }
-      if (feedback !== null) {
-        return { ...message, metadata: { ...message.metadata, feedback } };
-      }
-      const metadata = { ...message.metadata };
-      Reflect.deleteProperty(metadata, 'feedback');
-      return { ...message, metadata };
-    });
-
 export const previewRegeneration = (
   messages: MyUIMessage[],
   messageId: null | string,
@@ -123,3 +115,48 @@ export const previewRegeneration = (
     { ...target, metadata: {}, parts: [] },
   ];
 };
+
+export const reconcileHydratedMessages = ({
+  activeStream,
+  current,
+  persisted,
+}: HydrationReconciliation): MyUIMessage[] => {
+  if (activeStream === null) {
+    return [...persisted];
+  }
+  const resumedAssistant = current.find(
+    (message) =>
+      message.role === 'assistant' &&
+      message.metadata?.responseId === activeStream.id,
+  );
+  if (resumedAssistant === undefined) {
+    return previewRegeneration(
+      [...persisted],
+      activeStream.replacementMessageId,
+    );
+  }
+  const replacement =
+    activeStream.replacementMessageId === null
+      ? resumedAssistant
+      : { ...resumedAssistant, id: activeStream.replacementMessageId };
+  return replaceFinishedMessage({
+    pruneAfterReplacement: activeStream.replacementMessageId !== null,
+    replacement,
+    streamMessageId: resumedAssistant.id,
+  })([...persisted]);
+};
+
+export const applyFeedback =
+  (messageId: string, feedback: FeedbackSelection) =>
+  (messages: MyUIMessage[]): MyUIMessage[] =>
+    messages.map((message) => {
+      if (message.id !== messageId) {
+        return message;
+      }
+      if (feedback !== null) {
+        return { ...message, metadata: { ...message.metadata, feedback } };
+      }
+      const metadata = { ...message.metadata };
+      Reflect.deleteProperty(metadata, 'feedback');
+      return { ...message, metadata };
+    });

--- a/web/lib/conversation-types.ts
+++ b/web/lib/conversation-types.ts
@@ -1,7 +1,14 @@
 import type { MyUIMessage } from '@/lib/api-types';
 
+export type ActiveConversationStream = {
+  readonly id: string;
+  readonly replacementMessageId: null | string;
+};
+
 export type ChatConversationHistory = {
-  readonly conversation: ConversationRow;
+  readonly conversation: ConversationRow & {
+    readonly activeStream: ActiveConversationStream | null;
+  };
   readonly messages: readonly MyUIMessage[];
 };
 

--- a/web/lib/transport.ts
+++ b/web/lib/transport.ts
@@ -170,13 +170,15 @@ const parseActiveStream = (value: unknown): ActiveConversationStream | null => {
     return null;
   }
   const { id, replacementMessageId } = value;
+  const normalizedReplacementMessageId = replacementMessageId ?? null;
   if (
     typeof id !== 'string' ||
-    (replacementMessageId !== null && typeof replacementMessageId !== 'string')
+    (normalizedReplacementMessageId !== null &&
+      typeof normalizedReplacementMessageId !== 'string')
   ) {
     return null;
   }
-  return { id, replacementMessageId };
+  return { id, replacementMessageId: normalizedReplacementMessageId };
 };
 
 export const listChatConversations = async (): Promise<ConversationRow[]> => {

--- a/web/lib/transport.ts
+++ b/web/lib/transport.ts
@@ -3,6 +3,7 @@ import { posthog } from 'posthog-js';
 
 import type { ModelId, MyUIMessage, QueryTransformMode } from '@/lib/api-types';
 import type {
+  ActiveConversationStream,
   ChatConversationHistory,
   ConversationRow,
 } from '@/lib/conversation-types';
@@ -161,6 +162,23 @@ const isUiMessage = (value: unknown): value is MyUIMessage => {
   );
 };
 
+const parseActiveStream = (value: unknown): ActiveConversationStream | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (!isRecord(value)) {
+    return null;
+  }
+  const { id, replacementMessageId } = value;
+  if (
+    typeof id !== 'string' ||
+    (replacementMessageId !== null && typeof replacementMessageId !== 'string')
+  ) {
+    return null;
+  }
+  return { id, replacementMessageId };
+};
+
 export const listChatConversations = async (): Promise<ConversationRow[]> => {
   const response = await fetch('/api/chat', { method: 'GET' });
 
@@ -211,7 +229,7 @@ const parseConversationHistory = (
     return null;
   }
   const conversationRecord = conversation as Record<string, unknown>;
-  const { id, model, title } = conversationRecord;
+  const { activeStream, id, model, title } = conversationRecord;
   if (
     typeof id !== 'string' ||
     (model !== null && typeof model !== 'string') ||
@@ -222,7 +240,12 @@ const parseConversationHistory = (
     return null;
   }
   return {
-    conversation: { id, model, title: title ?? 'New conversation' },
+    conversation: {
+      activeStream: parseActiveStream(activeStream),
+      id,
+      model,
+      title: title ?? 'New conversation',
+    },
     messages,
   };
 };

--- a/web/lib/use-conversation-chat-runtime.ts
+++ b/web/lib/use-conversation-chat-runtime.ts
@@ -108,7 +108,10 @@ export const useConversationChatRuntime = ({
         }
         const finishedConversationId = activeId;
         setActiveStatus(undefined);
-        const replacementId = regeneratingMessageIdRef.current;
+        const replacementId =
+          regeneratingMessageIdRef.current ??
+          message.metadata?.replacementMessageId ??
+          null;
         const error = activeErrorRef.current;
         activeErrorRef.current = undefined;
         if (isAbort || isError) {
@@ -120,6 +123,9 @@ export const useConversationChatRuntime = ({
           return;
         }
         if (replacementId !== null && message.id === replacementId) {
+          regeneratingMessageIdRef.current = null;
+          setRegeneratingMessageId(null);
+          fireAndForget(refreshConversations());
           return;
         }
         regeneratingMessageIdRef.current = null;

--- a/web/lib/use-conversation-chat-runtime.ts
+++ b/web/lib/use-conversation-chat-runtime.ts
@@ -122,12 +122,6 @@ export const useConversationChatRuntime = ({
         if (finishedConversationId === null) {
           return;
         }
-        if (replacementId !== null && message.id === replacementId) {
-          regeneratingMessageIdRef.current = null;
-          setRegeneratingMessageId(null);
-          fireAndForget(refreshConversations());
-          return;
-        }
         regeneratingMessageIdRef.current = null;
         setRegeneratingMessageId(null);
         const finalizedBase = finalizeMessage(

--- a/web/lib/use-conversation-hydration.ts
+++ b/web/lib/use-conversation-hydration.ts
@@ -11,6 +11,7 @@ import {
 import type { ErrorNotice, MyUIMessage } from '@/lib/api-types';
 
 import { fireAndForget } from '@/lib/async';
+import { reconcileHydratedMessages } from '@/lib/conversation-message-state';
 import { t } from '@/lib/i18n';
 import {
   ChatConversationRequestError,
@@ -72,13 +73,20 @@ export const useConversationHydration = ({
         const serverHistory = await loadChatConversationHistory(id);
         if (serverHistory !== null) {
           if (!isCancelled()) {
-            setMessages((current) =>
-              serverHistory.messages.length === 0 &&
-              current.length > 0 &&
-              hasLocalConversationState(id)
-                ? current
-                : [...serverHistory.messages],
-            );
+            setMessages((current) => {
+              if (
+                serverHistory.messages.length === 0 &&
+                current.length > 0 &&
+                hasLocalConversationState(id)
+              ) {
+                return current;
+              }
+              return reconcileHydratedMessages({
+                activeStream: serverHistory.conversation.activeStream,
+                current,
+                persisted: serverHistory.messages,
+              });
+            });
             clearPreserveMarker(id);
             clearActiveStreamMarker(id);
           }

--- a/web/test/api-chat-boundaries.route.test.ts
+++ b/web/test/api-chat-boundaries.route.test.ts
@@ -24,6 +24,7 @@ const okStreamResponse = (): Response =>
   });
 
 const ACTIVE_RESPONSE_ID = 'active_response_id' as const;
+const ACTIVE_REPLACEMENT_MESSAGE_ID = 'active_replacement_message_id' as const;
 const ACTIVE_STATUS = 'active_status' as const;
 const ACTIVE_STREAM_ID = 'active_stream_id' as const;
 const RESPONSE_ID_FIELD = 'response_id' as const;
@@ -39,6 +40,7 @@ const loadedConversation = (
   messages: LoadedConversation['messages'],
 ): LoadedConversation => ({
   conversation: {
+    [ACTIVE_REPLACEMENT_MESSAGE_ID]: null,
     [ACTIVE_RESPONSE_ID]: RESPONSE_ID,
     [ACTIVE_STATUS]: 'streaming',
     [ACTIVE_STREAM_ID]: RESPONSE_ID,

--- a/web/test/api-chat-route-support.ts
+++ b/web/test/api-chat-route-support.ts
@@ -17,6 +17,7 @@ export const OTHER_USER_ID = 'anon-user-2';
 
 export type LoadedConversation = {
   readonly conversation: {
+    readonly active_replacement_message_id: null | string;
     readonly active_response_id: null | string;
     readonly active_status: null | string;
     readonly active_stream_id: null | string;
@@ -137,6 +138,7 @@ export const routeMocks = {
     deleteConversation: vi.fn(async (_input: StateClientInput) => {}),
     listConversations: vi.fn(async (_input: { readonly userId: string }) => [
       {
+        active_replacement_message_id: null,
         active_response_id: null,
         active_status: null,
         active_stream_id: null,
@@ -149,6 +151,7 @@ export const routeMocks = {
     loadConversation: vi.fn(
       async (_input: StateClientInput): Promise<LoadedConversation> => ({
         conversation: {
+          active_replacement_message_id: null,
           active_response_id: RESPONSE_ID,
           active_status: 'streaming',
           active_stream_id: RESPONSE_ID,
@@ -175,6 +178,9 @@ export const routeMocks = {
         ],
       }),
     ),
+    markActiveStreamStreamingIfPending: vi.fn(
+      async (_input: StateClientInput) => {},
+    ),
     replaceAssistantMessage: vi.fn(async (_input: StateClientInput) => {}),
     setActiveStream: vi.fn(async (_input: StateClientInput) => {}),
     stopActiveStreamIfCurrent: vi.fn(async (_input: StateClientInput) => {}),
@@ -187,6 +193,7 @@ export const routeMocks = {
 
 export const resetRouteMocks = (): void => {
   vi.clearAllMocks();
+  vi.spyOn(crypto, 'randomUUID').mockReturnValue(RESPONSE_ID);
   routeMocks.consumedResumableStreams.length = 0;
   routeMocks.getAuthenticatedChatUserId.mockResolvedValue(USER_ID);
   routeMocks.sharingClient.getConversationShareStatus.mockResolvedValue(null);

--- a/web/test/api-chat-route-support.ts
+++ b/web/test/api-chat-route-support.ts
@@ -15,6 +15,8 @@ export const SHARE_TOKEN = '018f0f36-2b1d-7cc0-a50b-5f2d90c91d23';
 export const USER_ID = 'anon-user-1';
 export const OTHER_USER_ID = 'anon-user-2';
 
+const randomUuidSpy = vi.spyOn(crypto, 'randomUUID');
+
 export type LoadedConversation = {
   readonly conversation: {
     readonly active_replacement_message_id: null | string;
@@ -193,7 +195,7 @@ export const routeMocks = {
 
 export const resetRouteMocks = (): void => {
   vi.clearAllMocks();
-  vi.spyOn(crypto, 'randomUUID').mockReturnValue(RESPONSE_ID);
+  randomUuidSpy.mockReturnValue(RESPONSE_ID);
   routeMocks.consumedResumableStreams.length = 0;
   routeMocks.getAuthenticatedChatUserId.mockResolvedValue(USER_ID);
   routeMocks.sharingClient.getConversationShareStatus.mockResolvedValue(null);

--- a/web/test/api-chat.route.test.ts
+++ b/web/test/api-chat.route.test.ts
@@ -15,10 +15,12 @@ import {
   USER_ID,
 } from './api-chat-route-support';
 
+const SSE_CONTENT_TYPE = 'text/event-stream';
+
 const okStreamResponse = (...frames: string[]): Response =>
   new Response(sseBody(...frames), {
     headers: {
-      'content-type': 'text/event-stream',
+      'content-type': SSE_CONTENT_TYPE,
       'X-Response-Id': RESPONSE_ID,
     },
     status: 200,
@@ -38,6 +40,30 @@ const importPost = async (): Promise<(req: Request) => Promise<Response>> => {
 
   return POST;
 };
+
+const regenerationRequest = (): Request =>
+  new Request('http://localhost/api/chat', {
+    body: JSON.stringify({
+      id: CONVERSATION_ID,
+      messageId: TARGET_ASSISTANT_ID,
+      messages: [
+        {
+          id: 'u1',
+          parts: [{ text: 'Здраво', type: 'text' }],
+          role: 'user',
+        },
+        {
+          id: TARGET_ASSISTANT_ID,
+          parts: [{ text: 'Стар одговор', type: 'text' }],
+          role: 'assistant',
+        },
+      ],
+      model: MODEL,
+      trigger: 'regenerate-message',
+    }),
+    headers: { 'content-type': JSON_CONTENT_TYPE },
+    method: 'POST',
+  });
 
 describe('POST /api/chat', () => {
   beforeEach(() => {
@@ -82,7 +108,7 @@ describe('POST /api/chat', () => {
 
     const res = await POST(req);
 
-    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    expect(res.headers.get('content-type')).toContain(SSE_CONTENT_TYPE);
 
     expect(fetchMock).toHaveBeenCalledOnce();
 
@@ -96,7 +122,7 @@ describe('POST /api/chat', () => {
     };
     const out = await res.text();
 
-    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    expect(res.headers.get('content-type')).toContain(SSE_CONTENT_TYPE);
     expect(url).toBe(`${API_BASE_URL}/chat/`);
     expect(new Headers(init.headers).get('x-api-key')).toBe('test-key');
     expect(sentBody.messages).toStrictEqual([
@@ -310,6 +336,7 @@ describe('POST /api/chat', () => {
           { state: 'done', text: 'Здраво!', type: 'text' },
         ],
         responseId: RESPONSE_ID,
+        streamId: RESPONSE_ID,
         userId: USER_ID,
       });
     });
@@ -321,6 +348,28 @@ describe('POST /api/chat', () => {
       streamId: RESPONSE_ID,
       userId: USER_ID,
     });
+    expect(routeMocks.activeChatProducers.unregister).toHaveBeenCalledWith(
+      RESPONSE_ID,
+    );
+  });
+
+  it('treats stale normal persistence as a completed stream', async () => {
+    const { ChatStateRequestError } = await import('@/lib/chat-state-client');
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(okStreamResponse(HELLO_TOKEN_FRAME, DONE_FRAME)),
+    );
+    routeMocks.stateClient.upsertAssistantMessage.mockRejectedValueOnce(
+      new ChatStateRequestError(404),
+    );
+
+    const response = await (await importPost())(chatRequest());
+    const out = await response.text();
+
+    expect(out).toContain('Здраво');
+    expect(out).not.toContain('stream error');
     expect(routeMocks.activeChatProducers.unregister).toHaveBeenCalledWith(
       RESPONSE_ID,
     );
@@ -338,30 +387,7 @@ describe('POST /api/chat', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const post = await importPost();
-    const response = await post(
-      new Request('http://localhost/api/chat', {
-        body: JSON.stringify({
-          id: CONVERSATION_ID,
-          messageId: TARGET_ASSISTANT_ID,
-          messages: [
-            {
-              id: 'u1',
-              parts: [{ text: 'Здраво', type: 'text' }],
-              role: 'user',
-            },
-            {
-              id: TARGET_ASSISTANT_ID,
-              parts: [{ text: 'Стар одговор', type: 'text' }],
-              role: 'assistant',
-            },
-          ],
-          model: MODEL,
-          trigger: 'regenerate-message',
-        }),
-        headers: { 'content-type': JSON_CONTENT_TYPE },
-        method: 'POST',
-      }),
-    );
+    const response = await post(regenerationRequest());
 
     await response.text();
 
@@ -390,6 +416,7 @@ describe('POST /api/chat', () => {
         parts: [{ state: 'done', text: 'Нов одговор', type: 'text' }],
         responseId: RESPONSE_ID,
         retainedMessageIds: [SERVER_USER_MESSAGE_ID, TARGET_ASSISTANT_ID],
+        streamId: RESPONSE_ID,
         userId: USER_ID,
       });
     });
@@ -411,6 +438,33 @@ describe('POST /api/chat', () => {
       messageId: 'u1',
       userId: USER_ID,
     });
+  });
+
+  it('treats stale regeneration persistence as a completed stream', async () => {
+    const { ChatStateRequestError } = await import('@/lib/chat-state-client');
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          okStreamResponse(
+            'event: token\ndata: {"text":"Нов одговор"}\n\n',
+            DONE_FRAME,
+          ),
+        ),
+    );
+    routeMocks.stateClient.replaceAssistantMessage.mockRejectedValueOnce(
+      new ChatStateRequestError(404),
+    );
+
+    const response = await (await importPost())(regenerationRequest());
+    const out = await response.text();
+
+    expect(out).toContain('Нов одговор');
+    expect(out).not.toContain('stream error');
+    expect(routeMocks.activeChatProducers.unregister).toHaveBeenCalledWith(
+      RESPONSE_ID,
+    );
   });
 
   it('unregisters the producer before upstream when pending state fails', async () => {
@@ -495,14 +549,17 @@ describe('POST /api/chat', () => {
     });
   });
 
-  it('rejects missing response ids before active state or Redis stream creation', async () => {
+  it('accepts legacy upstream streams without an echoed response id', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn<typeof fetch>().mockResolvedValue(
-        new Response(sseBody('event: token\ndata: {"text":"orphan"}\n\n'), {
-          headers: { 'content-type': 'text/event-stream' },
-          status: 200,
-        }),
+        new Response(
+          sseBody('event: token\ndata: {"text":"legacy"}\n\n', DONE_FRAME),
+          {
+            headers: { 'content-type': SSE_CONTENT_TYPE },
+            status: 200,
+          },
+        ),
       ),
     );
 
@@ -510,19 +567,54 @@ describe('POST /api/chat', () => {
     const res = await post(chatRequest({ text: 'hi' }));
     const out = await res.text();
 
+    expect(out).toContain('legacy');
+    expect(out).not.toContain('data-error');
+    expect(routeMocks.stateClient.setActiveStream).toHaveBeenCalledOnce();
+
+    await vi.waitFor(() => {
+      expect(
+        routeMocks.stateClient.upsertAssistantMessage,
+      ).toHaveBeenCalledExactlyOnceWith({
+        content: 'legacy',
+        conversationId: CONVERSATION_ID,
+        metadata: {
+          inferenceModel: MODEL,
+          responseId: RESPONSE_ID,
+        },
+        parts: [{ state: 'done', text: 'legacy', type: 'text' }],
+        responseId: RESPONSE_ID,
+        streamId: RESPONSE_ID,
+        userId: USER_ID,
+      });
+    });
+  });
+
+  it('rejects an upstream response id that differs from the requested id', async () => {
+    const mismatchedResponseId = '018f0f36-2b1d-7cc0-a50b-5f2d90c91d99';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(sseBody(HELLO_TOKEN_FRAME), {
+          headers: {
+            'content-type': SSE_CONTENT_TYPE,
+            'X-Response-Id': mismatchedResponseId,
+          },
+          status: 200,
+        }),
+      ),
+    );
+
+    const response = await (await importPost())(chatRequest());
+    const out = await response.text();
+
     expect(out).toContain('data-error');
     expect(out).toContain('Request failed');
-    expect(routeMocks.stateClient.setActiveStream).toHaveBeenCalledOnce();
-    expect(
-      routeMocks.stateClient.clearActiveStreamIfCurrent,
-    ).toHaveBeenCalledWith({
-      conversationId: CONVERSATION_ID,
-      streamId: RESPONSE_ID,
-      userId: USER_ID,
-    });
     expect(routeMocks.activeChatProducers.unregister).toHaveBeenCalledWith(
       RESPONSE_ID,
     );
+    expect(
+      routeMocks.stateClient.upsertAssistantMessage,
+    ).not.toHaveBeenCalled();
   });
 });
 

--- a/web/test/api-chat.route.test.ts
+++ b/web/test/api-chat.route.test.ts
@@ -113,6 +113,7 @@ describe('POST /api/chat', () => {
       'x-api-key': 'test-key',
       'X-Distinct-Id': 'browser-distinct-id',
       'X-PostHog-Session-Id': 'session-test-id',
+      'X-Response-Id': RESPONSE_ID,
     });
     expect(out).toContain('Здраво');
     expect(out).toContain(RESPONSE_ID);
@@ -199,17 +200,66 @@ describe('POST /api/chat', () => {
       RESPONSE_ID,
       expect.any(AbortController),
     );
-    expect(routeMocks.stateClient.setActiveStream).toHaveBeenCalledWith({
+    expect(routeMocks.stateClient.setActiveStream).toHaveBeenNthCalledWith(1, {
       activeResponseId: RESPONSE_ID,
+      activeStatus: 'pending',
       activeStreamId: RESPONSE_ID,
       conversationId: CONVERSATION_ID,
+      replacementMessageId: null,
       userId: USER_ID,
     });
     expect(
       routeMocks.resumableContext.createNewResumableStream,
     ).toHaveBeenCalledWith(RESPONSE_ID, expect.any(Function));
+
+    await vi.waitFor(() => {
+      expect(
+        routeMocks.stateClient.markActiveStreamStreamingIfPending,
+      ).toHaveBeenCalledExactlyOnceWith({
+        conversationId: CONVERSATION_ID,
+        streamId: RESPONSE_ID,
+        userId: USER_ID,
+      });
+    });
+
+    expect(routeMocks.stateClient.setActiveStream).toHaveBeenCalledOnce();
+
     await expect(res.text()).resolves.toContain('Здраво');
     expect(routeMocks.consumedResumableStreams.at(0)).toContain('Здраво');
+  });
+
+  it('claims pending ownership before starting the upstream request', async () => {
+    let pendingWasClaimed = false;
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(() => {
+      pendingWasClaimed =
+        routeMocks.stateClient.setActiveStream.mock.calls.length === 1;
+      return Promise.resolve(okStreamResponse(HELLO_TOKEN_FRAME, DONE_FRAME));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await (await importPost())(chatRequest());
+
+    await response.text();
+
+    expect(pendingWasClaimed).toBe(true);
+  });
+
+  it('keeps the response alive when its pending stream was superseded', async () => {
+    const { ChatStateRequestError } = await import('@/lib/chat-state-client');
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(okStreamResponse(HELLO_TOKEN_FRAME, DONE_FRAME));
+    routeMocks.stateClient.markActiveStreamStreamingIfPending.mockRejectedValueOnce(
+      new ChatStateRequestError(404),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await (await importPost())(chatRequest());
+
+    await expect(response.text()).resolves.toContain('Здраво');
+    expect(routeMocks.activeChatProducers.unregister).toHaveBeenCalledWith(
+      RESPONSE_ID,
+    );
   });
 
   it('persists the final assistant message and clears the active stream when streaming completes', async () => {
@@ -231,36 +281,39 @@ describe('POST /api/chat', () => {
     const res = await (await importPost())(chatRequest({ text: 'Hi' }));
     await res.text();
 
-    expect(
-      routeMocks.stateClient.upsertAssistantMessage,
-    ).toHaveBeenCalledExactlyOnceWith({
-      content: 'Здраво!',
-      conversationId: CONVERSATION_ID,
-      metadata: {
-        diagnostics: {
-          candidateCount: null,
-          serverTotalMs: 1_700,
-          serverTtftMs: 200,
-          spans: {},
-          thinkingMs: 400,
-          tokens: { input: 10, output: 20, total: 30 },
-          topDistance: null,
+    await vi.waitFor(() => {
+      expect(
+        routeMocks.stateClient.upsertAssistantMessage,
+      ).toHaveBeenCalledExactlyOnceWith({
+        content: 'Здраво!',
+        conversationId: CONVERSATION_ID,
+        metadata: {
+          diagnostics: {
+            candidateCount: null,
+            serverTotalMs: 1_700,
+            serverTtftMs: 200,
+            spans: {},
+            thinkingMs: 400,
+            tokens: { input: 10, output: 20, total: 30 },
+            topDistance: null,
+          },
+          inferenceModel: MODEL,
+          responseId: RESPONSE_ID,
+          timing: { totalMs: 1_700, ttftMs: 200 },
         },
-        inferenceModel: MODEL,
+        parts: [
+          {
+            state: 'done',
+            text: 'Проверувам правила.',
+            type: 'reasoning',
+          },
+          { state: 'done', text: 'Здраво!', type: 'text' },
+        ],
         responseId: RESPONSE_ID,
-        timing: { totalMs: 1_700, ttftMs: 200 },
-      },
-      parts: [
-        {
-          state: 'done',
-          text: 'Проверувам правила.',
-          type: 'reasoning',
-        },
-        { state: 'done', text: 'Здраво!', type: 'text' },
-      ],
-      responseId: RESPONSE_ID,
-      userId: USER_ID,
+        userId: USER_ID,
+      });
     });
+
     expect(
       routeMocks.stateClient.clearActiveStreamIfCurrent,
     ).toHaveBeenCalledWith({
@@ -321,16 +374,32 @@ describe('POST /api/chat', () => {
     expect(upstreamBody.match(/Stored question/gu)).toHaveLength(1);
     expect(upstreamBody).not.toContain('Здраво');
     expect(upstreamBody).not.toContain('Стар одговор');
-    expect(
-      routeMocks.stateClient.replaceAssistantMessage,
-    ).toHaveBeenCalledExactlyOnceWith({
-      content: 'Нов одговор',
+
+    await vi.waitFor(() => {
+      expect(
+        routeMocks.stateClient.replaceAssistantMessage,
+      ).toHaveBeenCalledExactlyOnceWith({
+        content: 'Нов одговор',
+        conversationId: CONVERSATION_ID,
+        messageId: TARGET_ASSISTANT_ID,
+        metadata: {
+          inferenceModel: MODEL,
+          replacementMessageId: TARGET_ASSISTANT_ID,
+          responseId: RESPONSE_ID,
+        },
+        parts: [{ state: 'done', text: 'Нов одговор', type: 'text' }],
+        responseId: RESPONSE_ID,
+        retainedMessageIds: [SERVER_USER_MESSAGE_ID, TARGET_ASSISTANT_ID],
+        userId: USER_ID,
+      });
+    });
+
+    expect(routeMocks.stateClient.setActiveStream).toHaveBeenNthCalledWith(1, {
+      activeResponseId: RESPONSE_ID,
+      activeStatus: 'pending',
+      activeStreamId: RESPONSE_ID,
       conversationId: CONVERSATION_ID,
-      messageId: TARGET_ASSISTANT_ID,
-      metadata: { inferenceModel: MODEL, responseId: RESPONSE_ID },
-      parts: [{ state: 'done', text: 'Нов одговор', type: 'text' }],
-      responseId: RESPONSE_ID,
-      retainedMessageIds: [SERVER_USER_MESSAGE_ID, TARGET_ASSISTANT_ID],
+      replacementMessageId: TARGET_ASSISTANT_ID,
       userId: USER_ID,
     });
     expect(
@@ -344,7 +413,7 @@ describe('POST /api/chat', () => {
     });
   });
 
-  it('aborts upstream and unregisters the producer when setting active stream state fails', async () => {
+  it('unregisters the producer before upstream when pending state fails', async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValue(okStreamResponse(HELLO_TOKEN_FRAME));
@@ -354,13 +423,10 @@ describe('POST /api/chat', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const res = await (await importPost())(chatRequest({ text: 'Hi' }));
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    const signal = init.signal;
-    const abortSignal = signal instanceof AbortSignal ? signal : null;
     const out = await res.text();
 
     expect(out).toContain('data-error');
-    expect(abortSignal?.aborted).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(routeMocks.activeChatProducers.unregister).toHaveBeenCalledWith(
       RESPONSE_ID,
     );
@@ -422,7 +488,11 @@ describe('POST /api/chat', () => {
     expect(out).not.toContain('Failed to retrieve or re-rank context');
     expect(
       routeMocks.stateClient.clearActiveStreamIfCurrent,
-    ).not.toHaveBeenCalled();
+    ).toHaveBeenCalledWith({
+      conversationId: CONVERSATION_ID,
+      streamId: RESPONSE_ID,
+      userId: USER_ID,
+    });
   });
 
   it('rejects missing response ids before active state or Redis stream creation', async () => {
@@ -442,8 +512,17 @@ describe('POST /api/chat', () => {
 
     expect(out).toContain('data-error');
     expect(out).toContain('Request failed');
-    expect(routeMocks.stateClient.setActiveStream).not.toHaveBeenCalled();
-    expect(routeMocks.activeChatProducers.register).not.toHaveBeenCalled();
+    expect(routeMocks.stateClient.setActiveStream).toHaveBeenCalledOnce();
+    expect(
+      routeMocks.stateClient.clearActiveStreamIfCurrent,
+    ).toHaveBeenCalledWith({
+      conversationId: CONVERSATION_ID,
+      streamId: RESPONSE_ID,
+      userId: USER_ID,
+    });
+    expect(routeMocks.activeChatProducers.unregister).toHaveBeenCalledWith(
+      RESPONSE_ID,
+    );
   });
 });
 

--- a/web/test/chat-history.route.test.ts
+++ b/web/test/chat-history.route.test.ts
@@ -11,6 +11,8 @@ import {
   USER_ID,
 } from './api-chat-route-support';
 
+const STORED_TITLE = 'Stored title';
+
 const importGet = async (): Promise<
   (
     req: Request,
@@ -46,12 +48,13 @@ describe('GET /api/chat/[id]/history', () => {
     // Given: the Python API has durable conversation messages for this owner.
     routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
       conversation: {
+        active_replacement_message_id: null,
         active_response_id: null,
         active_status: null,
         active_stream_id: null,
         id: CONVERSATION_ID,
         model: MODEL,
-        title: 'Stored title',
+        title: STORED_TITLE,
         user_id: USER_ID,
       },
       messages: [
@@ -97,9 +100,10 @@ describe('GET /api/chat/[id]/history', () => {
     expect(res.status).toBe(200);
     expect(body).toStrictEqual({
       conversation: {
+        activeStream: null,
         id: CONVERSATION_ID,
         model: MODEL,
-        title: 'Stored title',
+        title: STORED_TITLE,
       },
       messages: [
         {
@@ -142,12 +146,13 @@ describe('GET /api/chat/[id]/history', () => {
     // Given: legacy and malformed rows still have durable text content.
     routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
       conversation: {
+        active_replacement_message_id: null,
         active_response_id: null,
         active_status: null,
         active_stream_id: null,
         id: CONVERSATION_ID,
         model: MODEL,
-        title: 'Stored title',
+        title: STORED_TITLE,
         user_id: USER_ID,
       },
       messages: [
@@ -177,9 +182,10 @@ describe('GET /api/chat/[id]/history', () => {
     expect(res.status).toBe(200);
     expect(body).toStrictEqual({
       conversation: {
+        activeStream: null,
         id: CONVERSATION_ID,
         model: MODEL,
-        title: 'Stored title',
+        title: STORED_TITLE,
       },
       messages: [
         {
@@ -195,6 +201,39 @@ describe('GET /api/chat/[id]/history', () => {
           role: 'assistant',
         },
       ],
+    });
+  });
+
+  it('returns the active regeneration descriptor needed after a refresh', async () => {
+    const replacementMessageId = '018f0f36-2b1d-7cc0-a50b-5f2d90c91d35';
+    routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
+      conversation: {
+        active_replacement_message_id: replacementMessageId,
+        active_response_id: RESPONSE_ID,
+        active_status: 'streaming',
+        active_stream_id: RESPONSE_ID,
+        id: CONVERSATION_ID,
+        model: MODEL,
+        title: STORED_TITLE,
+        user_id: USER_ID,
+      },
+      messages: [],
+    });
+
+    const res = await (await importGet())(historyRequest(), routeContext());
+    const body: unknown = await res.json();
+
+    expect(body).toStrictEqual({
+      conversation: {
+        activeStream: {
+          id: RESPONSE_ID,
+          replacementMessageId,
+        },
+        id: CONVERSATION_ID,
+        model: MODEL,
+        title: STORED_TITLE,
+      },
+      messages: [],
     });
   });
 

--- a/web/test/chat-state-client.test.ts
+++ b/web/test/chat-state-client.test.ts
@@ -215,12 +215,16 @@ describe('createChatStateClient', () => {
         { state: 'done', text: 'Answer', type: 'text' },
       ],
       responseId: 'response-parts',
+      streamId: 'stream-parts',
       userId: CHAT_USER_ID,
     });
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
 
-    expect(JSON.parse(init.body as string)).toMatchObject({
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+
+    expect(body['active_stream_id']).toBe('stream-parts');
+    expect(body).toMatchObject({
       parts: [
         { state: 'done', text: 'Reasoning', type: 'reasoning' },
         { state: 'done', text: 'Answer', type: 'text' },
@@ -243,12 +247,16 @@ describe('createChatStateClient', () => {
       parts: [{ state: 'done', text: 'Replacement', type: 'text' }],
       responseId: 'response-parts',
       retainedMessageIds: ['message-parts'],
+      streamId: 'stream-parts',
       userId: CHAT_USER_ID,
     });
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
 
-    expect(JSON.parse(init.body as string)).toMatchObject({
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+
+    expect(body['active_stream_id']).toBe('stream-parts');
+    expect(body).toMatchObject({
       parts: [{ state: 'done', text: 'Replacement', type: 'text' }],
     });
   });

--- a/web/test/chat-state-client.test.ts
+++ b/web/test/chat-state-client.test.ts
@@ -312,10 +312,36 @@ describe('createChatStateClient', () => {
     await expect(
       createChatStateClient().setActiveStream({
         activeResponseId: 'response-missing',
+        activeStatus: 'pending',
         activeStreamId: 'stream-missing',
         conversationId: 'conv-missing',
+        replacementMessageId: null,
         userId: CHAT_USER_ID,
       }),
     ).rejects.toMatchObject(new ChatStateRequestError(404));
+  });
+
+  it('marks only the matching pending stream as streaming', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { createChatStateClient } = await import('@/lib/chat-state-client');
+    await createChatStateClient().markActiveStreamStreamingIfPending({
+      conversationId: 'conv-current',
+      streamId: 'stream-current',
+      userId: CHAT_USER_ID,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe(
+      'https://api:8880/chat/state/conversations/conv-current/active-stream/stream-current/streaming',
+    );
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toStrictEqual(
+      Object.fromEntries([['user_id', CHAT_USER_ID]]),
+    );
   });
 });

--- a/web/test/chat-stop.route.test.ts
+++ b/web/test/chat-stop.route.test.ts
@@ -52,6 +52,7 @@ describe('POST /api/chat/[id]/stop', () => {
     // Given: the API state already has no active stream.
     routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
       conversation: {
+        active_replacement_message_id: null,
         active_response_id: null,
         active_status: 'stopped',
         active_stream_id: null,
@@ -80,6 +81,7 @@ describe('POST /api/chat/[id]/stop', () => {
     // Given: a stale stop request races after a newer active stream was stored.
     routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
       conversation: {
+        active_replacement_message_id: null,
         active_response_id: NEWER_STREAM_ID,
         active_status: 'streaming',
         active_stream_id: NEWER_STREAM_ID,
@@ -113,6 +115,7 @@ describe('POST /api/chat/[id]/stop', () => {
     // Given: the server already recorded an active stream before the browser received its response id.
     routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
       conversation: {
+        active_replacement_message_id: null,
         active_response_id: RESPONSE_ID,
         active_status: 'streaming',
         active_stream_id: RESPONSE_ID,

--- a/web/test/chat-stream.route.test.ts
+++ b/web/test/chat-stream.route.test.ts
@@ -95,6 +95,7 @@ describe('GET /api/chat/[id]/stream', () => {
     // Given: the API state has no active stream for this owned conversation.
     routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
       conversation: {
+        active_replacement_message_id: null,
         active_response_id: null,
         active_status: null,
         active_stream_id: null,
@@ -112,6 +113,37 @@ describe('GET /api/chat/[id]/stream', () => {
     await expect(res.text()).resolves.toBe('');
     expect(
       routeMocks.resumableContext.resumeExistingStream,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('waits for a pending stream registration instead of clearing active state', async () => {
+    // Given: Postgres committed the pending stream before Redis created its sentinel.
+    routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
+      conversation: {
+        active_replacement_message_id: null,
+        active_response_id: RESPONSE_ID,
+        active_status: 'pending',
+        active_stream_id: RESPONSE_ID,
+        id: CONVERSATION_ID,
+        user_id: USER_ID,
+      },
+      messages: [],
+    });
+    routeMocks.resumableContext.resumeExistingStream
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(sseBody('data: registered-token\n\n'));
+
+    // When: refresh lands inside the Postgres-to-Redis registration window.
+    const res = await (await importGet())(streamRequest(), routeContext());
+
+    // Then: the route retries the pending stream and never destroys valid active state.
+    expect(res.status).toBe(200);
+    await expect(res.text()).resolves.toContain('registered-token');
+    expect(
+      routeMocks.resumableContext.resumeExistingStream,
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      routeMocks.stateClient.clearActiveStreamIfCurrent,
     ).not.toHaveBeenCalled();
   });
 

--- a/web/test/conversation-message-state.test.ts
+++ b/web/test/conversation-message-state.test.ts
@@ -4,6 +4,7 @@ import type { MyUIMessage } from '@/lib/api-types';
 
 import {
   applyFeedback,
+  reconcileHydratedMessages,
   replaceFinishedMessage,
 } from '@/lib/conversation-message-state';
 
@@ -40,6 +41,73 @@ describe('replaceFinishedMessage', () => {
       { text: 'new complete', type: 'text' },
     ]);
     expect(next.at(1)?.metadata?.responseId).toBe('resp-1');
+  });
+});
+
+describe('reconcileHydratedMessages', () => {
+  it('keeps a resumed assistant when persisted history arrives after the stream', () => {
+    const persisted: MyUIMessage[] = [
+      { id: 'u1', parts: [{ text: 'Прашање', type: 'text' }], role: 'user' },
+    ];
+    const resumed = assistantMessage('stream-1', 'resp-1', 'Нов одговор');
+
+    const next = reconcileHydratedMessages({
+      activeStream: { id: 'resp-1', replacementMessageId: null },
+      current: [resumed],
+      persisted,
+    });
+
+    expect(next.map((message) => message.id)).toStrictEqual(['u1', 'stream-1']);
+    expect(next.at(1)?.parts).toStrictEqual([
+      { text: 'Нов одговор', type: 'text' },
+    ]);
+  });
+
+  it('restores a regenerated target and prunes later turns after refresh', () => {
+    const persisted: MyUIMessage[] = [
+      { id: 'u1', parts: [{ text: 'Прво', type: 'text' }], role: 'user' },
+      assistantMessage('a1', 'old-1', 'Стар одговор'),
+      { id: 'u2', parts: [{ text: 'Второ', type: 'text' }], role: 'user' },
+      assistantMessage('a2', 'old-2', 'Подоцнежен одговор'),
+    ];
+    const resumed: MyUIMessage = {
+      ...assistantMessage('stream-2', 'resp-2', 'Регенериран одговор'),
+      metadata: {
+        replacementMessageId: 'a1',
+        responseId: 'resp-2',
+      },
+    };
+
+    const next = reconcileHydratedMessages({
+      activeStream: { id: 'resp-2', replacementMessageId: 'a1' },
+      current: [resumed],
+      persisted,
+    });
+
+    expect(next.map((message) => message.id)).toStrictEqual(['u1', 'a1']);
+    expect(next.at(1)?.parts).toStrictEqual([
+      { text: 'Регенериран одговор', type: 'text' },
+    ]);
+    expect(next.at(1)?.metadata?.responseId).toBe('resp-2');
+  });
+
+  it('prepares the regeneration target when history arrives before the resumed stream', () => {
+    const persisted: MyUIMessage[] = [
+      { id: 'u1', parts: [{ text: 'Прво', type: 'text' }], role: 'user' },
+      assistantMessage('a1', 'old-1', 'Стар одговор'),
+      { id: 'u2', parts: [{ text: 'Второ', type: 'text' }], role: 'user' },
+      assistantMessage('a2', 'old-2', 'Подоцнежен одговор'),
+    ];
+
+    const next = reconcileHydratedMessages({
+      activeStream: { id: 'resp-2', replacementMessageId: 'a1' },
+      current: [],
+      persisted,
+    });
+
+    expect(next.map((message) => message.id)).toStrictEqual(['u1', 'a1']);
+    expect(next.at(1)?.parts).toStrictEqual([]);
+    expect(next.at(1)?.metadata).toStrictEqual({});
   });
 });
 

--- a/web/test/transport.test.ts
+++ b/web/test/transport.test.ts
@@ -245,6 +245,32 @@ describe('buildChatTransport', () => {
     });
   });
 
+  it('normalizes an omitted active-stream replacement id to null', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockResolvedValue(
+        Response.json({
+          conversation: {
+            activeStream: { id: ACTIVE_STREAM_ID },
+            id: 'conv-7',
+            model: null,
+            title: null,
+          },
+          messages: [],
+        }),
+      ),
+    );
+
+    await expect(loadChatConversationHistory('conv-7')).resolves.toMatchObject({
+      conversation: {
+        activeStream: {
+          id: ACTIVE_STREAM_ID,
+          replacementMessageId: null,
+        },
+      },
+    });
+  });
+
   it('returns an empty conversation list when the server returns invalid JSON', async () => {
     vi.stubGlobal(
       'fetch',

--- a/web/test/transport.test.ts
+++ b/web/test/transport.test.ts
@@ -235,7 +235,12 @@ describe('buildChatTransport', () => {
     );
 
     await expect(loadChatConversationHistory('conv-7')).resolves.toStrictEqual({
-      conversation: { id: 'conv-7', model: null, title: 'New conversation' },
+      conversation: {
+        activeStream: null,
+        id: 'conv-7',
+        model: null,
+        title: 'New conversation',
+      },
       messages,
     });
   });

--- a/web/test/use-conversation-chat-runtime.test.tsx
+++ b/web/test/use-conversation-chat-runtime.test.tsx
@@ -1,9 +1,13 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ErrorNotice, MyUIMessage } from '@/lib/api-types';
 
 import { useConversationChatRuntime } from '@/lib/use-conversation-chat-runtime';
+
+type MessageUpdate =
+  | ((messages: MyUIMessage[]) => MyUIMessage[])
+  | MyUIMessage[];
 
 type RuntimeDataPart =
   | { readonly data: ErrorNotice; readonly type: 'data-error' }
@@ -36,8 +40,9 @@ const previousMessages: MyUIMessage[] = [
 ];
 
 const useChatOptions: RuntimeOptions[] = [];
-const setMessages = vi.fn<(messages: MyUIMessage[]) => void>();
+const setMessages = vi.fn<(messages: MessageUpdate) => void>();
 const refreshConversations = vi.fn<() => Promise<void>>();
+const getChatStatus = vi.fn<() => 'ready' | 'submitted'>(() => 'ready');
 const { refetchModels } = vi.hoisted(() => ({
   refetchModels: vi.fn<() => Promise<void>>(),
 }));
@@ -50,7 +55,7 @@ vi.mock('@ai-sdk/react', () => ({
       regenerate: vi.fn<() => Promise<void>>(),
       sendMessage: vi.fn<() => Promise<void>>(),
       setMessages,
-      status: 'ready',
+      status: getChatStatus(),
       stop: vi.fn<() => void>(),
     };
   },
@@ -80,7 +85,13 @@ describe('useConversationChatRuntime sponsored errors', () => {
     refetchModels.mockReset();
     refetchModels.mockResolvedValue();
     setMessages.mockReset();
+    getChatStatus.mockReset();
+    getChatStatus.mockReturnValue('ready');
     useChatOptions.length = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('refreshes the model catalog and preserves the prior conversation on terminal quota errors', async () => {
@@ -165,5 +176,52 @@ describe('useConversationChatRuntime sponsored errors', () => {
     await Promise.resolve();
 
     expect(refetchModels).not.toHaveBeenCalled();
+  });
+
+  it('finalizes client timing when a regenerated message keeps its target id', () => {
+    getChatStatus.mockReturnValue('submitted');
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    renderHook(() =>
+      useConversationChatRuntime({
+        activeId: 'conversation-1',
+        model: 'gpt-5.6-luna',
+        preserveEmptyHydrationIdRef: { current: null },
+        reasoning: false,
+        refreshConversations,
+        setActiveId: vi.fn<(id: null | string) => void>(),
+      }),
+    );
+    const options = useChatOptions.at(-1);
+    if (options?.onFinish === undefined) {
+      throw new Error('Chat runtime finish callback was not registered');
+    }
+    nowSpy.mockReturnValue(1_800);
+
+    act(() => {
+      options.onFinish?.({
+        isAbort: false,
+        isError: false,
+        message: {
+          id: 'a1',
+          metadata: {
+            replacementMessageId: 'a1',
+            responseId: 'response-2',
+          },
+          parts: [{ text: 'Регенериран одговор', type: 'text' }],
+          role: 'assistant',
+        },
+      });
+    });
+
+    const update = setMessages.mock.calls[0]?.[0];
+    if (typeof update !== 'function') {
+      throw new TypeError('Expected a functional message update');
+    }
+    const updated = update(previousMessages);
+
+    expect(updated.at(1)?.metadata?.timing).toStrictEqual({
+      totalMs: 800,
+      ttftMs: 0,
+    });
   });
 });

--- a/web/test/use-conversation-hydration.test.tsx
+++ b/web/test/use-conversation-hydration.test.tsx
@@ -27,12 +27,17 @@ const transportMocks = vi.hoisted(() => {
 
   return {
     ChatConversationRequestError,
-    loadChatConversationHistory:
-      vi.fn<
-        (
-          conversationId: string,
-        ) => Promise<null | { readonly messages: readonly MyUIMessage[] }>
-      >(),
+    loadChatConversationHistory: vi.fn<
+      (conversationId: string) => Promise<null | {
+        readonly conversation: {
+          readonly activeStream: null | {
+            readonly id: string;
+            readonly replacementMessageId: null | string;
+          };
+        };
+        readonly messages: readonly MyUIMessage[];
+      }>
+    >(),
   };
 });
 const setActiveError = vi.fn<(value: ErrorNotice | undefined) => void>();
@@ -49,14 +54,18 @@ const message = (id: string, text: string): MyUIMessage => ({
 
 const useHydratedMessages = ({
   activeStreamConversationId,
+  initialMessages,
   preserveEmptyHydrationId,
 }: {
   readonly activeStreamConversationId?: string;
+  readonly initialMessages?: readonly MyUIMessage[];
   readonly preserveEmptyHydrationId?: string;
 } = {}): MyUIMessage[] => {
-  const [messages, setMessages] = useState<MyUIMessage[]>(() => [
-    message(PREVIOUS_ID, PREVIOUS_TEXT),
-  ]);
+  const [messages, setMessages] = useState<MyUIMessage[]>(() =>
+    initialMessages === undefined
+      ? [message(PREVIOUS_ID, PREVIOUS_TEXT)]
+      : [...initialMessages],
+  );
   const convoIdRef = useRef<null | string>(null);
   const preserveEmptyHydrationIdRef = useRef<null | string>(
     preserveEmptyHydrationId ?? null,
@@ -87,6 +96,7 @@ describe('useConversationHydration', () => {
     setActiveError.mockReset();
     setActiveId.mockReset();
     transportMocks.loadChatConversationHistory.mockResolvedValue({
+      conversation: { activeStream: null },
       messages: [message('server-b', 'Conversation B')],
     });
   });
@@ -106,6 +116,7 @@ describe('useConversationHydration', () => {
 
   it('clears previous messages when the selected server conversation is empty', async () => {
     transportMocks.loadChatConversationHistory.mockResolvedValue({
+      conversation: { activeStream: null },
       messages: [],
     });
 
@@ -118,6 +129,7 @@ describe('useConversationHydration', () => {
 
   it('preserves local messages when a locally created conversation has not saved history yet', async () => {
     transportMocks.loadChatConversationHistory.mockResolvedValue({
+      conversation: { activeStream: null },
       messages: [],
     });
 
@@ -133,6 +145,7 @@ describe('useConversationHydration', () => {
 
   it('preserves resumed stream messages when server history is still empty', async () => {
     transportMocks.loadChatConversationHistory.mockResolvedValue({
+      conversation: { activeStream: null },
       messages: [],
     });
 
@@ -144,6 +157,69 @@ describe('useConversationHydration', () => {
       expect(result.current).toHaveLength(1);
       expect(result.current[0]?.id).toBe(PREVIOUS_ID);
     });
+  });
+
+  it('merges non-empty persisted history with an already resumed assistant', async () => {
+    const resumedAssistant: MyUIMessage = {
+      id: 'stream-answer',
+      metadata: { responseId: 'active-response' },
+      parts: [{ text: 'Resumed answer', type: 'text' }],
+      role: 'assistant',
+    };
+    transportMocks.loadChatConversationHistory.mockResolvedValue({
+      conversation: {
+        activeStream: {
+          id: 'active-response',
+          replacementMessageId: null,
+        },
+      },
+      messages: [message('server-user', 'Persisted question')],
+    });
+
+    const { result } = renderHook(() =>
+      useHydratedMessages({ initialMessages: [resumedAssistant] }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.map((item) => item.id)).toStrictEqual([
+        'server-user',
+        'stream-answer',
+      ]);
+    });
+  });
+
+  it('prunes stale later turns when regeneration history arrives before the stream', async () => {
+    transportMocks.loadChatConversationHistory.mockResolvedValue({
+      conversation: {
+        activeStream: {
+          id: 'active-response',
+          replacementMessageId: 'server-answer',
+        },
+      },
+      messages: [
+        message('server-user', 'Persisted question'),
+        {
+          id: 'server-answer',
+          metadata: { responseId: 'old-response' },
+          parts: [{ text: 'Old answer', type: 'text' }],
+          role: 'assistant',
+        },
+        message('later-user', 'Stale follow-up'),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useHydratedMessages({ initialMessages: [] }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.map((item) => item.id)).toStrictEqual([
+        'server-user',
+        'server-answer',
+      ]);
+    });
+
+    expect(result.current.at(1)?.parts).toStrictEqual([]);
   });
 
   it('preserves previous messages and surfaces an error when selected conversation history rejects', async () => {

--- a/web/test/use-generated-title.test.tsx
+++ b/web/test/use-generated-title.test.tsx
@@ -88,6 +88,7 @@ test('loads the requested conversation before generating its title', async () =>
   ];
   loadChatConversationHistory.mockResolvedValue({
     conversation: {
+      activeStream: null,
       id: CONVERSATION_ID,
       model: MODEL_ID,
       title: OLD_TITLE,


### PR DESCRIPTION
## Summary
- claim canonical stream IDs before upstream work and guard active stream transitions
- persist regeneration replacement targets and reconcile history without duplicate or stale turns
- replay resumable UI stream progress and cover refresh recovery in browser tests

## Verification
- API: 306 passed, 4 skipped; Ruff and mypy passed
- Web: 456 Vitest tests passed; type check, lint, and production build passed
- Headed Chromium: regeneration refresh and normal generation refresh/resume passed
- Independent goal, QA, code quality, security, and context reviews passed

## Deployment
- apply `api/resources/migrations/0009_add_active_chat_replacement.sql` before deploying the updated services