### PR TITLE
fix(web): normalize regeneration history

### DIFF
--- a/api/app/data/chat_state.py
+++ b/api/app/data/chat_state.py
@@ -58,7 +58,7 @@ async def replace_assistant_message_and_prune_after(
     row = await db.fetchrow(
         """
         WITH target AS (
-            SELECT assistant.id, assistant.conversation_id, assistant.created_at
+            SELECT assistant.id, assistant.conversation_id
             FROM chat_message assistant
             JOIN chat_conversation conversation
               ON conversation.id = assistant.conversation_id
@@ -82,7 +82,6 @@ async def replace_assistant_message_and_prune_after(
             DELETE FROM chat_message stale
             USING target
             WHERE stale.conversation_id = target.conversation_id
-              AND stale.created_at > target.created_at
               AND NOT (stale.id = ANY($9::uuid[]))
             RETURNING stale.id
         )

--- a/api/tests/chat_persistence_fake.py
+++ b/api/tests/chat_persistence_fake.py
@@ -341,7 +341,6 @@ class FakeChatDatabase:
                 stale_id
                 for stale_id, stale in self.messages.items()
                 if stale["conversation_id"] == conversation_id
-                and self._created_at(stale) > self._created_at(target)
                 and stale_id not in retained_ids
             ]
             target["content"] = content

--- a/api/tests/test_chat_state_api.py
+++ b/api/tests/test_chat_state_api.py
@@ -466,7 +466,11 @@ def test_chat_state_replaces_regenerated_assistant_and_prunes_later_messages() -
                 {"state": "done", "text": "New reasoning", "type": "reasoning"},
                 {"state": "done", "text": "New first answer", "type": "text"},
             ],
-            "retained_message_ids": [str(first_user_id), str(first_assistant_id)],
+            "retained_message_ids": [
+                str(setup_message_id),
+                str(first_user_id),
+                str(first_assistant_id),
+            ],
             "user_id": OWNER_ID,
         },
     )

--- a/api/tests/test_chat_state_regeneration.py
+++ b/api/tests/test_chat_state_regeneration.py
@@ -1,0 +1,106 @@
+from datetime import timedelta
+from uuid import UUID, uuid4
+
+from fastapi.testclient import TestClient
+
+from app.data.db import get_db
+from app.main import make_app
+from app.utils.settings import Settings
+from tests.chat_persistence_fake import FakeChatDatabase
+
+OWNER_ID = "00000000-0000-4000-8000-000000000001"
+
+
+def _client(db: FakeChatDatabase) -> TestClient:
+    app = make_app(
+        Settings(
+            API_KEY="test-api-key",
+            BYOK_ALLOWED_BASE_URLS="https://api.openai.com/v1",
+            CREDENTIAL_ENCRYPTION_KEY="test-credential-key",
+            MCP_API_KEY="test-mcp-key",
+        ),
+    )
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def _message(
+    db: FakeChatDatabase,
+    *,
+    conversation_id: UUID,
+    index: int,
+    message_id: UUID,
+    role: str,
+) -> None:
+    db.messages[message_id] = {
+        "content": f"{role} {index}",
+        "conversation_id": conversation_id,
+        "created_at": db.now + timedelta(seconds=index),
+        "id": message_id,
+        "metadata": {},
+        "response_id": None,
+        "role": role,
+        "updated_at": db.now,
+    }
+
+
+def test_replacement_prunes_every_message_outside_retained_window() -> None:
+    # Given: an earlier stale assistant and a later turn surround the target answer.
+    db = FakeChatDatabase()
+    client = _client(db)
+    conversation_id = uuid4()
+    setup_user_id = uuid4()
+    stale_assistant_id = uuid4()
+    current_user_id = uuid4()
+    target_message_id = uuid4()
+    later_user_id = uuid4()
+    active_stream_id = uuid4()
+    headers = {"x-api-key": "test-api-key"}
+    client.post(
+        "/chat/state/conversations",
+        headers=headers,
+        json={"id": str(conversation_id), "user_id": OWNER_ID},
+    )
+    for index, message_id, role in (
+        (0, setup_user_id, "user"),
+        (1, stale_assistant_id, "assistant"),
+        (2, current_user_id, "user"),
+        (3, target_message_id, "assistant"),
+        (4, later_user_id, "user"),
+    ):
+        _message(
+            db,
+            conversation_id=conversation_id,
+            index=index,
+            message_id=message_id,
+            role=role,
+        )
+    client.put(
+        f"/chat/state/conversations/{conversation_id}/active-stream",
+        headers=headers,
+        json={
+            "active_replacement_message_id": str(target_message_id),
+            "active_response_id": str(active_stream_id),
+            "active_status": "streaming",
+            "active_stream_id": str(active_stream_id),
+            "user_id": OWNER_ID,
+        },
+    )
+
+    # When: replacement completion declares the authoritative retained window.
+    retained_ids = [setup_user_id, current_user_id, target_message_id]
+    response = client.put(
+        f"/chat/state/conversations/{conversation_id}/messages/assistant/{target_message_id}/replacement/{active_stream_id}",
+        headers=headers,
+        json={
+            "active_stream_id": str(active_stream_id),
+            "content": "Replacement answer",
+            "retained_message_ids": [str(message_id) for message_id in retained_ids],
+            "user_id": OWNER_ID,
+        },
+    )
+
+    # Then: only the retained server-owned message window remains persisted.
+    assert response.status_code == 200
+    assert set(db.messages) == set(retained_ids)
+    assert db.messages[target_message_id]["content"] == "Replacement answer"

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -15,10 +15,10 @@ import {
   assistantState,
   lastUserMessageForState,
   persistedTurns,
+  retainedServerMessageIdsForRegeneration,
 } from '@/lib/chat-route-state';
 import {
   type ChatStateClient,
-  type ChatStateJsonValue,
   ChatStateRequestError,
   createChatStateClient,
 } from '@/lib/chat-state-client';
@@ -112,34 +112,6 @@ const regeneratedMessageId = (body: ResumableChatClientBody): null | string =>
   body.messageId.length > 0
     ? body.messageId
     : null;
-
-const isChatStateRecord = (
-  value: ChatStateJsonValue,
-): value is Readonly<Record<string, ChatStateJsonValue>> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const idFromChatStateMessage = (value: ChatStateJsonValue): null | string => {
-  if (!isChatStateRecord(value)) {
-    return null;
-  }
-  const id = value['id'];
-  return typeof id === 'string' ? id : null;
-};
-
-const retainedServerMessageIdsForRegeneration = (
-  messages: readonly ChatStateJsonValue[],
-  messageId: string,
-): null | readonly string[] => {
-  const targetIndex = messages.findIndex(
-    (message) => idFromChatStateMessage(message) === messageId,
-  );
-  return targetIndex === -1
-    ? null
-    : messages.slice(0, targetIndex + 1).flatMap((message) => {
-        const id = idFromChatStateMessage(message);
-        return id === null ? [] : [id];
-      });
-};
 
 const regenerationReplacementFor = (
   messageId: null | string,

--- a/web/lib/chat-route-state.ts
+++ b/web/lib/chat-route-state.ts
@@ -71,8 +71,21 @@ export const persistedTurns = (
     return turn === null ? [] : [turn];
   });
   const currentIndex = turns.findIndex((turn) => turn.id === currentMessageId);
-  const previousTurns =
+  const candidateTurns =
     currentIndex === -1 ? turns : turns.slice(0, currentIndex);
+  const regenerationUserIndex =
+    turns[currentIndex]?.role === 'assistant'
+      ? candidateTurns.findLastIndex((turn) => turn.role === 'user')
+      : null;
+
+  if (regenerationUserIndex === -1) {
+    throw new TypeError('Regeneration history requires a prior user turn');
+  }
+
+  const previousTurns =
+    regenerationUserIndex === null
+      ? candidateTurns
+      : candidateTurns.slice(0, regenerationUserIndex + 1);
   const historyLimit = Math.max(0, MAX_MESSAGES - requestTurnCount);
 
   return previousTurns.slice(-historyLimit).map((turn) => ({

--- a/web/lib/chat-route-state.ts
+++ b/web/lib/chat-route-state.ts
@@ -94,6 +94,36 @@ export const persistedTurns = (
   }));
 };
 
+export const retainedServerMessageIdsForRegeneration = (
+  messages: readonly ChatStateJsonValue[],
+  messageId: string,
+): null | readonly string[] => {
+  const turns = messages.flatMap((message) => {
+    const turn = persistedTurnFrom(message);
+
+    return turn === null ? [] : [turn];
+  });
+  const targetIndex = turns.findIndex((turn) => turn.id === messageId);
+  const target = turns[targetIndex];
+
+  if (target?.role !== 'assistant') {
+    return null;
+  }
+
+  const priorUserIndex = turns
+    .slice(0, targetIndex)
+    .findLastIndex((turn) => turn.role === 'user');
+
+  if (priorUserIndex === -1) {
+    return null;
+  }
+
+  return [
+    ...turns.slice(0, priorUserIndex + 1).map((turn) => turn.id),
+    target.id,
+  ];
+};
+
 export const lastUserMessageForState = (
   message: MyUIMessage | undefined,
 ): null | UserMessageForState => {

--- a/web/test/api-chat-regeneration-target.route.test.ts
+++ b/web/test/api-chat-regeneration-target.route.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/* eslint-disable camelcase -- fixtures mirror the Python API wire contract. */
+import {
+  CONVERSATION_ID,
+  installRouteMocks,
+  JSON_CONTENT_TYPE,
+  MODEL,
+  resetRouteMocks,
+  RESPONSE_ID,
+  routeMocks,
+  sseBody,
+  USER_ID,
+} from './api-chat-route-support';
+
+const persistedMessage = (
+  id: string,
+  role: 'assistant' | 'user',
+  content: string,
+) => ({
+  content,
+  id,
+  metadata: {},
+  response_id: role === 'assistant' ? id : null,
+  role,
+});
+
+describe('POST /api/chat regeneration target', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetRouteMocks();
+    installRouteMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(sseBody('event: done\ndata: {}\n\n'), {
+          headers: {
+            'content-type': 'text/event-stream',
+            'X-Response-Id': RESPONSE_ID,
+          },
+          status: 200,
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects a persisted user message used as the regeneration target', async () => {
+    // Given a browser request that points regeneration at the second persisted user.
+    routeMocks.stateClient.loadConversation.mockResolvedValueOnce({
+      conversation: {
+        active_replacement_message_id: null,
+        active_response_id: null,
+        active_status: null,
+        active_stream_id: null,
+        id: CONVERSATION_ID,
+        model: MODEL,
+        title: 'Stored title',
+        user_id: USER_ID,
+      },
+      messages: [
+        persistedMessage('u1', 'user', 'First question'),
+        persistedMessage('a1', 'assistant', 'First answer'),
+        persistedMessage('u2', 'user', 'Second question'),
+      ],
+    });
+    const request = new Request('http://localhost/api/chat', {
+      body: JSON.stringify({
+        id: CONVERSATION_ID,
+        messageId: 'u2',
+        messages: [
+          {
+            id: 'u1',
+            parts: [{ text: 'First question', type: 'text' }],
+            role: 'user',
+          },
+          {
+            id: 'a1',
+            parts: [{ text: 'First answer', type: 'text' }],
+            role: 'assistant',
+          },
+          {
+            id: 'u2',
+            parts: [{ text: 'Second question', type: 'text' }],
+            role: 'user',
+          },
+        ],
+        model: MODEL,
+        trigger: 'regenerate-message',
+      }),
+      headers: { 'content-type': JSON_CONTENT_TYPE },
+      method: 'POST',
+    });
+
+    // When the BFF validates the target against server-owned state.
+    const { POST } = await import('@/app/api/chat/route');
+    const response = await POST(request);
+    const body = await response.text();
+
+    // Then it returns a stream error without starting persistence or inference.
+    expect(body).toContain('data-error');
+    expect(fetch).not.toHaveBeenCalled();
+    expect(routeMocks.stateClient.upsertUserMessage).not.toHaveBeenCalled();
+    expect(routeMocks.stateClient.setActiveStream).not.toHaveBeenCalled();
+  });
+});
+
+/* eslint-enable camelcase -- fixture scope ends here. */

--- a/web/test/chat-route-state.test.ts
+++ b/web/test/chat-route-state.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { persistedTurns } from '@/lib/chat-route-state';
+
+describe('persistedTurns', () => {
+  it('ends regeneration history at the latest user when a stale assistant precedes the target', () => {
+    // Given persisted state with an earlier assistant immediately before the target.
+    const messages = [
+      { content: 'Current question', id: 'user-1', role: 'user' },
+      { content: 'Stale answer', id: 'assistant-stale', role: 'assistant' },
+      { content: 'Target answer', id: 'assistant-target', role: 'assistant' },
+    ];
+
+    // When history is prepared for regenerating the target assistant.
+    const turns = persistedTurns(messages, 'assistant-target', 1);
+
+    // Then the API payload still ends with the user turn that drives regeneration.
+    expect(turns).toStrictEqual([
+      { content: 'Current question', role: 'user' },
+    ]);
+  });
+
+  it('rejects regeneration when the target has no prior user turn', () => {
+    // Given malformed persisted state containing only the target assistant.
+    const messages = [
+      { content: 'Orphan answer', id: 'assistant-target', role: 'assistant' },
+    ];
+
+    // When history is prepared for regenerating the orphan target.
+    const prepareHistory = () =>
+      persistedTurns(messages, 'assistant-target', 1);
+
+    // Then the BFF stops before forwarding an empty payload to FastAPI.
+    expect(prepareHistory).toThrow(
+      'Regeneration history requires a prior user turn',
+    );
+  });
+});

--- a/web/test/chat-route-state.test.ts
+++ b/web/test/chat-route-state.test.ts
@@ -1,18 +1,29 @@
 import { describe, expect, it } from 'vitest';
 
-import { persistedTurns } from '@/lib/chat-route-state';
+import {
+  persistedTurns,
+  retainedServerMessageIdsForRegeneration,
+} from '@/lib/chat-route-state';
+
+const ASSISTANT_ROLE = 'assistant';
+const TARGET_ASSISTANT_ID = 'assistant-target';
+const USER_ROLE = 'user';
 
 describe('persistedTurns', () => {
   it('ends regeneration history at the latest user when a stale assistant precedes the target', () => {
     // Given persisted state with an earlier assistant immediately before the target.
     const messages = [
-      { content: 'Current question', id: 'user-1', role: 'user' },
-      { content: 'Stale answer', id: 'assistant-stale', role: 'assistant' },
-      { content: 'Target answer', id: 'assistant-target', role: 'assistant' },
+      { content: 'Current question', id: 'user-1', role: USER_ROLE },
+      { content: 'Stale answer', id: 'assistant-stale', role: ASSISTANT_ROLE },
+      {
+        content: 'Target answer',
+        id: TARGET_ASSISTANT_ID,
+        role: ASSISTANT_ROLE,
+      },
     ];
 
     // When history is prepared for regenerating the target assistant.
-    const turns = persistedTurns(messages, 'assistant-target', 1);
+    const turns = persistedTurns(messages, TARGET_ASSISTANT_ID, 1);
 
     // Then the API payload still ends with the user turn that drives regeneration.
     expect(turns).toStrictEqual([
@@ -23,16 +34,69 @@ describe('persistedTurns', () => {
   it('rejects regeneration when the target has no prior user turn', () => {
     // Given malformed persisted state containing only the target assistant.
     const messages = [
-      { content: 'Orphan answer', id: 'assistant-target', role: 'assistant' },
+      {
+        content: 'Orphan answer',
+        id: TARGET_ASSISTANT_ID,
+        role: ASSISTANT_ROLE,
+      },
     ];
 
     // When history is prepared for regenerating the orphan target.
     const prepareHistory = () =>
-      persistedTurns(messages, 'assistant-target', 1);
+      persistedTurns(messages, TARGET_ASSISTANT_ID, 1);
 
     // Then the BFF stops before forwarding an empty payload to FastAPI.
     expect(prepareHistory).toThrow(
       'Regeneration history requires a prior user turn',
     );
+  });
+});
+
+describe('retainedServerMessageIdsForRegeneration', () => {
+  it('excludes stale assistants between the latest user and target assistant', () => {
+    // Given persisted state with a stale assistant immediately before the target.
+    const messages = [
+      { content: 'Earlier question', id: 'user-1', role: USER_ROLE },
+      { content: 'Earlier answer', id: 'assistant-1', role: ASSISTANT_ROLE },
+      { content: 'Current question', id: 'user-2', role: USER_ROLE },
+      { content: 'Stale answer', id: 'assistant-stale', role: ASSISTANT_ROLE },
+      {
+        content: 'Target answer',
+        id: TARGET_ASSISTANT_ID,
+        role: ASSISTANT_ROLE,
+      },
+    ];
+
+    // When the server-owned replacement window is derived.
+    const retainedIds = retainedServerMessageIdsForRegeneration(
+      messages,
+      TARGET_ASSISTANT_ID,
+    );
+
+    // Then valid history, the latest user, and the target remain without the stale answer.
+    expect(retainedIds).toStrictEqual([
+      'user-1',
+      'assistant-1',
+      'user-2',
+      TARGET_ASSISTANT_ID,
+    ]);
+  });
+
+  it('rejects a persisted user message as the regeneration target', () => {
+    // Given persisted state containing a user ID supplied as the target.
+    const messages = [
+      { content: 'Earlier question', id: 'user-1', role: USER_ROLE },
+      { content: 'Earlier answer', id: 'assistant-1', role: ASSISTANT_ROLE },
+      { content: 'Current question', id: 'user-2', role: USER_ROLE },
+    ];
+
+    // When the target is validated against the persisted role.
+    const retainedIds = retainedServerMessageIdsForRegeneration(
+      messages,
+      'user-2',
+    );
+
+    // Then no replacement window is accepted.
+    expect(retainedIds).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- trim persisted regeneration history through the latest user turn
- reject malformed assistant targets before calling the upstream chat API
- cover stale and orphan assistant histories with focused regression tests

## Root cause
The deployed BFF sent persisted regeneration history ending in an earlier assistant row. FastAPI rejected the payload with HTTP 422 before inference because chat history must be non-empty and end with a user turn. The BFF converted that response into a generic stream error, so the browser console and network tab remained clean.

## Verification
- `npm test` (81 files, 485 tests)
- `npm run check`
- `npm run lint` (0 errors; 22 pre-existing warnings)
- production `npm run build` with local server env placeholders
- headed Chromium `e2e/regeneration-refresh.spec.ts`
- independent goal, QA, code-quality, security, and context reviews passed