### PR TITLE
fix(web): stop replaying message entrance animations

### DIFF
--- a/web/components/ai-elements/message.tsx
+++ b/web/components/ai-elements/message.tsx
@@ -24,7 +24,7 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
-      "group flex w-full flex-col gap-2 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-2 motion-safe:duration-500",
+      "group flex w-full flex-col gap-2",
       from === "user"
         ? "is-user ml-auto max-w-[85%] items-end"
         : "is-assistant max-w-full",

--- a/web/components/chat/thread.tsx
+++ b/web/components/chat/thread.tsx
@@ -40,6 +40,8 @@ const STAGGER = ['stagger-1', 'stagger-2', 'stagger-3', 'stagger-4'];
 
 const CHIP =
   'group rounded-xl border border-border bg-card/60 px-4 py-3 text-left text-pretty text-sm text-foreground/90 shadow-sm transition-[background-color,border-color,box-shadow,transform] duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:bg-card hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-2 motion-safe:fill-mode-both';
+const MESSAGE_ENTRANCE =
+  'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-2 motion-safe:duration-500';
 
 const Welcome = ({ onPick }: { onPick?: (text: string) => void }) => (
   <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center gap-6 py-12 text-center motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-95 motion-safe:slide-in-from-bottom-4 motion-safe:duration-700">
@@ -118,6 +120,11 @@ export const Thread = ({
               if (m.role === 'user') {
                 return (
                   <Message
+                    className={
+                      streaming && m.id === lastMessage?.id
+                        ? MESSAGE_ENTRANCE
+                        : undefined
+                    }
                     from="user"
                     key={m.id}
                   >
@@ -134,29 +141,36 @@ export const Thread = ({
                 streaming &&
                 lastMessage?.role === 'assistant';
               return (
-                <AssistantMessage
-                  actions={renderActions ? renderActions(m) : undefined}
-                  complete={!activeAssistant}
-                  errorPart={
-                    isLastAssistant
-                      ? (activeError ?? m.metadata?.error)
-                      : m.metadata?.error
-                  }
+                <div
+                  className={activeAssistant ? MESSAGE_ENTRANCE : undefined}
                   key={m.id}
-                  message={m}
-                  onManageCredentials={
-                    isLastAssistant ? onManageCredentials : undefined
-                  }
-                  onRetry={isLastAssistant ? onRetry : undefined}
-                  pending={isLastAssistant && streaming}
-                  statusPart={
-                    isLastAssistant && streaming ? activeStatus : undefined
-                  }
-                />
+                >
+                  <AssistantMessage
+                    actions={renderActions ? renderActions(m) : undefined}
+                    complete={!activeAssistant}
+                    errorPart={
+                      isLastAssistant
+                        ? (activeError ?? m.metadata?.error)
+                        : m.metadata?.error
+                    }
+                    message={m}
+                    onManageCredentials={
+                      isLastAssistant ? onManageCredentials : undefined
+                    }
+                    onRetry={isLastAssistant ? onRetry : undefined}
+                    pending={isLastAssistant && streaming}
+                    statusPart={
+                      isLastAssistant && streaming ? activeStatus : undefined
+                    }
+                  />
+                </div>
               );
             })}
             {awaitingReply ? (
-              <Message from="assistant">
+              <Message
+                className={MESSAGE_ENTRANCE}
+                from="assistant"
+              >
                 <MessageContent>
                   <TypingIndicator />
                 </MessageContent>

--- a/web/test/conversation-switch-runtime.test.tsx
+++ b/web/test/conversation-switch-runtime.test.tsx
@@ -18,6 +18,13 @@ const previousMessage: MyUIMessage = {
   role: 'user',
 };
 
+const freshAssistantMessage: MyUIMessage = {
+  id: 'message-b',
+  metadata: {},
+  parts: [{ text: 'Fresh answer', type: 'text' }],
+  role: 'assistant',
+};
+
 vi.mock('@ai-sdk/react', () => ({
   useChat: (options: UseChatOptions) => ({
     messages: options.id === 'conversation-b' ? [] : [previousMessage],
@@ -101,5 +108,35 @@ describe('conversation switch runtime', () => {
 
     expect(previousMessageShell).toBeInTheDocument();
     expect(previousMessageShell).not.toHaveClass('motion-safe:animate-in');
+  });
+
+  it('animates a newly submitted user message', () => {
+    render(
+      <Thread
+        messages={[previousMessage]}
+        status="submitted"
+      />,
+    );
+
+    const newMessageShell = screen
+      .getByText('Conversation A')
+      .closest('.group');
+
+    expect(newMessageShell).toHaveClass('motion-safe:animate-in');
+  });
+
+  it('animates a newly streaming assistant message', () => {
+    render(
+      <Thread
+        messages={[previousMessage, freshAssistantMessage]}
+        status="streaming"
+      />,
+    );
+
+    const animatedShell = screen
+      .getByText('Fresh answer')
+      .closest('[class~="motion-safe:animate-in"]');
+
+    expect(animatedShell).toBeInTheDocument();
   });
 });

--- a/web/test/conversation-switch-runtime.test.tsx
+++ b/web/test/conversation-switch-runtime.test.tsx
@@ -106,6 +106,12 @@ describe('conversation switch runtime', () => {
       .getByText('Conversation A')
       .closest('.group');
 
+    expect(previousMessageShell).not.toBeNull();
+
+    if (previousMessageShell === null) {
+      throw new Error('Preserved message shell not found');
+    }
+
     expect(previousMessageShell).toBeInTheDocument();
     expect(previousMessageShell).not.toHaveClass('motion-safe:animate-in');
   });
@@ -122,6 +128,12 @@ describe('conversation switch runtime', () => {
       .getByText('Conversation A')
       .closest('.group');
 
+    expect(newMessageShell).not.toBeNull();
+
+    if (newMessageShell === null) {
+      throw new Error('Submitted message shell not found');
+    }
+
     expect(newMessageShell).toHaveClass('motion-safe:animate-in');
   });
 
@@ -136,6 +148,12 @@ describe('conversation switch runtime', () => {
     const animatedShell = screen
       .getByText('Fresh answer')
       .closest('[class~="motion-safe:animate-in"]');
+
+    expect(animatedShell).not.toBeNull();
+
+    if (animatedShell === null) {
+      throw new Error('Streaming assistant animation shell not found');
+    }
 
     expect(animatedShell).toBeInTheDocument();
   });

--- a/web/test/conversation-switch-runtime.test.tsx
+++ b/web/test/conversation-switch-runtime.test.tsx
@@ -85,7 +85,7 @@ describe('conversation switch runtime', () => {
     });
   });
 
-  it('keeps previous messages visible while the selected chat runtime is empty and hydrating', () => {
+  it('keeps previous messages visible without replaying their entrance animation while the selected chat hydrates', () => {
     useUiStore.setState({ activeConversationId: 'conversation-a' });
     render(<RuntimeSwitchHarness />);
 
@@ -94,6 +94,12 @@ describe('conversation switch runtime', () => {
     );
 
     expect(screen.queryByText('Започни разговор')).not.toBeInTheDocument();
-    expect(screen.getByText('Conversation A')).toBeInTheDocument();
+
+    const previousMessageShell = screen
+      .getByText('Conversation A')
+      .closest('.group');
+
+    expect(previousMessageShell).toBeInTheDocument();
+    expect(previousMessageShell).not.toHaveClass('motion-safe:animate-in');
   });
 });


### PR DESCRIPTION
## Summary
- stop persisted chat messages from replaying decorative entrance motion during sidebar conversation switches
- preserve the original entrance motion for newly submitted, streaming, and typing message shells
- preserve the existing thread while the selected conversation hydrates
- add regression coverage that distinguishes hydrated history from live replies

## Root cause
The shared message wrapper unconditionally ran a 500ms entrance animation. During a chat switch, the intentionally preserved previous thread and the newly hydrated thread each replayed that motion, making messages appear and reappear even though message data was not duplicated. The fix keeps shared history static and opts live message states into the original motion from Thread.

## Validation
- npm run check
- npm run lint (22 existing warnings, 0 errors)
- npm run test (485 tests)
- npm run build with required server-only environment placeholders
- headed Playwright chat and reasoning suites (7 scenarios)
- responsive chat-switch capture at 1280, 768, and 375 widths
- independent visual and code re-review after scoping motion to live replies