### PR TITLE
feat(web): improve responsive chat interactions

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,16 +24,17 @@ The chat UI is an operational product surface: fast, quiet, and readable for stu
 
 ## 5. Components
 
-- Sidebar conversation row: selectable title button plus compact row-action icon buttons that reveal on hover/focus for desktop and stay visible on mobile.
+- Sidebar conversation row: selectable title button plus compact row-action icon buttons that reveal on hover/focus for fine pointers. Coarse pointers use one 44px overflow trigger with labeled generate, rename, and delete menu items so conversation titles keep useful width.
 - Row action button: Lucide icon, `size-3.5`, semantic aria label, focus-visible ring, muted default color, stronger hover color matching the action intent, and the existing Radix tooltip using the same localized label on hover or keyboard focus.
 - Destructive row action: use destructive hover color only for delete.
+- Answer sources: automatically expose one or two source cards below a completed answer; larger source sets stay collapsed behind the source-count trigger. The trigger and external source links keep compact fine-pointer sizing and expose at least 44px targets on coarse pointers.
 - Auth sign-in panel: card surface using `card`, `border`, `background`, `primary`, and `muted-foreground` tokens, with provider buttons that visibly change border/background on hover and use `focus-visible:ring-ring`.
 - Auth sign-in content: limit the supporting value list to 2 concise benefits so the primary action remains visible on small screens. The panel uses `Започни разговор`, and provider actions follow `Продолжи со {provider.name}`.
 - Credential settings dialog: modal card using existing `Dialog`, `Input`, and `Button` primitives. Provider rows use `border`, `card`, `muted`, and `muted-foreground` tokens, with saved state indicated by text and destructive delete action only when a credential exists. Deleting a saved key opens a focused confirmation dialog; cancellation preserves the credential and confirmation is the only path that starts deletion.
 - Model selector option: group models only by provider in catalog order. Models without saved provider credentials remain visible but disabled, use `muted-foreground`, and pair a Lucide key icon with visible key-required text rather than relying on color or hover help.
 - Scrollable select menu: keep both scroll-arrow rows mounted while overflow exists so reaching a boundary never moves the popup. Show the unavailable direction with `muted-foreground` and without pointer behavior; hide both rows when the menu does not overflow.
 - Diagnostics hover card: preserve the existing hover/focus interaction, keep the card inside the dynamic viewport with the standard 16px outer gutter, and make the card the single vertical scroll owner when its full diagnostics content is taller than the available screen. The preferred minimum width must yield to Radix's available width on ultra-narrow viewports. While the trigger has keyboard focus, Arrow, Page Up/Down, Home, and End keys scroll the card without moving the conversation. Desktop-sized content remains unchanged and the surrounding conversation does not become a second scroll owner.
-- Mobile sidebar: a modal Radix dialog that traps focus, closes on Escape or overlay interaction, and restores focus to the header trigger. Desktop retains the static complementary landmark.
+- Compact sidebar: viewports below `lg` use a modal Radix dialog that traps focus, closes on Escape or overlay interaction, and restores focus to the header trigger. Desktop viewports from `lg` retain the static complementary landmark so tablet-width chat content keeps enough reading space.
 - Conversation loading state: preserve the current list/thread during transient failures and present an inline alert with a retry action. Only a confirmed missing conversation clears the selection.
 - Composer submission failure: retain the draft and show an inline retryable error; clear the draft only after the message is accepted.
 - Sponsored quota notice: present the exhausted state and localized reset time as passive information, then offer `Додај API клуч` as the only recovery action. Use the existing primary `Button` treatment with a coarse-pointer 44px target. Do not render wait, dismiss, or retry controls that cannot change the quota state.
@@ -48,7 +49,7 @@ The chat UI is an operational product surface: fast, quiet, and readable for stu
 ## 6. Accessibility
 
 - Every icon-only action must have an `aria-label` from `web/lib/i18n.ts`.
-- Primary controls, dialog actions, close controls, search clear, and conversation row actions expose at least 44px targets whenever the primary pointer is coarse. Compact desktop sizing is gated by `pointer-fine`, not viewport width, so touch tablets retain full targets.
+- Primary controls, dialog actions, close controls, search clear, conversation overflow actions, source disclosure, and external source links expose at least 44px targets whenever the primary pointer is coarse. Compact desktop sizing is gated by `pointer-fine`, not viewport width, so touch tablets retain full targets.
 - Mobile header and drawer honor safe-area insets; decorative logo and GitHub shortcut are hidden below `sm` to protect the title and primary actions.
 - Modal drawers contain keyboard focus and restore it to their invoking control.
 - The account trigger exposes its expanded state through the Radix menu primitive, retains a visible focus ring, and keeps identity text available through a full accessible label when visual text truncates.

--- a/web/components/chat/chat-screen.tsx
+++ b/web/components/chat/chat-screen.tsx
@@ -15,6 +15,7 @@ import { Thread } from '@/components/chat/thread';
 import { CredentialSettingsDialog } from '@/components/shell/credential-settings-dialog';
 import { Header } from '@/components/shell/header';
 import { Sidebar } from '@/components/shell/sidebar';
+import { DESKTOP_SIDEBAR_QUERY } from '@/components/shell/sidebar-helpers';
 import { SidebarUserIdentity } from '@/components/shell/sidebar-user-identity';
 import { t } from '@/lib/i18n';
 import { isModelAvailable, recoverSelectedModel } from '@/lib/model-catalog';
@@ -25,7 +26,6 @@ import { useCredentials } from '@/lib/use-credentials';
 import { useHealth } from '@/lib/use-health';
 import { useModels } from '@/lib/use-models';
 
-const DESKTOP_SIDEBAR_QUERY = '(min-width: 768px)';
 const useIsomorphicLayoutEffect =
   typeof window === 'undefined' ? useEffect : useLayoutEffect;
 

--- a/web/components/chat/chat-screen.tsx
+++ b/web/components/chat/chat-screen.tsx
@@ -168,7 +168,7 @@ export const ChatScreen = () => {
           generatingTitleId={generatingTitleId}
           listError={conversationListError}
           listLoading={conversationListLoading}
-          mobile={sidebarSynced && !desktopSidebar}
+          mobile={!sidebarSynced || !desktopSidebar}
           onClose={() => {
             setSidebarOpen(false);
           }}
@@ -178,7 +178,7 @@ export const ChatScreen = () => {
           onRename={onRename}
           onRetryList={onRetryConversationList}
           onSelect={onSelect}
-          open={sidebarOpen}
+          open={sidebarSynced && sidebarOpen}
           synced={sidebarSynced}
         />
         <main

--- a/web/components/chat/message.tsx
+++ b/web/components/chat/message.tsx
@@ -28,6 +28,7 @@ import { useSearchStage } from '@/lib/use-search-stage';
 
 export type AssistantMessageProps = {
   actions?: ReactNode;
+  complete?: boolean;
   errorPart?: ErrorNotice;
   message: MyUIMessage;
   onManageCredentials?: () => void;
@@ -558,6 +559,7 @@ const AssistantMessageStatus = ({
 };
 export const AssistantMessage = ({
   actions,
+  complete,
   errorPart,
   message,
   onManageCredentials,
@@ -590,6 +592,7 @@ export const AssistantMessage = ({
   const inferenceModel = message.metadata?.inferenceModel;
   const sources = message.metadata?.sources ?? [];
   const responseId = message.metadata?.responseId;
+  const answerComplete = complete ?? !pending;
 
   return (
     <Message from="assistant">
@@ -616,7 +619,12 @@ export const AssistantMessage = ({
             timing={timing}
           />
         )}
-        {text === null ? null : <SourceCards sources={sources} />}
+        {text === null ? null : (
+          <SourceCards
+            complete={answerComplete}
+            sources={sources}
+          />
+        )}
         <AssistantMessageStatus
           errorPart={errorPart}
           pending={pending}

--- a/web/components/chat/source-cards.tsx
+++ b/web/components/chat/source-cards.tsx
@@ -8,6 +8,7 @@ import type { RetrievedSource } from '@/lib/api-types';
 import { t } from '@/lib/i18n';
 
 const PREVIEW_WORD_LIMIT = 12;
+const AUTO_EXPAND_SOURCE_LIMIT = 2;
 const SENTENCE_END_RE = /[.!?]/u;
 const WHITESPACE_RE = /\s+/u;
 
@@ -89,7 +90,7 @@ const SourceCard = ({ source }: { source: RetrievedSource }) => {
             {links.map((link) => (
               <a
                 aria-label={`${t('sources.link')}: ${link.label}`}
-                className="rounded-md p-1 text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-fine:min-h-0 pointer-fine:min-w-0 pointer-fine:p-1"
                 href={link.url}
                 key={`${link.label}:${link.url}`}
                 rel="noreferrer"
@@ -113,12 +114,24 @@ export const SourceCards = ({
 }: {
   sources: readonly RetrievedSource[];
 }) => {
-  const [open, setOpen] = useState(false);
+  const sourceCount = sources.length;
+  const [disclosure, setDisclosure] = useState<'automatic' | 'closed' | 'open'>(
+    'automatic',
+  );
+  const open =
+    disclosure === 'open' ||
+    (disclosure === 'automatic' &&
+      sourceCount > 0 &&
+      sourceCount <= AUTO_EXPAND_SOURCE_LIMIT);
   const panelId = useId();
 
-  if (sources.length === 0) {
+  if (sourceCount === 0) {
     return null;
   }
+
+  const toggleDisclosure = () => {
+    setDisclosure(open ? 'closed' : 'open');
+  };
 
   return (
     <section
@@ -130,10 +143,8 @@ export const SourceCards = ({
         aria-controls={panelId}
         aria-expanded={open}
         aria-label={open ? t('sources.hide') : t('sources.show')}
-        className="inline-flex items-center gap-1.5 rounded-md text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        onClick={() => {
-          setOpen((current) => !current);
-        }}
+        className="inline-flex min-h-11 items-center gap-1.5 rounded-md px-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-fine:min-h-0 pointer-fine:px-0 pointer-fine:text-xs"
+        onClick={toggleDisclosure}
         type="button"
       >
         <ChevronRight
@@ -146,7 +157,7 @@ export const SourceCards = ({
         />
         <span>{t('sources.title')}</span>
         <span className="rounded-full border border-border/70 px-1.5 py-0.5 text-[10px] tabular-nums text-muted-foreground/70">
-          {sources.length}
+          {sourceCount}
         </span>
       </button>
       {open ? (

--- a/web/components/chat/source-cards.tsx
+++ b/web/components/chat/source-cards.tsx
@@ -110,8 +110,10 @@ const SourceCard = ({ source }: { source: RetrievedSource }) => {
 };
 
 export const SourceCards = ({
+  complete,
   sources,
 }: {
+  complete: boolean;
   sources: readonly RetrievedSource[];
 }) => {
   const sourceCount = sources.length;
@@ -121,6 +123,7 @@ export const SourceCards = ({
   const open =
     disclosure === 'open' ||
     (disclosure === 'automatic' &&
+      complete &&
       sourceCount > 0 &&
       sourceCount <= AUTO_EXPAND_SOURCE_LIMIT);
   const panelId = useId();

--- a/web/components/chat/thread.tsx
+++ b/web/components/chat/thread.tsx
@@ -129,9 +129,14 @@ export const Thread = ({
               }
 
               const isLastAssistant = m.id === lastAssistantId;
+              const activeAssistant =
+                isLastAssistant &&
+                streaming &&
+                lastMessage?.role === 'assistant';
               return (
                 <AssistantMessage
                   actions={renderActions ? renderActions(m) : undefined}
+                  complete={!activeAssistant}
                   errorPart={
                     isLastAssistant
                       ? (activeError ?? m.metadata?.error)

--- a/web/components/shell/conversation-list.tsx
+++ b/web/components/shell/conversation-list.tsx
@@ -1,10 +1,9 @@
-import { LoaderCircle, Pencil, Trash2, WandSparkles } from 'lucide-react';
 import { useState } from 'react';
 
 import type { MaybeAsyncAction } from '@/lib/action-result';
 import type { ConversationRow } from '@/lib/conversation-types';
 
-import { ConversationActionTooltip } from '@/components/shell/conversation-action-tooltip';
+import { ConversationRowActions } from '@/components/shell/conversation-row-actions';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
@@ -47,8 +46,6 @@ export const ConversationList = ({
   const [pendingDelete, setPendingDelete] = useState<ConversationRow | null>(
     null,
   );
-  const isGeneratingAnyTitle = generatingTitleId !== null;
-
   const openRename = (conversation: ConversationRow) => {
     setRenameFailed(false);
     setRenameTarget(conversation);
@@ -80,94 +77,33 @@ export const ConversationList = ({
   return (
     <>
       <ul className="flex flex-col gap-1">
-        {conversations.map((c) => {
-          const isGeneratingTitle = generatingTitleId === c.id;
-
-          return (
-            <li
-              aria-current={c.id === activeId ? 'true' : undefined}
-              className={`group flex items-center justify-between gap-1 rounded-lg px-2.5 py-1.5 text-sm text-foreground/80 transition-colors duration-150 hover:bg-muted/70 ${
-                c.id === activeId ? 'bg-muted font-medium text-foreground' : ''
-              }`}
-              data-testid={`conversation-${c.id}`}
-              key={c.id}
+        {conversations.map((c) => (
+          <li
+            aria-current={c.id === activeId ? 'true' : undefined}
+            className={`group flex items-center justify-between gap-1 rounded-lg px-2.5 py-1.5 text-sm text-foreground/80 transition-colors duration-150 hover:bg-muted/70 ${
+              c.id === activeId ? 'bg-muted font-medium text-foreground' : ''
+            }`}
+            data-testid={`conversation-${c.id}`}
+            key={c.id}
+          >
+            <button
+              className="min-h-11 flex-1 truncate rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50 pointer-fine:min-h-0"
+              onClick={() => {
+                onSelect(c.id);
+              }}
+              type="button"
             >
-              <button
-                className="min-h-11 flex-1 truncate rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50 sm:pointer-fine:min-h-0"
-                onClick={() => {
-                  onSelect(c.id);
-                }}
-                type="button"
-              >
-                {c.title}
-              </button>
-              <span
-                className="flex items-center gap-1 opacity-100 transition-opacity duration-150 sm:pointer-fine:opacity-0 sm:pointer-fine:group-focus-within:opacity-100 sm:pointer-fine:group-hover:opacity-100"
-                data-testid="row-actions"
-              >
-                {onGenerateTitle ? (
-                  <ConversationActionTooltip
-                    disabled={isGeneratingAnyTitle}
-                    label={t('conversation.generateTitle')}
-                  >
-                    <button
-                      aria-busy={isGeneratingTitle || undefined}
-                      aria-label={t('conversation.generateTitle')}
-                      className="inline-flex size-11 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-background hover:text-primary focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-60 sm:pointer-fine:size-6"
-                      disabled={isGeneratingAnyTitle}
-                      onClick={() => {
-                        onGenerateTitle(c.id);
-                      }}
-                      type="button"
-                    >
-                      {isGeneratingTitle ? (
-                        <LoaderCircle
-                          aria-hidden="true"
-                          className="size-3.5 animate-spin"
-                        />
-                      ) : (
-                        <WandSparkles
-                          aria-hidden="true"
-                          className="size-3.5"
-                        />
-                      )}
-                    </button>
-                  </ConversationActionTooltip>
-                ) : null}
-                <ConversationActionTooltip label={t('conversation.rename')}>
-                  <button
-                    aria-label={t('conversation.rename')}
-                    className="inline-flex size-11 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-background hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 sm:pointer-fine:size-6"
-                    onClick={() => {
-                      openRename(c);
-                    }}
-                    type="button"
-                  >
-                    <Pencil
-                      aria-hidden="true"
-                      className="size-3.5"
-                    />
-                  </button>
-                </ConversationActionTooltip>
-                <ConversationActionTooltip label={t('conversation.delete')}>
-                  <button
-                    aria-label={t('conversation.delete')}
-                    className="inline-flex size-11 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-background hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring/50 sm:pointer-fine:size-6"
-                    onClick={() => {
-                      setPendingDelete(c);
-                    }}
-                    type="button"
-                  >
-                    <Trash2
-                      aria-hidden="true"
-                      className="size-3.5"
-                    />
-                  </button>
-                </ConversationActionTooltip>
-              </span>
-            </li>
-          );
-        })}
+              {c.title}
+            </button>
+            <ConversationRowActions
+              conversation={c}
+              generatingTitleId={generatingTitleId}
+              onDeleteAction={setPendingDelete}
+              onGenerateTitle={onGenerateTitle}
+              onRenameAction={openRename}
+            />
+          </li>
+        ))}
       </ul>
 
       <Dialog

--- a/web/components/shell/conversation-row-actions.tsx
+++ b/web/components/shell/conversation-row-actions.tsx
@@ -1,0 +1,170 @@
+import {
+  Ellipsis,
+  LoaderCircle,
+  Pencil,
+  Trash2,
+  WandSparkles,
+} from 'lucide-react';
+
+import type { ConversationRow } from '@/lib/conversation-types';
+
+import { ConversationActionTooltip } from '@/components/shell/conversation-action-tooltip';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { t } from '@/lib/i18n';
+
+type ConversationRowActionsProps = {
+  readonly conversation: ConversationRow;
+  readonly generatingTitleId: null | string;
+  readonly onDeleteAction: (conversation: ConversationRow) => void;
+  readonly onGenerateTitle?: (id: string) => void;
+  readonly onRenameAction: (conversation: ConversationRow) => void;
+};
+
+export const ConversationRowActions = ({
+  conversation,
+  generatingTitleId,
+  onDeleteAction,
+  onGenerateTitle,
+  onRenameAction,
+}: ConversationRowActionsProps) => {
+  const isGeneratingAnyTitle = generatingTitleId !== null;
+  const isGeneratingTitle = generatingTitleId === conversation.id;
+  const actionsLabel = `${t('conversation.actions')}: ${conversation.title}`;
+
+  return (
+    <>
+      <span
+        className="hidden items-center gap-1 opacity-0 transition-opacity duration-150 pointer-fine:flex pointer-fine:group-focus-within:opacity-100 pointer-fine:group-hover:opacity-100"
+        data-testid="row-actions"
+      >
+        {onGenerateTitle ? (
+          <ConversationActionTooltip
+            disabled={isGeneratingAnyTitle}
+            label={t('conversation.generateTitle')}
+          >
+            <button
+              aria-busy={isGeneratingTitle || undefined}
+              aria-label={t('conversation.generateTitle')}
+              className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-background hover:text-primary focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-60"
+              disabled={isGeneratingAnyTitle}
+              onClick={() => {
+                onGenerateTitle(conversation.id);
+              }}
+              type="button"
+            >
+              {isGeneratingTitle ? (
+                <LoaderCircle
+                  aria-hidden="true"
+                  className="size-3.5 animate-spin"
+                />
+              ) : (
+                <WandSparkles
+                  aria-hidden="true"
+                  className="size-3.5"
+                />
+              )}
+            </button>
+          </ConversationActionTooltip>
+        ) : null}
+        <ConversationActionTooltip label={t('conversation.rename')}>
+          <button
+            aria-label={t('conversation.rename')}
+            className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-background hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => {
+              onRenameAction(conversation);
+            }}
+            type="button"
+          >
+            <Pencil
+              aria-hidden="true"
+              className="size-3.5"
+            />
+          </button>
+        </ConversationActionTooltip>
+        <ConversationActionTooltip label={t('conversation.delete')}>
+          <button
+            aria-label={t('conversation.delete')}
+            className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-background hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => {
+              onDeleteAction(conversation);
+            }}
+            type="button"
+          >
+            <Trash2
+              aria-hidden="true"
+              className="size-3.5"
+            />
+          </button>
+        </ConversationActionTooltip>
+      </span>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            aria-label={actionsLabel}
+            className="inline-flex size-12 shrink-0 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-background hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring pointer-fine:hidden"
+            type="button"
+          >
+            <Ellipsis
+              aria-hidden="true"
+              className="size-5"
+            />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className="min-w-48"
+          collisionPadding={12}
+        >
+          <DropdownMenuGroup>
+            {onGenerateTitle ? (
+              <DropdownMenuItem
+                aria-busy={isGeneratingTitle || undefined}
+                className="min-h-11 pointer-fine:min-h-8"
+                disabled={isGeneratingAnyTitle}
+                onSelect={() => {
+                  onGenerateTitle(conversation.id);
+                }}
+              >
+                {isGeneratingTitle ? (
+                  <LoaderCircle
+                    aria-hidden="true"
+                    className="animate-spin"
+                  />
+                ) : (
+                  <WandSparkles aria-hidden="true" />
+                )}
+                {t('conversation.generateTitle')}
+              </DropdownMenuItem>
+            ) : null}
+            <DropdownMenuItem
+              className="min-h-11 pointer-fine:min-h-8"
+              onSelect={() => {
+                onRenameAction(conversation);
+              }}
+            >
+              <Pencil aria-hidden="true" />
+              {t('conversation.rename')}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="min-h-11 pointer-fine:min-h-8"
+              onSelect={() => {
+                onDeleteAction(conversation);
+              }}
+              variant="destructive"
+            >
+              <Trash2 aria-hidden="true" />
+              {t('conversation.delete')}
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
+  );
+};

--- a/web/components/shell/sidebar-helpers.ts
+++ b/web/components/shell/sidebar-helpers.ts
@@ -1,5 +1,8 @@
 import type { ConversationRow } from '@/lib/conversation-types';
 
+export const DESKTOP_SIDEBAR_QUERY = '(min-width: 1024px)';
+const COMPACT_SIDEBAR_QUERY = '(max-width: 1023px)';
+
 type ConversationFilter = {
   readonly filtered: ConversationRow[];
   readonly term: string;
@@ -8,7 +11,7 @@ type ConversationFilter = {
 export const closeSidebarOnMobile = (onClose: () => void): void => {
   if (
     typeof matchMedia === 'function' &&
-    matchMedia('(max-width: 767px)').matches
+    matchMedia(COMPACT_SIDEBAR_QUERY).matches
   ) {
     onClose();
   }
@@ -19,10 +22,10 @@ export const getSidebarWidthClass = (
   synced: boolean,
 ): string => {
   if (!synced) {
-    return 'md:w-64';
+    return 'lg:w-64';
   }
 
-  return open ? 'md:w-64' : 'md:w-0';
+  return open ? 'lg:w-64' : 'lg:w-0';
 };
 
 export const getConversationFilter = (

--- a/web/e2e/chat.spec.ts
+++ b/web/e2e/chat.spec.ts
@@ -9,6 +9,7 @@ import {
   stagedRunChunks,
   startChatStreamServer,
   toolRunChunks,
+  type UiChunk,
 } from './helpers/sse';
 
 const RESPONSE_ID = '11111111-2222-3333-4444-555555555555';
@@ -197,6 +198,74 @@ test.describe('chat streaming (mocked BFF)', () => {
       'aria-pressed',
       'false',
     );
+
+    await chatServer.close();
+  });
+
+  test('keeps small source sets collapsed until the streamed answer completes', async ({
+    page,
+  }, testInfo) => {
+    const answerId = 'txt-source-answer';
+    const sourceTitle = 'Упис на семестар';
+    const sources = [
+      { id: 'q1', kind: 'faq', title: sourceTitle },
+      { id: 'q2', kind: 'faq', title: 'Заверка на семестар' },
+    ] as const;
+    const chatServer = await startChatStreamServer({
+      gapMs: 3_000,
+      head: [
+        {
+          messageMetadata: {
+            inferenceModel: INFERENCE_MODEL,
+            responseId: RESPONSE_ID,
+          },
+          type: 'start',
+        },
+        { id: answerId, type: 'text-start' },
+        {
+          delta: 'Одговорот се генерира и изворите се подготвени.',
+          id: answerId,
+          type: 'text-delta',
+        },
+        { messageMetadata: { sources }, type: 'message-metadata' },
+      ] satisfies UiChunk[],
+      tail: [{ id: answerId, type: 'text-end' }, { type: 'finish' }],
+    });
+
+    await page.route('**/api/health', async (route) => {
+      await route.fulfill({
+        body: JSON.stringify({ ok: true }),
+        contentType: 'application/json',
+        status: 200,
+      });
+    });
+    await page.route('**/api/chat/*/stream', async (route) => {
+      await route.fulfill({ status: 204 });
+    });
+    await mockModels(page);
+    await installMockChatState(page, { streamUrl: chatServer.url });
+    await page.goto('/');
+    await page.getByTestId(COMPOSER_INPUT).fill('Кои се условите за упис?');
+    await page.getByTestId(COMPOSER_SUBMIT).click();
+
+    const collapsedToggle = page.getByRole('button', {
+      name: 'Прикажи извори',
+    });
+    await expect(collapsedToggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.getByText(sourceTitle)).toHaveCount(0);
+    await page.screenshot({
+      animations: 'disabled',
+      path: testInfo.outputPath('streaming-sources-collapsed.png'),
+    });
+
+    await expect(
+      page.getByRole('button', { name: 'Сокриј извори' }),
+    ).toHaveAttribute('aria-expanded', 'true', { timeout: 10_000 });
+    await expect(page.getByText(sourceTitle)).toBeVisible();
+    await page.screenshot({
+      animations: 'disabled',
+      path: testInfo.outputPath('completed-sources-open.png'),
+    });
 
     await chatServer.close();
   });

--- a/web/e2e/helpers/sse.ts
+++ b/web/e2e/helpers/sse.ts
@@ -1,6 +1,8 @@
 import { createServer, type Server } from 'node:http';
 import { type AddressInfo } from 'node:net';
 
+import type { MyUIMessage } from '@/lib/api-types';
+
 export type UiChunk =
   | {
       data: Record<string, never>;
@@ -37,17 +39,7 @@ export type UiChunk =
       type: 'start';
     }
   | {
-      messageMetadata: {
-        diagnostics: {
-          cost?: { inputUsd: number; outputUsd: number; totalUsd: number };
-          serverTotalMs: number;
-          serverTtftMs: number;
-          spans?: Record<string, number>;
-          tokens: { input: number; output: number; total: number };
-        };
-        inferenceModel?: string;
-        responseId?: string;
-      };
+      messageMetadata: NonNullable<MyUIMessage['metadata']>;
       type: 'message-metadata';
     }
   | { type: 'finish' };

--- a/web/e2e/mobile-chat.spec.ts
+++ b/web/e2e/mobile-chat.spec.ts
@@ -15,6 +15,7 @@ const DEFAULT_SESSION_USER = {
   email: 'student@example.com',
   name: 'Student',
 } as const satisfies MockSessionUser;
+const CONVERSATION_TITLE = 'Услови за запишување семестар';
 const SIDEBAR_TOGGLE_LABEL = 'Прикажи/сокриј странична лента';
 const STREAM_URL = 'http://127.0.0.1:9/stream';
 const SPONSORED_MODEL = 'gpt-5.6-luna';
@@ -116,6 +117,42 @@ test('mobile primary controls meet the 44px touch target minimum', async ({
 
   expect(triggerBox?.height).toBeGreaterThanOrEqual(44);
   expect(triggerBox?.width).toBeGreaterThanOrEqual(44);
+});
+
+test('mobile conversation actions use one touch-friendly overflow menu', async ({
+  page,
+}) => {
+  // Given a conversation in the compact sidebar.
+  await page.setViewportSize({ height: 812, width: 375 });
+  await mockSession(page);
+  await mockModels(page);
+  await installMockChatState(page, {
+    conversations: [
+      { id: 'conversation-1', model: null, title: CONVERSATION_TITLE },
+    ],
+    streamUrl: STREAM_URL,
+  });
+  await page.goto('/');
+  await page.getByRole('button', { name: SIDEBAR_TOGGLE_LABEL }).click();
+  const drawer = page.getByRole('dialog', { name: 'Странична лента' });
+
+  // When the row action trigger is opened.
+  const actionsTrigger = drawer.getByRole('button', {
+    name: `Дејства за разговорот: ${CONVERSATION_TITLE}`,
+  });
+  const triggerBox = await actionsTrigger.boundingBox();
+  await actionsTrigger.click();
+
+  // Then one 44px trigger exposes labeled menu actions without crowding the title.
+  expect(triggerBox?.height).toBeGreaterThanOrEqual(44);
+  expect(triggerBox?.width).toBeGreaterThanOrEqual(44);
+  await expect(
+    page.getByRole('menuitem', { name: 'Генерирај име' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('menuitem', { name: 'Преименувај' }),
+  ).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'Избриши' })).toBeVisible();
 });
 
 test('mobile keeps account actions in the profile menu and opens credentials after closing the drawer', async ({

--- a/web/e2e/responsive-shell.spec.ts
+++ b/web/e2e/responsive-shell.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test';
+
+import { installMockChatState } from './helpers/chat-state';
+import { mockModels } from './helpers/models';
+
+const SIDEBAR_TOGGLE_LABEL = 'Прикажи/сокриј странична лента';
+const STREAM_URL = 'http://127.0.0.1:9/stream';
+const CONVERSATION_TITLE = 'Услови за запишување семестар';
+
+test('tablet width keeps the chat sidebar in a modal drawer', async ({
+  page,
+}) => {
+  // Given a tablet-width chat shell.
+  await page.setViewportSize({ height: 900, width: 768 });
+  await page.route('**/api/health', async (route) => {
+    await route.fulfill({
+      body: JSON.stringify({ ok: true }),
+      contentType: 'application/json',
+      status: 200,
+    });
+  });
+  await mockModels(page);
+  await installMockChatState(page, {
+    conversations: [
+      { id: 'conversation-1', model: null, title: CONVERSATION_TITLE },
+    ],
+    streamUrl: STREAM_URL,
+  });
+  await page.goto('/');
+
+  // When the user opens navigation.
+  await expect(page.getByRole('complementary')).toHaveCount(0);
+  await page.getByRole('button', { name: SIDEBAR_TOGGLE_LABEL }).click();
+
+  // Then navigation overlays the chat instead of permanently narrowing it.
+  await expect(
+    page.getByRole('dialog', { name: 'Странична лента' }),
+  ).toBeVisible();
+  await expect(page.locator('#main-content')).toHaveCSS('width', '768px');
+
+  await page.getByRole('button', { name: CONVERSATION_TITLE }).click();
+
+  await expect(
+    page.getByRole('dialog', { name: 'Странична лента' }),
+  ).toBeHidden();
+});
+
+test('narrow fine pointers retain inline conversation actions', async ({
+  page,
+}) => {
+  // Given a narrow desktop browser with a fine primary pointer.
+  await page.setViewportSize({ height: 812, width: 375 });
+  await page.route('**/api/health', async (route) => {
+    await route.fulfill({
+      body: JSON.stringify({ ok: true }),
+      contentType: 'application/json',
+      status: 200,
+    });
+  });
+  await mockModels(page);
+  await installMockChatState(page, {
+    conversations: [
+      { id: 'conversation-1', model: null, title: CONVERSATION_TITLE },
+    ],
+    streamUrl: STREAM_URL,
+  });
+  await page.goto('/');
+  await page.getByRole('button', { name: SIDEBAR_TOGGLE_LABEL }).click();
+  const row = page.getByTestId('conversation-conversation-1');
+
+  // When the fine pointer hovers the conversation row.
+  await row.hover();
+
+  // Then inline controls are available without the coarse-pointer overflow trigger.
+  await expect(row.getByTestId('row-actions')).toHaveCSS('display', 'flex');
+  await expect(
+    row.getByRole('button', {
+      name: `Дејства за разговорот: ${CONVERSATION_TITLE}`,
+    }),
+  ).toHaveCount(0);
+  await expect(row.getByRole('button', { name: 'Преименувај' })).toBeVisible();
+});

--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -28,6 +28,7 @@ export const messages = {
   'composer.reasoning': 'Размислување',
   'composer.send': 'Испрати',
   'composer.stop': 'Запри',
+  'conversation.actions': 'Дејства за разговорот',
   'conversation.contextLabel': 'Активен разговор',
   'conversation.createError':
     'Разговорот не можеше да се започне. Прашањето е зачувано за повторен обид.',

--- a/web/test/conversation-list-a11y.test.tsx
+++ b/web/test/conversation-list-a11y.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { ConversationRow } from '@/lib/conversation-types';
@@ -36,11 +37,14 @@ describe('ConversationList accessibility', () => {
     const actions = within(item).getByTestId('row-actions');
 
     expect(actions).toHaveClass(
-      'sm:pointer-fine:group-focus-within:opacity-100',
+      'hidden',
+      'pointer-fine:flex',
+      'pointer-fine:group-focus-within:opacity-100',
     );
   });
 
-  it('gives mobile conversation controls 44px touch targets', () => {
+  it('uses one 44px mobile menu trigger with labeled actions', async () => {
+    const user = userEvent.setup();
     render(
       <ConversationList
         activeId={null}
@@ -53,25 +57,28 @@ describe('ConversationList accessibility', () => {
     );
 
     const item = screen.getByTestId('conversation-c1');
+    const actionsTrigger = within(item).getByRole('button', {
+      name: 'Дејства за разговорот: Прв разговор',
+    });
 
     expect(
       within(item).getByRole('button', { name: 'Прв разговор' }),
-    ).toHaveClass('min-h-11', 'sm:pointer-fine:min-h-0');
+    ).toHaveClass('min-h-11', 'pointer-fine:min-h-0');
+    expect(actionsTrigger).toHaveClass('size-12', 'pointer-fine:hidden');
+
+    await user.click(actionsTrigger);
+
+    const menu = screen.getByRole('menu');
+
     expect(
-      within(item).getByRole('button', { name: 'Генерирај име' }),
-    ).toHaveClass('size-11');
+      within(menu).getByRole('menuitem', { name: 'Генерирај име' }),
+    ).toHaveClass('min-h-11', 'pointer-fine:min-h-8');
     expect(
-      within(item).getByRole('button', { name: 'Генерирај име' }),
-    ).toHaveClass('sm:pointer-fine:size-6');
-    expect(
-      within(item).getByRole('button', { name: 'Преименувај' }),
-    ).toHaveClass('size-11');
-    expect(
-      within(item).getByRole('button', { name: 'Преименувај' }),
-    ).toHaveClass('sm:pointer-fine:size-6');
-    expect(within(item).getByRole('button', { name: 'Избриши' })).toHaveClass(
-      'size-11',
-      'sm:pointer-fine:size-6',
+      within(menu).getByRole('menuitem', { name: 'Преименувај' }),
+    ).toHaveClass('min-h-11', 'pointer-fine:min-h-8');
+    expect(within(menu).getByRole('menuitem', { name: 'Избриши' })).toHaveClass(
+      'min-h-11',
+      'pointer-fine:min-h-8',
     );
   });
 

--- a/web/test/shell.test.tsx
+++ b/web/test/shell.test.tsx
@@ -471,6 +471,28 @@ describe('ChatPage persistence', () => {
     vi.unstubAllGlobals();
   });
 
+  it('keeps the sidebar modal below the large-screen breakpoint', async () => {
+    const media: MediaQueryList = {
+      addEventListener: vi.fn<MediaQueryList['addEventListener']>(),
+      addListener: vi.fn<MediaQueryList['addListener']>(),
+      dispatchEvent: vi.fn<MediaQueryList['dispatchEvent']>(() => true),
+      matches: false,
+      media: '(min-width: 1024px)',
+      onchange: null,
+      removeEventListener: vi.fn<MediaQueryList['removeEventListener']>(),
+      removeListener: vi.fn<MediaQueryList['removeListener']>(),
+    };
+    const matchMediaMock = vi.fn<(query: string) => MediaQueryList>(
+      () => media,
+    );
+    vi.stubGlobal('matchMedia', matchMediaMock);
+
+    renderChatPage();
+
+    await expect(screen.findByRole('textbox')).resolves.toBeInTheDocument();
+    expect(matchMediaMock).toHaveBeenCalledWith('(min-width: 1024px)');
+  });
+
   it('keeps contextual and account actions out of the global header', async () => {
     renderChatPage();
 

--- a/web/test/shell.test.tsx
+++ b/web/test/shell.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SessionProvider } from 'next-auth/react';
+import { renderToString } from 'react-dom/server';
 import {
   afterEach,
   beforeAll,
@@ -469,6 +470,22 @@ describe('ChatPage persistence', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it('omits the static sidebar before the viewport is synchronized', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const markup = renderToString(
+      <SessionProvider>
+        <QueryClientProvider client={queryClient}>
+          <ChatScreen />
+        </QueryClientProvider>
+      </SessionProvider>,
+    );
+
+    expect(markup).not.toContain('<aside');
   });
 
   it('keeps the sidebar modal below the large-screen breakpoint', async () => {

--- a/web/test/sidebar.test.tsx
+++ b/web/test/sidebar.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Sidebar } from '@/components/shell/sidebar';
+import { getSidebarWidthClass } from '@/components/shell/sidebar-helpers';
 import { SidebarUserIdentity } from '@/components/shell/sidebar-user-identity';
 
 type MockSessionState =
@@ -219,5 +220,52 @@ describe('Sidebar conversation loading', () => {
     expect(screen.getByRole('status')).toHaveTextContent(
       'Се вчитуваат разговори…',
     );
+  });
+});
+
+describe('Sidebar responsive behavior', () => {
+  it('closes the tablet drawer after selecting a conversation', async () => {
+    const onClose = vi.fn<() => void>();
+    const onSelect = vi.fn<(id: string) => void>();
+    const media: MediaQueryList = {
+      addEventListener: vi.fn<MediaQueryList['addEventListener']>(),
+      addListener: vi.fn<MediaQueryList['addListener']>(),
+      dispatchEvent: vi.fn<MediaQueryList['dispatchEvent']>(() => true),
+      matches: true,
+      media: '(max-width: 1023px)',
+      onchange: null,
+      removeEventListener: vi.fn<MediaQueryList['removeEventListener']>(),
+      removeListener: vi.fn<MediaQueryList['removeListener']>(),
+    };
+    const matchMediaMock = vi.fn<(query: string) => MediaQueryList>(
+      () => media,
+    );
+    const user = userEvent.setup();
+    vi.stubGlobal('matchMedia', matchMediaMock);
+    render(
+      <Sidebar
+        {...baseProps}
+        conversations={[
+          { id: 'conversation-1', model: null, title: 'Прв разговор' },
+        ]}
+        mobile
+        onClose={onClose}
+        onSelect={onSelect}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Прв разговор' }));
+
+    expect(onSelect).toHaveBeenCalledWith('conversation-1');
+    expect(matchMediaMock).toHaveBeenCalledWith('(max-width: 1023px)');
+
+    expect(onClose).toHaveBeenCalledOnce();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the large breakpoint for static sidebar width', () => {
+    expect(getSidebarWidthClass(true, false)).toBe('lg:w-64');
+    expect(getSidebarWidthClass(false, true)).toBe('lg:w-0');
   });
 });

--- a/web/test/thread.test.tsx
+++ b/web/test/thread.test.tsx
@@ -23,6 +23,11 @@ const CHUNK_SOURCE_TITLE_RE = /Статут на ФИНКИ · Член 12/u;
 const COLLAPSED_CHUNK_TEXT =
   'Правилата за запишување и заверка на семестарот се наведени во овој член…';
 const EXPANDED_CHUNK_TEXT_RE = /Вториот став/u;
+const FIRST_SOURCE_TITLE = 'Прв извор';
+const SECOND_SOURCE_TITLE = 'Втор извор';
+const THIRD_SOURCE_TITLE = 'Трет извор';
+const SHOW_SOURCES_LABEL = 'Прикажи извори';
+const HIDE_SOURCES_LABEL = 'Сокриј извори';
 const SPONSORED_RESET_TEXT = '18 јул. 2026, 14:00.';
 const TIMING_TESTID = 'message-timing';
 
@@ -494,7 +499,7 @@ describe('AssistantMessage', () => {
     render(<AssistantMessage message={msg} />);
 
     const sources = screen.getByTestId('message-sources');
-    const toggle = screen.getByRole('button', { name: 'Сокриј извори' });
+    const toggle = screen.getByRole('button', { name: HIDE_SOURCES_LABEL });
 
     expect(sources).toHaveTextContent('Извори');
     expect(sources).toHaveTextContent('2');
@@ -532,12 +537,42 @@ describe('AssistantMessage', () => {
     );
     expect(finkiLink).toHaveAttribute('href', 'https://www.finki.ukim.mk/');
 
-    await user.click(screen.getByRole('button', { name: 'Сокриј извори' }));
+    await user.click(screen.getByRole('button', { name: HIDE_SOURCES_LABEL }));
 
     expect(
-      screen.getByRole('button', { name: 'Прикажи извори' }),
+      screen.getByRole('button', { name: SHOW_SOURCES_LABEL }),
     ).toHaveAttribute(ARIA_EXPANDED, 'false');
     expect(screen.queryByText('Упис')).toBeNull();
+  });
+
+  it('waits for answer completion before automatically opening a small source set', () => {
+    const message: MyUIMessage = {
+      id: 'a1',
+      metadata: {
+        sources: [
+          { id: 'q1', kind: 'faq', title: FIRST_SOURCE_TITLE },
+          { id: 'q2', kind: 'faq', title: SECOND_SOURCE_TITLE },
+        ],
+      },
+      parts: [{ text: 'Одговорот сè уште се генерира.', type: 'text' }],
+      role: 'assistant',
+    };
+    const view = render(
+      <AssistantMessage
+        message={message}
+        pending
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: SHOW_SOURCES_LABEL }),
+    ).toHaveAttribute(ARIA_EXPANDED, 'false');
+
+    view.rerender(<AssistantMessage message={message} />);
+
+    expect(
+      screen.getByRole('button', { name: HIDE_SOURCES_LABEL }),
+    ).toHaveAttribute(ARIA_EXPANDED, 'true');
   });
 
   it('keeps larger source sets collapsed until requested', () => {
@@ -545,9 +580,9 @@ describe('AssistantMessage', () => {
       id: 'a1',
       metadata: {
         sources: [
-          { id: 'q1', kind: 'faq', title: 'Прв извор' },
-          { id: 'q2', kind: 'faq', title: 'Втор извор' },
-          { id: 'q3', kind: 'faq', title: 'Трет извор' },
+          { id: 'q1', kind: 'faq', title: FIRST_SOURCE_TITLE },
+          { id: 'q2', kind: 'faq', title: SECOND_SOURCE_TITLE },
+          { id: 'q3', kind: 'faq', title: THIRD_SOURCE_TITLE },
         ],
       },
       parts: [{ text: 'Готово', type: 'text' }],
@@ -557,9 +592,9 @@ describe('AssistantMessage', () => {
     render(<AssistantMessage message={msg} />);
 
     expect(
-      screen.getByRole('button', { name: 'Прикажи извори' }),
+      screen.getByRole('button', { name: SHOW_SOURCES_LABEL }),
     ).toHaveAttribute(ARIA_EXPANDED, 'false');
-    expect(screen.queryByText('Прв извор')).toBeNull();
+    expect(screen.queryByText(FIRST_SOURCE_TITLE)).toBeNull();
   });
 
   it('keeps a larger source set collapsed when metadata arrives after text', () => {
@@ -573,9 +608,9 @@ describe('AssistantMessage', () => {
       ...emptyMessage,
       metadata: {
         sources: [
-          { id: 'q1', kind: 'faq', title: 'Прв извор' },
-          { id: 'q2', kind: 'faq', title: 'Втор извор' },
-          { id: 'q3', kind: 'faq', title: 'Трет извор' },
+          { id: 'q1', kind: 'faq', title: FIRST_SOURCE_TITLE },
+          { id: 'q2', kind: 'faq', title: SECOND_SOURCE_TITLE },
+          { id: 'q3', kind: 'faq', title: THIRD_SOURCE_TITLE },
         ],
       },
     };
@@ -584,9 +619,9 @@ describe('AssistantMessage', () => {
     view.rerender(<AssistantMessage message={loadedMessage} />);
 
     expect(
-      screen.getByRole('button', { name: 'Прикажи извори' }),
+      screen.getByRole('button', { name: SHOW_SOURCES_LABEL }),
     ).toHaveAttribute(ARIA_EXPANDED, 'false');
-    expect(screen.queryByText('Прв извор')).toBeNull();
+    expect(screen.queryByText(FIRST_SOURCE_TITLE)).toBeNull();
   });
 
   it('collapses an automatically opened source set when it grows past two', () => {
@@ -594,8 +629,8 @@ describe('AssistantMessage', () => {
       id: 'a1',
       metadata: {
         sources: [
-          { id: 'q1', kind: 'faq', title: 'Прв извор' },
-          { id: 'q2', kind: 'faq', title: 'Втор извор' },
+          { id: 'q1', kind: 'faq', title: FIRST_SOURCE_TITLE },
+          { id: 'q2', kind: 'faq', title: SECOND_SOURCE_TITLE },
         ],
       },
       parts: [{ text: 'Готово', type: 'text' }],
@@ -605,24 +640,24 @@ describe('AssistantMessage', () => {
       ...smallMessage,
       metadata: {
         sources: [
-          { id: 'q1', kind: 'faq', title: 'Прв извор' },
-          { id: 'q2', kind: 'faq', title: 'Втор извор' },
-          { id: 'q3', kind: 'faq', title: 'Трет извор' },
+          { id: 'q1', kind: 'faq', title: FIRST_SOURCE_TITLE },
+          { id: 'q2', kind: 'faq', title: SECOND_SOURCE_TITLE },
+          { id: 'q3', kind: 'faq', title: THIRD_SOURCE_TITLE },
         ],
       },
     };
     const view = render(<AssistantMessage message={smallMessage} />);
 
     expect(
-      screen.getByRole('button', { name: 'Сокриј извори' }),
+      screen.getByRole('button', { name: HIDE_SOURCES_LABEL }),
     ).toHaveAttribute(ARIA_EXPANDED, 'true');
 
     view.rerender(<AssistantMessage message={largeMessage} />);
 
     expect(
-      screen.getByRole('button', { name: 'Прикажи извори' }),
+      screen.getByRole('button', { name: SHOW_SOURCES_LABEL }),
     ).toHaveAttribute(ARIA_EXPANDED, 'false');
-    expect(screen.queryByText('Прв извор')).toBeNull();
+    expect(screen.queryByText(FIRST_SOURCE_TITLE)).toBeNull();
   });
 
   it('reveals the model, trace ID, and throughput rows in the diagnostics popover', async () => {
@@ -706,6 +741,40 @@ describe('AssistantMessage', () => {
     );
 
     expect(screen.queryByTestId(TIMING_TESTID)).toBeNull();
+  });
+});
+
+describe('Thread source disclosure', () => {
+  it('keeps completed sources open while waiting for the next reply', () => {
+    const messages: MyUIMessage[] = [
+      userMessage('Прво прашање'),
+      {
+        id: 'a1',
+        metadata: {
+          sources: [{ id: 'q1', kind: 'faq', title: FIRST_SOURCE_TITLE }],
+        },
+        parts: [{ text: 'Завршен одговор', type: 'text' }],
+        role: 'assistant',
+      },
+      {
+        id: 'u2',
+        metadata: {},
+        parts: [{ text: 'Следно прашање', type: 'text' }],
+        role: 'user',
+      },
+    ];
+
+    render(
+      <Thread
+        messages={messages}
+        status="submitted"
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: HIDE_SOURCES_LABEL }),
+    ).toHaveAttribute(ARIA_EXPANDED, 'true');
+    expect(screen.getByText(FIRST_SOURCE_TITLE)).toBeInTheDocument();
   });
 });
 

--- a/web/test/thread.test.tsx
+++ b/web/test/thread.test.tsx
@@ -459,7 +459,7 @@ describe('AssistantMessage', () => {
     expect(footnote).toHaveTextContent('2.3s');
   });
 
-  it('keeps source cards collapsed until the user expands them', async () => {
+  it('opens a small source set by default and keeps its links touchable', async () => {
     const user = userEvent.setup();
     const chunkSnippet =
       'Правилата за запишување и заверка на семестарот се наведени во овој член со повеќе детали. Вториот став содржи дополнителни детали што треба да се прикажат кога картичката е отворена.';
@@ -494,17 +494,12 @@ describe('AssistantMessage', () => {
     render(<AssistantMessage message={msg} />);
 
     const sources = screen.getByTestId('message-sources');
-    const toggle = screen.getByRole('button', { name: 'Прикажи извори' });
+    const toggle = screen.getByRole('button', { name: 'Сокриј извори' });
 
     expect(sources).toHaveTextContent('Извори');
     expect(sources).toHaveTextContent('2');
-    expect(toggle).toHaveAttribute(ARIA_EXPANDED, 'false');
-    expect(screen.queryByText('Упис')).toBeNull();
-    expect(screen.queryByText(CHUNK_SOURCE_TITLE)).toBeNull();
-
-    await user.click(toggle);
-
     expect(toggle).toHaveAttribute(ARIA_EXPANDED, 'true');
+    expect(toggle).toHaveClass('min-h-11', 'pointer-fine:min-h-0');
     expect(screen.getByText('Упис')).toBeInTheDocument();
     expect(screen.getByText(CHUNK_SOURCE_TITLE)).toBeInTheDocument();
 
@@ -525,14 +520,17 @@ describe('AssistantMessage', () => {
     expect(expandedChunkText).not.toHaveClass('line-clamp-2');
     expect(expandedChunkText).toHaveClass('whitespace-pre-wrap');
 
-    expect(screen.getByRole('link', { name: 'Врска: iKnow' })).toHaveAttribute(
-      'href',
-      'https://iknow.ukim.mk/',
+    const iKnowLink = screen.getByRole('link', { name: 'Врска: iKnow' });
+    const finkiLink = screen.getByRole('link', { name: 'Врска: ФИНКИ' });
+
+    expect(iKnowLink).toHaveAttribute('href', 'https://iknow.ukim.mk/');
+    expect(iKnowLink).toHaveClass(
+      'min-h-11',
+      'min-w-11',
+      'pointer-fine:min-h-0',
+      'pointer-fine:min-w-0',
     );
-    expect(screen.getByRole('link', { name: 'Врска: ФИНКИ' })).toHaveAttribute(
-      'href',
-      'https://www.finki.ukim.mk/',
-    );
+    expect(finkiLink).toHaveAttribute('href', 'https://www.finki.ukim.mk/');
 
     await user.click(screen.getByRole('button', { name: 'Сокриј извори' }));
 
@@ -540,6 +538,91 @@ describe('AssistantMessage', () => {
       screen.getByRole('button', { name: 'Прикажи извори' }),
     ).toHaveAttribute(ARIA_EXPANDED, 'false');
     expect(screen.queryByText('Упис')).toBeNull();
+  });
+
+  it('keeps larger source sets collapsed until requested', () => {
+    const msg: MyUIMessage = {
+      id: 'a1',
+      metadata: {
+        sources: [
+          { id: 'q1', kind: 'faq', title: 'Прв извор' },
+          { id: 'q2', kind: 'faq', title: 'Втор извор' },
+          { id: 'q3', kind: 'faq', title: 'Трет извор' },
+        ],
+      },
+      parts: [{ text: 'Готово', type: 'text' }],
+      role: 'assistant',
+    };
+
+    render(<AssistantMessage message={msg} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Прикажи извори' }),
+    ).toHaveAttribute(ARIA_EXPANDED, 'false');
+    expect(screen.queryByText('Прв извор')).toBeNull();
+  });
+
+  it('keeps a larger source set collapsed when metadata arrives after text', () => {
+    const emptyMessage: MyUIMessage = {
+      id: 'a1',
+      metadata: { sources: [] },
+      parts: [{ text: 'Готово', type: 'text' }],
+      role: 'assistant',
+    };
+    const loadedMessage: MyUIMessage = {
+      ...emptyMessage,
+      metadata: {
+        sources: [
+          { id: 'q1', kind: 'faq', title: 'Прв извор' },
+          { id: 'q2', kind: 'faq', title: 'Втор извор' },
+          { id: 'q3', kind: 'faq', title: 'Трет извор' },
+        ],
+      },
+    };
+    const view = render(<AssistantMessage message={emptyMessage} />);
+
+    view.rerender(<AssistantMessage message={loadedMessage} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Прикажи извори' }),
+    ).toHaveAttribute(ARIA_EXPANDED, 'false');
+    expect(screen.queryByText('Прв извор')).toBeNull();
+  });
+
+  it('collapses an automatically opened source set when it grows past two', () => {
+    const smallMessage: MyUIMessage = {
+      id: 'a1',
+      metadata: {
+        sources: [
+          { id: 'q1', kind: 'faq', title: 'Прв извор' },
+          { id: 'q2', kind: 'faq', title: 'Втор извор' },
+        ],
+      },
+      parts: [{ text: 'Готово', type: 'text' }],
+      role: 'assistant',
+    };
+    const largeMessage: MyUIMessage = {
+      ...smallMessage,
+      metadata: {
+        sources: [
+          { id: 'q1', kind: 'faq', title: 'Прв извор' },
+          { id: 'q2', kind: 'faq', title: 'Втор извор' },
+          { id: 'q3', kind: 'faq', title: 'Трет извор' },
+        ],
+      },
+    };
+    const view = render(<AssistantMessage message={smallMessage} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Сокриј извори' }),
+    ).toHaveAttribute(ARIA_EXPANDED, 'true');
+
+    view.rerender(<AssistantMessage message={largeMessage} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Прикажи извори' }),
+    ).toHaveAttribute(ARIA_EXPANDED, 'false');
+    expect(screen.queryByText('Прв извор')).toBeNull();
   });
 
   it('reveals the model, trace ID, and throughput rows in the diagnostics popover', async () => {


### PR DESCRIPTION
## Summary
- expose one/two-source evidence by default, keep larger source sets collapsed, and preserve explicit disclosure choices
- adapt conversation actions and touch targets to pointer capability instead of viewport width
- align modal versus static sidebar behavior at the shared 1024px breakpoint and document the interaction contract

## Verification
- `npm run check`
- `npm run lint` (0 errors; existing warnings only)
- `npm run test` (467 passed)
- `npm run e2e` (33 passed)
- `npm run build`
- responsive browser QA at 375px, 768px, and 1280px in light and dark modes
- independent goal, code-quality, context, hands-on QA, security, and dual visual reviews passed