### PR TITLE
fix(web): expand sidebar row click target

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,7 +24,7 @@ The chat UI is an operational product surface: fast, quiet, and readable for stu
 
 ## 5. Components
 
-- Sidebar conversation row: selectable title button plus compact row-action icon buttons that reveal on hover/focus for fine pointers. Coarse pointers use one 44px overflow trigger with labeled generate, rename, and delete menu items so conversation titles keep useful width.
+- Sidebar conversation row: full-row selection button spanning the rounded hover surface, with compact row-action icon buttons layered above it and independently operable on fine pointers. Coarse pointers use one 44px overflow trigger with labeled generate, rename, and delete menu items so conversation titles keep useful width.
 - Row action button: Lucide icon, `size-3.5`, semantic aria label, focus-visible ring, muted default color, stronger hover color matching the action intent, and the existing Radix tooltip using the same localized label on hover or keyboard focus.
 - Destructive row action: use destructive hover color only for delete.
 - Answer sources: automatically expose one or two source cards below a completed answer; larger source sets stay collapsed behind the source-count trigger. The trigger and external source links keep compact fine-pointer sizing and expose at least 44px targets on coarse pointers.

--- a/web/components/shell/conversation-list.tsx
+++ b/web/components/shell/conversation-list.tsx
@@ -80,14 +80,14 @@ export const ConversationList = ({
         {conversations.map((c) => (
           <li
             aria-current={c.id === activeId ? 'true' : undefined}
-            className={`group flex items-center justify-between gap-1 rounded-lg px-2.5 py-1.5 text-sm text-foreground/80 transition-colors duration-150 hover:bg-muted/70 ${
+            className={`group relative isolate flex items-center justify-between gap-1 rounded-lg px-2.5 py-1.5 text-sm text-foreground/80 transition-colors duration-150 hover:bg-muted/70 ${
               c.id === activeId ? 'bg-muted font-medium text-foreground' : ''
             }`}
             data-testid={`conversation-${c.id}`}
             key={c.id}
           >
             <button
-              className="min-h-11 flex-1 truncate rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50 pointer-fine:min-h-0"
+              className="min-h-11 flex-1 truncate rounded-md text-left outline-none before:absolute before:inset-0 before:rounded-lg before:content-[''] focus-visible:before:ring-2 focus-visible:before:ring-ring/50 pointer-fine:min-h-0"
               onClick={() => {
                 onSelect(c.id);
               }}
@@ -95,13 +95,15 @@ export const ConversationList = ({
             >
               {c.title}
             </button>
-            <ConversationRowActions
-              conversation={c}
-              generatingTitleId={generatingTitleId}
-              onDeleteAction={setPendingDelete}
-              onGenerateTitle={onGenerateTitle}
-              onRenameAction={openRename}
-            />
+            <div className="relative z-10 flex shrink-0">
+              <ConversationRowActions
+                conversation={c}
+                generatingTitleId={generatingTitleId}
+                onDeleteAction={setPendingDelete}
+                onGenerateTitle={onGenerateTitle}
+                onRenameAction={openRename}
+              />
+            </div>
           </li>
         ))}
       </ul>

--- a/web/test/conversation-list-a11y.test.tsx
+++ b/web/test/conversation-list-a11y.test.tsx
@@ -22,6 +22,30 @@ const conversations: ConversationRow[] = [
 const noop = vi.fn<() => void>;
 
 describe('ConversationList accessibility', () => {
+  it('uses the whole row as the conversation selection target', () => {
+    render(
+      <ConversationList
+        activeId={null}
+        conversations={conversations}
+        onDelete={noop()}
+        onRename={noop()}
+        onSelect={noop()}
+      />,
+    );
+
+    const item = screen.getByTestId('conversation-c1');
+    const selection = within(item).getByRole('button', {
+      name: 'Прв разговор',
+    });
+
+    expect(item).toHaveClass('relative');
+    expect(selection).toHaveClass('before:absolute', 'before:inset-0');
+    expect(within(item).getByTestId('row-actions').parentElement).toHaveClass(
+      'relative',
+      'z-10',
+    );
+  });
+
   it('keeps row actions discoverable when a keyboard user focuses the row', () => {
     render(
       <ConversationList


### PR DESCRIPTION
## Summary
- Expand the sidebar conversation selection hit target to the full hovered row surface
- Keep row action controls layered above the selection target
- Document and test the row interaction contract

## Verification
- npm test:all
- npm run build with test server environment values
- TypeScript LSP web error scan
- Browser QA: row padding click selected chat; rename action stayed independent; console errors/warnings 0
- Visual QA: 12 fresh captures across 375/768/1280 rest/hover/focus passed independent review