### PR TITLE
fix(web): guard resumable chat state

### DIFF
--- a/web/app/api/chat/[id]/history/route.ts
+++ b/web/app/api/chat/[id]/history/route.ts
@@ -5,6 +5,11 @@ import {
   getAuthenticatedChatUserId,
 } from '@/lib/authenticated-chat-user';
 import { parseChatStateMessages } from '@/lib/chat-history';
+import {
+  ChatStateRequestError,
+  createChatStateClient,
+  isResumableChatStreamStatus,
+} from '@/lib/chat-state-client';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -30,11 +35,6 @@ export const GET = async (
   { params }: RouteContext,
 ): Promise<Response> => {
   const { id: conversationId } = await params;
-  const {
-    ChatStateRequestError,
-    createChatStateClient,
-    isResumableChatStreamStatus,
-  } = await import('@/lib/chat-state-client');
   const chatState = createChatStateClient();
 
   try {

--- a/web/app/api/chat/[id]/history/route.ts
+++ b/web/app/api/chat/[id]/history/route.ts
@@ -30,8 +30,11 @@ export const GET = async (
   { params }: RouteContext,
 ): Promise<Response> => {
   const { id: conversationId } = await params;
-  const { ChatStateRequestError, createChatStateClient } =
-    await import('@/lib/chat-state-client');
+  const {
+    ChatStateRequestError,
+    createChatStateClient,
+    isResumableChatStreamStatus,
+  } = await import('@/lib/chat-state-client');
   const chatState = createChatStateClient();
 
   try {
@@ -43,7 +46,8 @@ export const GET = async (
     const uiMessages = await parseChatStateMessages(messages);
     const historyConversation: HistoryConversation = {
       activeStream:
-        conversation.active_stream_id === null
+        conversation.active_stream_id === null ||
+        !isResumableChatStreamStatus(conversation.active_status)
           ? null
           : {
               id: conversation.active_stream_id,

--- a/web/app/api/chat/[id]/stream/route.ts
+++ b/web/app/api/chat/[id]/stream/route.ts
@@ -9,6 +9,7 @@ import {
 import {
   ChatStateRequestError,
   createChatStateClient,
+  isResumableChatStreamStatus,
 } from '@/lib/chat-state-client';
 import { createChatResumableStreamContext } from '@/lib/resumable-stream-context';
 
@@ -57,7 +58,10 @@ export const GET = async (
     });
     const activeStreamId = conversation.active_stream_id;
 
-    if (activeStreamId === null) {
+    if (
+      activeStreamId === null ||
+      !isResumableChatStreamStatus(conversation.active_status)
+    ) {
       return empty(204);
     }
 

--- a/web/e2e/resumable-chat.spec.ts
+++ b/web/e2e/resumable-chat.spec.ts
@@ -74,11 +74,14 @@ const emptyHistoryBody = (id: null | string): string =>
     messages: [],
   });
 
-const chunksForAnswer = (answer: string): UiChunk[] => [
+const chunksForAnswer = (
+  answer: string,
+  responseId: string = RESPONSE_ID,
+): UiChunk[] => [
   {
     messageMetadata: {
       inferenceModel: INFERENCE_MODEL,
-      responseId: RESPONSE_ID,
+      responseId,
     },
     type: 'start',
   },
@@ -105,6 +108,15 @@ const installHealthRoute = async (page: Page): Promise<void> => {
   });
 };
 
+const installChatStateRoutes = async (page: Page): Promise<void> => {
+  await page.context().route('**/api/chat/title', async (route) => {
+    await route.fulfill({ status: 204 });
+  });
+  await page.context().route('**/api/chat/*/share', async (route) => {
+    await route.fulfill({ status: 204 });
+  });
+};
+
 test.describe('resumable chat lifecycle (mocked BFF)', () => {
   test('resumes after refresh and persists the completed assistant response', async ({
     page,
@@ -112,6 +124,7 @@ test.describe('resumable chat lifecycle (mocked BFF)', () => {
     // Given: the initial POST emits one token slowly while the resume endpoint can replay the full stream.
     await installHealthRoute(page);
     await installModelRoute(page);
+    await installChatStateRoutes(page);
     const firstLegServer = await startChatStreamServer({
       gapMs: LONG_GAP_MS,
       head: chunksForAnswer(FIRST_TOKEN).slice(0, 3),
@@ -277,96 +290,105 @@ test.describe('resumable chat lifecycle (mocked BFF)', () => {
 
   test('explicit stop prevents a later refresh from resuming the stream', async ({
     page,
-  }) => {
+  }, testInfo) => {
     // Given: an active stream has rendered a partial answer.
     await installHealthRoute(page);
     await installModelRoute(page);
+    await installChatStateRoutes(page);
+    const responseId = `${RESPONSE_ID}-${testInfo.repeatEachIndex}-${testInfo.workerIndex}-${testInfo.retry}`;
     const activeServer = await startChatStreamServer({
       gapMs: LONG_GAP_MS,
-      head: chunksForAnswer(STOP_TOKEN).slice(0, 3),
+      head: chunksForAnswer(STOP_TOKEN, responseId).slice(0, 3),
       tail: [],
     });
-    const stopRequests: unknown[] = [];
-    const resumeStatuses: number[] = [];
-    const conversations: ConversationRow[] = [];
-    let conversationId: null | string = null;
+    try {
+      const stopRequests: unknown[] = [];
+      const resumeStatuses: number[] = [];
+      const conversations: ConversationRow[] = [];
+      let conversationId: null | string = null;
 
-    await page.route('**/api/chat', async (route) => {
-      if (route.request().method() === 'GET') {
+      await page.route('**/api/chat', async (route) => {
+        if (route.request().method() === 'GET') {
+          await route.fulfill({
+            body: JSON.stringify(conversations),
+            contentType: 'application/json',
+            status: 200,
+          });
+          return;
+        }
         await route.fulfill({
-          body: JSON.stringify(conversations),
+          headers: { location: activeServer.url },
+          status: 307,
+        });
+      });
+      await page.route('**/api/chat/*', async (route) => {
+        if (route.request().method() === 'PATCH') {
+          conversationId = conversationIdFrom(route.request().url());
+          if (
+            conversations.every(
+              (conversation) => conversation.id !== conversationId,
+            )
+          ) {
+            conversations.unshift({
+              id: conversationId,
+              model: INFERENCE_MODEL,
+              title: 'Започни долг одговор.',
+            });
+          }
+          await route.fulfill({ status: 204 });
+          return;
+        }
+        await route.fallback();
+      });
+      await page.route('**/api/chat/*/stop', async (route) => {
+        stopRequests.push(JSON.parse(route.request().postData() ?? '{}'));
+        await route.fulfill({
+          body: JSON.stringify({ aborted: true, stopped: true }),
           contentType: 'application/json',
           status: 200,
         });
-        return;
-      }
-      await route.fulfill({
-        headers: { location: activeServer.url },
-        status: 307,
       });
-    });
-    await page.route('**/api/chat/*', async (route) => {
-      if (route.request().method() === 'PATCH') {
-        conversationId = conversationIdFrom(route.request().url());
-        if (
-          conversations.every(
-            (conversation) => conversation.id !== conversationId,
-          )
-        ) {
-          conversations.unshift({
-            id: conversationId,
-            model: INFERENCE_MODEL,
-            title: 'Започни долг одговор.',
-          });
-        }
+      await page.route('**/api/chat/*/stream', async (route) => {
+        resumeStatuses.push(204);
         await route.fulfill({ status: 204 });
-        return;
-      }
-      await route.fallback();
-    });
-    await page.route('**/api/chat/*/stop', async (route) => {
-      stopRequests.push(JSON.parse(route.request().postData() ?? '{}'));
-      await route.fulfill({
-        body: JSON.stringify({ aborted: true, stopped: true }),
-        contentType: 'application/json',
-        status: 200,
       });
-    });
-    await page.route('**/api/chat/*/stream', async (route) => {
-      resumeStatuses.push(204);
-      await route.fulfill({ status: 204 });
-    });
-    await page.route('**/api/chat/*/history', async (route) => {
-      await route.fulfill({
-        body: emptyHistoryBody(conversationId),
-        contentType: 'application/json',
-        status: 200,
+      await page.route('**/api/chat/*/history', async (route) => {
+        await route.fulfill({
+          body: emptyHistoryBody(conversationId),
+          contentType: 'application/json',
+          status: 200,
+        });
       });
-    });
 
-    await page.goto('/');
-    await page.getByTestId('composer-input').fill('Започни долг одговор.');
-    await page.getByTestId('composer-input').press('Enter');
-    await expect(page.getByTestId('answer-text')).toContainText(STOP_TOKEN);
+      await page.goto('/');
+      await page.getByTestId('composer-model').click();
+      await expect(
+        page.getByTestId('model-free-badge-claude-sonnet-5'),
+      ).toContainText('5/5');
+      await page.keyboard.press('Escape');
+      await page.getByTestId('composer-input').fill('Започни долг одговор.');
+      await page.getByTestId('composer-input').press('Enter');
+      await expect(page.getByTestId('answer-text')).toContainText(STOP_TOKEN);
 
-    // When: the user explicitly stops and refreshes the same chat.
-    await page.getByTestId('composer-submit').click();
-    await expect.poll(() => stopRequests).toHaveLength(1);
-    const noActiveResponse = page.waitForResponse((response) =>
-      CHAT_STREAM_URL_PATTERN.test(response.url()),
-    );
-    await page.reload();
+      // When: the user explicitly stops and refreshes the same chat.
+      await page.getByTestId('composer-submit').click();
+      await expect.poll(() => stopRequests).toHaveLength(1);
+      const noActiveResponse = page.waitForResponse((response) =>
+        CHAT_STREAM_URL_PATTERN.test(response.url()),
+      );
+      await page.reload();
 
-    // Then: reconnect receives 204/no-active instead of replaying the stopped stream.
-    const noActive = await noActiveResponse;
-    expect(noActive.status()).toBe(204);
-    expect(resumeStatuses.length).toBeGreaterThan(0);
-    expect(resumeStatuses.every((status) => status === 204)).toBe(true);
-    expect(stopRequests[0]).toEqual({
-      activeStreamId: RESPONSE_ID,
-    });
-
-    await activeServer.close();
+      // Then: reconnect receives 204/no-active instead of replaying the stopped stream.
+      const noActive = await noActiveResponse;
+      expect(noActive.status()).toBe(204);
+      expect(resumeStatuses.length).toBeGreaterThan(0);
+      expect(resumeStatuses.every((status) => status === 204)).toBe(true);
+      expect(stopRequests[0]).toEqual({
+        activeStreamId: responseId,
+      });
+    } finally {
+      await activeServer.close();
+    }
   });
 });
 

--- a/web/lib/chat-state-client.ts
+++ b/web/lib/chat-state-client.ts
@@ -10,6 +10,13 @@ import { API_BASE_URL, CHAT_API_KEY } from '@/lib/env';
 
 /* eslint-disable camelcase -- Python chat state API uses snake_case fields. */
 
+export type ChatStateActiveStreamStatus =
+  | 'completed'
+  | 'error'
+  | 'pending'
+  | 'stopped'
+  | 'streaming';
+
 export type ChatStateClient = {
   readonly clearActiveStreamIfCurrent: (
     input: ClearActiveStreamInput,
@@ -52,10 +59,14 @@ export type ChatStateClient = {
   readonly upsertUserMessage: (input: UpsertUserMessageInput) => Promise<void>;
 };
 
+export const isResumableChatStreamStatus = (
+  status: ChatStateActiveStreamStatus | null,
+): boolean => status === 'pending' || status === 'streaming';
+
 export type ChatStateConversation = {
   readonly active_replacement_message_id: null | string;
   readonly active_response_id: null | string;
-  readonly active_status: null | string;
+  readonly active_status: ChatStateActiveStreamStatus | null;
   readonly active_stream_id: null | string;
   readonly created_at?: string;
   readonly id: string;

--- a/web/test/chat-history.route.test.ts
+++ b/web/test/chat-history.route.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { ChatStateActiveStreamStatus } from '@/lib/chat-state-client';
+
 /* eslint-disable camelcase -- Test fixtures mirror the Python chat state API wire format. */
 import {
   CONVERSATION_ID,
@@ -12,6 +14,18 @@ import {
 } from './api-chat-route-support';
 
 const STORED_TITLE = 'Stored title';
+
+type ExpectedActiveStream = {
+  readonly id: string;
+  readonly replacementMessageId: null | string;
+};
+
+type StoredConversationOverrides = {
+  readonly active_replacement_message_id?: null | string;
+  readonly active_response_id?: null | string;
+  readonly active_status?: ChatStateActiveStreamStatus | null;
+  readonly active_stream_id?: null | string;
+};
 
 const importGet = async (): Promise<
   (
@@ -33,30 +47,45 @@ const routeContext = () => ({
   params: Promise.resolve({ id: CONVERSATION_ID }),
 });
 
-describe('GET /api/chat/[id]/history', () => {
-  beforeEach(() => {
-    vi.resetModules();
-    resetRouteMocks();
-    installRouteMocks();
-  });
+const getHistory = async (): Promise<Response> =>
+  (await importGet())(historyRequest(), routeContext());
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
+const expectedConversation = (
+  activeStream: ExpectedActiveStream | null = null,
+) => ({
+  activeStream,
+  id: CONVERSATION_ID,
+  model: MODEL,
+  title: STORED_TITLE,
+});
 
+const storedConversation = (overrides: StoredConversationOverrides = {}) => ({
+  active_replacement_message_id: null,
+  active_response_id: null,
+  active_status: null,
+  active_stream_id: null,
+  id: CONVERSATION_ID,
+  model: MODEL,
+  title: STORED_TITLE,
+  user_id: USER_ID,
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.resetModules();
+  resetRouteMocks();
+  installRouteMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('GET /api/chat/[id]/history persisted messages', () => {
   it('returns persisted UI messages for the owner', async () => {
     // Given: the Python API has durable conversation messages for this owner.
     routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
-      conversation: {
-        active_replacement_message_id: null,
-        active_response_id: null,
-        active_status: null,
-        active_stream_id: null,
-        id: CONVERSATION_ID,
-        model: MODEL,
-        title: STORED_TITLE,
-        user_id: USER_ID,
-      },
+      conversation: storedConversation(),
       messages: [
         {
           content: 'Stored question',
@@ -90,21 +119,13 @@ describe('GET /api/chat/[id]/history', () => {
         },
       ],
     });
-    const get = await importGet();
-
     // When: the browser asks for completed history after local storage was cleared.
-    const res = await get(historyRequest(), routeContext());
-    const body: unknown = await res.json();
+    const res = await getHistory();
 
     // Then: the route exposes UI-message history with response id metadata preserved.
     expect(res.status).toBe(200);
-    expect(body).toStrictEqual({
-      conversation: {
-        activeStream: null,
-        id: CONVERSATION_ID,
-        model: MODEL,
-        title: STORED_TITLE,
-      },
+    await expect(res.json()).resolves.toStrictEqual({
+      conversation: expectedConversation(),
       messages: [
         {
           id: '018f0f36-2b1d-7cc0-a50b-5f2d90c91d31',
@@ -145,16 +166,7 @@ describe('GET /api/chat/[id]/history', () => {
   it('falls back to text when persisted parts are absent or invalid', async () => {
     // Given: legacy and malformed rows still have durable text content.
     routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
-      conversation: {
-        active_replacement_message_id: null,
-        active_response_id: null,
-        active_status: null,
-        active_stream_id: null,
-        id: CONVERSATION_ID,
-        model: MODEL,
-        title: STORED_TITLE,
-        user_id: USER_ID,
-      },
+      conversation: storedConversation(),
       messages: [
         {
           content: 'Legacy question',
@@ -175,18 +187,12 @@ describe('GET /api/chat/[id]/history', () => {
     });
 
     // When: history is reconstructed from those rows.
-    const res = await (await importGet())(historyRequest(), routeContext());
-    const body: unknown = await res.json();
+    const res = await getHistory();
 
     // Then: neither turn is dropped and both use their durable text content.
     expect(res.status).toBe(200);
-    expect(body).toStrictEqual({
-      conversation: {
-        activeStream: null,
-        id: CONVERSATION_ID,
-        model: MODEL,
-        title: STORED_TITLE,
-      },
+    await expect(res.json()).resolves.toStrictEqual({
+      conversation: expectedConversation(),
       messages: [
         {
           id: '018f0f36-2b1d-7cc0-a50b-5f2d90c91d33',
@@ -203,39 +209,57 @@ describe('GET /api/chat/[id]/history', () => {
       ],
     });
   });
+});
 
+describe('GET /api/chat/[id]/history active streams', () => {
   it('returns the active regeneration descriptor needed after a refresh', async () => {
     const replacementMessageId = '018f0f36-2b1d-7cc0-a50b-5f2d90c91d35';
     routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
-      conversation: {
+      conversation: storedConversation({
         active_replacement_message_id: replacementMessageId,
         active_response_id: RESPONSE_ID,
         active_status: 'streaming',
         active_stream_id: RESPONSE_ID,
-        id: CONVERSATION_ID,
-        model: MODEL,
-        title: STORED_TITLE,
-        user_id: USER_ID,
-      },
+      }),
       messages: [],
     });
 
-    const res = await (await importGet())(historyRequest(), routeContext());
-    const body: unknown = await res.json();
+    const res = await getHistory();
 
-    expect(body).toStrictEqual({
-      conversation: {
-        activeStream: {
-          id: RESPONSE_ID,
-          replacementMessageId,
-        },
-        id: CONVERSATION_ID,
-        model: MODEL,
-        title: STORED_TITLE,
-      },
+    await expect(res.json()).resolves.toStrictEqual({
+      conversation: expectedConversation({
+        id: RESPONSE_ID,
+        replacementMessageId,
+      }),
       messages: [],
     });
   });
+
+  it.each(['completed', 'stopped', 'error'] as const)(
+    'does not expose a stale active stream when its status is %s',
+    async (activeStatus) => {
+      // Given: terminal persistence still contains a stream id while cleanup races.
+      routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
+        conversation: storedConversation({
+          active_replacement_message_id: RESPONSE_ID,
+          active_response_id: RESPONSE_ID,
+          active_status: activeStatus,
+          active_stream_id: RESPONSE_ID,
+        }),
+        messages: [],
+      });
+
+      // When: the browser restores history after the terminal stream.
+      const res = await getHistory();
+
+      // Then: the HTTP response keeps the conversation shape but exposes no resume descriptor.
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toStrictEqual({
+        conversation: expectedConversation(),
+        messages: [],
+      });
+    },
+  );
 
   it('does not expose history when the API rejects the user', async () => {
     // Given: the API state endpoint rejects this user for the conversation.
@@ -245,7 +269,7 @@ describe('GET /api/chat/[id]/history', () => {
     );
 
     // When: the authenticated user asks for inaccessible completed history.
-    const res = await (await importGet())(historyRequest(), routeContext());
+    const res = await getHistory();
 
     // Then: the route preserves the ownership failure and returns no body.
     expect(res.status).toBe(404);
@@ -259,7 +283,7 @@ describe('GET /api/chat/[id]/history', () => {
       new AuthenticationRequiredError(),
     );
 
-    const res = await (await importGet())(historyRequest(), routeContext());
+    const res = await getHistory();
 
     expect(res.status).toBe(401);
     expect(routeMocks.stateClient.loadConversation).not.toHaveBeenCalled();

--- a/web/test/chat-stream.route.test.ts
+++ b/web/test/chat-stream.route.test.ts
@@ -32,17 +32,17 @@ const routeContext = () => ({
   params: Promise.resolve({ id: CONVERSATION_ID }),
 });
 
+beforeEach(() => {
+  vi.resetModules();
+  resetRouteMocks();
+  installRouteMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe('GET /api/chat/[id]/stream', () => {
-  beforeEach(() => {
-    vi.resetModules();
-    resetRouteMocks();
-    installRouteMocks();
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   it('returns UI-message SSE when the owner has an active Redis stream', async () => {
     // Given: the API state points at a live Redis-backed UI message stream.
     routeMocks.resumableContext.resumeExistingStream.mockResolvedValueOnce(
@@ -214,6 +214,72 @@ describe('GET /api/chat/[id]/stream', () => {
     // Then: missing stale state is treated as an idempotent no-active-stream response.
     expect(res.status).toBe(204);
     await expect(res.text()).resolves.toBe('');
+  });
+});
+
+describe('GET /api/chat/[id]/stream lifecycle states', () => {
+  it.each(['completed', 'stopped', 'error'] as const)(
+    'returns 204 without consulting Redis for a terminal %s stream',
+    async (activeStatus) => {
+      // Given: terminal API state retains a stale stream id while Redis still has a body.
+      routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
+        conversation: {
+          active_replacement_message_id: null,
+          active_response_id: RESPONSE_ID,
+          active_status: activeStatus,
+          active_stream_id: RESPONSE_ID,
+          id: CONVERSATION_ID,
+          user_id: USER_ID,
+        },
+        messages: [],
+      });
+      // When: the owner asks to reconnect after the stream reached its terminal state.
+      const res = await (await importGet())(streamRequest(), routeContext());
+
+      // Then: terminal state wins before Redis can resume or clean up the old stream.
+      expect(res.status).toBe(204);
+      await expect(res.text()).resolves.toBe('');
+      expect(
+        routeMocks.createChatResumableStreamContext,
+      ).not.toHaveBeenCalled();
+      expect(
+        routeMocks.resumableContext.resumeExistingStream,
+      ).not.toHaveBeenCalled();
+      expect(
+        routeMocks.stateClient.clearActiveStreamIfCurrent,
+      ).not.toHaveBeenCalled();
+    },
+  );
+
+  it('returns 204 without clearing a pending stream when registration retries exhaust', async () => {
+    // Given: API state is pending while every Redis registration lookup is absent.
+    routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
+      conversation: {
+        active_replacement_message_id: null,
+        active_response_id: RESPONSE_ID,
+        active_status: 'pending',
+        active_stream_id: RESPONSE_ID,
+        id: CONVERSATION_ID,
+        user_id: USER_ID,
+      },
+      messages: [],
+    });
+    routeMocks.resumableContext.resumeExistingStream.mockResolvedValue(
+      undefined,
+    );
+
+    // When: reconnect outlasts the bounded Postgres-to-Redis registration window.
+    const res = await (await importGet())(streamRequest(), routeContext());
+
+    // Then: the route returns no body without destroying pending API state.
+    expect(res.status).toBe(204);
+    await expect(res.text()).resolves.toBe('');
+    expect(
+      routeMocks.resumableContext.resumeExistingStream,
+    ).toHaveBeenCalledTimes(7);
+    expect(
+      routeMocks.stateClient.clearActiveStreamIfCurrent,
+    ).not.toHaveBeenCalled();
   });
 });
 

--- a/web/test/chat-stream.route.test.ts
+++ b/web/test/chat-stream.route.test.ts
@@ -1,3 +1,5 @@
+import type * as TimersPromises from 'node:timers/promises';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -9,6 +11,30 @@ import {
   sseBody,
   USER_ID,
 } from './api-chat-route-support';
+
+type PromiseTimerMock = (
+  milliseconds?: number,
+  value?: unknown,
+) => Promise<unknown>;
+
+const timerMocks = vi.hoisted(() => ({
+  setTimeout: vi.fn<PromiseTimerMock>((_milliseconds, value) =>
+    Promise.resolve(value),
+  ),
+}));
+
+vi.mock('node:timers/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof TimersPromises>();
+
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      setTimeout: timerMocks.setTimeout,
+    },
+    setTimeout: timerMocks.setTimeout,
+  };
+});
 
 /* eslint-disable camelcase -- Route tests mirror Python chat state API payloads. */
 
@@ -34,6 +60,7 @@ const routeContext = () => ({
 
 beforeEach(() => {
   vi.resetModules();
+  timerMocks.setTimeout.mockClear();
   resetRouteMocks();
   installRouteMocks();
 });
@@ -277,6 +304,7 @@ describe('GET /api/chat/[id]/stream lifecycle states', () => {
     expect(
       routeMocks.resumableContext.resumeExistingStream,
     ).toHaveBeenCalledTimes(7);
+    expect(timerMocks.setTimeout).toHaveBeenCalledTimes(6);
     expect(
       routeMocks.stateClient.clearActiveStreamIfCurrent,
     ).not.toHaveBeenCalled();


### PR DESCRIPTION
Guard resumable chat state against stale or incomplete stream sessions.

## Changes

**Terminal status gating** — history and stream resume routes now check stream status before allowing a session to be resumed, rejecting requests where the stream has already completed or failed.

**Pending preservation** — the chat-state client retains pending state across hydration so in-flight sessions are not prematurely cleared on page load or navigation.

**Deterministic lifecycle fixtures** — the resumable-chat E2E spec is restructured to use stable wait conditions and predictable state transitions, eliminating intermittent failures caused by race conditions in the previous fixture setup.

## Validation

- TypeScript: clean
- Lint: clean
- Vitest: 477 tests passing
- Production build: successful
- Playwright (targeted): 9 lifecycle tests passing
- Playwright (full suite): 34 tests passing