### PR TITLE
fix(web): prevent stale sign-in actions after deploys

### DIFF
--- a/.github/workflows/docker-web.yaml
+++ b/.github/workflows/docker-web.yaml
@@ -17,5 +17,6 @@ jobs:
       package-name: chat-bot-web
       cache-backend: registry
       build-args: |
+        NEXT_DEPLOYMENT_ID=${{ github.sha }}
         NEXT_PUBLIC_POSTHOG_KEY=${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
     secrets: inherit

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -16,8 +16,10 @@ COPY . .
 # Empty by default = analytics off; CI supplies it via --build-arg NEXT_PUBLIC_POSTHOG_KEY=... to enable.
 ARG NEXT_PUBLIC_POSTHOG_KEY=
 ARG NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+ARG NEXT_DEPLOYMENT_ID=
 ENV NEXT_PUBLIC_POSTHOG_KEY=$NEXT_PUBLIC_POSTHOG_KEY
 ENV NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST
+ENV NEXT_DEPLOYMENT_ID=$NEXT_DEPLOYMENT_ID
 RUN API_BASE_URL="http://localhost:8880" \
   AUTH_GOOGLE_ID="build-time-google-client-id" \
   AUTH_GOOGLE_SECRET="build-time-google-client-secret" \

--- a/web/app/signin/page.tsx
+++ b/web/app/signin/page.tsx
@@ -1,17 +1,7 @@
-import type { IconType } from 'react-icons';
-
-import { ArrowRight } from 'lucide-react';
-import { AuthError } from 'next-auth';
 import { redirect } from 'next/navigation';
-import { BsGoogle, BsMicrosoft } from 'react-icons/bs';
 
-import {
-  auth,
-  type AuthProviderId,
-  isAuthConfigured,
-  providerMap,
-  signIn,
-} from '@/auth';
+import { ProviderButtons } from '@/app/signin/provider-buttons';
+import { auth, isAuthConfigured, providerMap } from '@/auth';
 import { ChatShowcase } from '@/components/auth/chat-showcase';
 import { getSafeCallbackUrl } from '@/lib/callback-url';
 
@@ -21,11 +11,6 @@ type SignInPageProps = {
     readonly error?: string;
   }>;
 };
-
-const providerIcons = {
-  google: BsGoogle,
-  'microsoft-entra-id': BsMicrosoft,
-} satisfies Record<AuthProviderId, IconType>;
 
 const SignInPage = async ({ searchParams }: SignInPageProps) => {
   const [{ callbackUrl, error }, session] = await Promise.all([
@@ -86,46 +71,10 @@ const SignInPage = async ({ searchParams }: SignInPageProps) => {
                   подоцна.
                 </p>
               ) : (
-                providerMap.map((provider) => {
-                  const ProviderIcon = providerIcons[provider.id];
-
-                  return (
-                    <form
-                      action={async () => {
-                        'use server';
-
-                        try {
-                          await signIn(provider.id, {
-                            redirectTo: safeCallbackUrl,
-                          });
-                        } catch (signInError) {
-                          if (signInError instanceof AuthError) {
-                            redirect('/signin?error=OAuthSignin');
-                          }
-                          throw signInError;
-                        }
-                      }}
-                      key={provider.id}
-                    >
-                      <button
-                        className="group flex w-full items-center justify-between rounded-2xl border border-border bg-card px-4 py-3 text-left text-sm font-medium transition-[border-color,background-color,transform] hover:border-primary/60 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:translate-y-px motion-reduce:transform-none motion-reduce:transition-none"
-                        type="submit"
-                      >
-                        <span className="flex items-center gap-3">
-                          <ProviderIcon
-                            aria-hidden="true"
-                            className="h-4 w-4 shrink-0"
-                          />
-                          <span>Продолжи со {provider.name}</span>
-                        </span>
-                        <ArrowRight
-                          aria-hidden="true"
-                          className="h-4 w-4 text-muted-foreground group-hover:text-primary motion-safe:transition-[color,transform] motion-safe:group-hover:translate-x-0.5"
-                        />
-                      </button>
-                    </form>
-                  );
-                })
+                <ProviderButtons
+                  callbackUrl={safeCallbackUrl}
+                  providers={providerMap}
+                />
               )}
             </div>
           </section>

--- a/web/app/signin/provider-buttons.tsx
+++ b/web/app/signin/provider-buttons.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import type { IconType } from 'react-icons';
+
+import { ArrowRight } from 'lucide-react';
+import { signIn } from 'next-auth/react';
+import { useRef, useState } from 'react';
+import { BsGoogle, BsMicrosoft } from 'react-icons/bs';
+
+import type { AuthProviderId } from '@/auth';
+
+import { fireAndForget } from '@/lib/async';
+
+type AuthProvider = {
+  readonly id: AuthProviderId;
+  readonly name: string;
+};
+
+type ProviderButtonsProps = {
+  readonly callbackUrl: string;
+  readonly providers: readonly AuthProvider[];
+};
+
+const providerIcons = {
+  google: BsGoogle,
+  'microsoft-entra-id': BsMicrosoft,
+} satisfies Record<AuthProviderId, IconType>;
+
+export const ProviderButtons = ({
+  callbackUrl,
+  providers,
+}: ProviderButtonsProps) => {
+  const signInPendingRef = useRef(false);
+  const [isPending, setIsPending] = useState(false);
+
+  const clearPending = (): void => {
+    signInPendingRef.current = false;
+    setIsPending(false);
+  };
+
+  const beginSignIn = async (providerId: AuthProviderId): Promise<void> => {
+    if (signInPendingRef.current) {
+      return;
+    }
+    signInPendingRef.current = true;
+    setIsPending(true);
+    try {
+      await signIn(providerId, {
+        redirectTo: callbackUrl,
+      });
+    } catch (error: unknown) {
+      clearPending();
+      throw error;
+    }
+  };
+
+  return providers.map((provider) => {
+    const ProviderIcon = providerIcons[provider.id];
+
+    return (
+      <button
+        aria-busy={isPending}
+        className="group flex w-full items-center justify-between rounded-2xl border border-border bg-card px-4 py-3 text-left text-sm font-medium transition-[border-color,background-color,transform] hover:border-primary/60 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:translate-y-px disabled:cursor-wait disabled:opacity-70 motion-reduce:transform-none motion-reduce:transition-none"
+        disabled={isPending}
+        key={provider.id}
+        onClick={() => {
+          fireAndForget(beginSignIn(provider.id));
+        }}
+        type="button"
+      >
+        <span className="flex items-center gap-3">
+          <ProviderIcon
+            aria-hidden="true"
+            className="h-4 w-4 shrink-0"
+          />
+          <span>Продолжи со {provider.name}</span>
+        </span>
+        <ArrowRight
+          aria-hidden="true"
+          className="h-4 w-4 text-muted-foreground group-hover:text-primary motion-safe:transition-[color,transform] motion-safe:group-hover:translate-x-0.5"
+        />
+      </button>
+    );
+  });
+};

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,6 +1,11 @@
 import type { NextConfig } from 'next';
 
+const configuredDeploymentId = process.env['NEXT_DEPLOYMENT_ID']?.trim();
+const deploymentId =
+  configuredDeploymentId === '' ? undefined : configuredDeploymentId;
+
 const nextConfig: NextConfig = {
+  deploymentId,
   output: 'standalone',
   outputFileTracingRoot: import.meta.dirname,
   reactStrictMode: true,

--- a/web/test/next-config.test.ts
+++ b/web/test/next-config.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('next config', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('uses the build deployment ID', async () => {
+    // Given
+    vi.stubEnv('NEXT_DEPLOYMENT_ID', 'deployment-commit');
+
+    // When
+    const { default: nextConfig } = await import('../next.config');
+
+    // Then
+    expect(nextConfig.deploymentId).toBe('deployment-commit');
+  });
+
+  it('leaves deployment version detection disabled for blank IDs', async () => {
+    // Given
+    vi.stubEnv('NEXT_DEPLOYMENT_ID', ' '.repeat(3));
+
+    // When
+    const { default: nextConfig } = await import('../next.config');
+
+    // Then
+    expect(nextConfig.deploymentId).toBeUndefined();
+  });
+});

--- a/web/test/signin-page.test.tsx
+++ b/web/test/signin-page.test.tsx
@@ -1,22 +1,23 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   authMock,
   authState,
+  clientSignInMock,
   getSafeCallbackUrlMock,
   redirectMock,
-  signInMock,
 } = vi.hoisted(() => ({
   authMock: vi.fn<() => Promise<null>>(),
   authState: {
     providerMap: [{ id: 'google' as const, name: 'Google' }],
   },
+  clientSignInMock: vi.fn<() => Promise<void>>(),
   getSafeCallbackUrlMock: vi.fn<(callbackUrl?: string) => string>(() => '/'),
   redirectMock: vi.fn<(url: string) => never>((url) => {
     throw new Error(`redirect:${url}`);
   }),
-  signInMock: vi.fn<() => Promise<void>>(),
 }));
 
 vi.mock('@/auth', () => ({
@@ -25,15 +26,14 @@ vi.mock('@/auth', () => ({
   get providerMap() {
     return authState.providerMap;
   },
-  signIn: signInMock,
 }));
 
 vi.mock('@/lib/callback-url', () => ({
   getSafeCallbackUrl: getSafeCallbackUrlMock,
 }));
 
-vi.mock('next-auth', () => ({
-  AuthError: class AuthError extends Error {},
+vi.mock('next-auth/react', () => ({
+  signIn: clientSignInMock,
 }));
 
 vi.mock('next/navigation', () => ({
@@ -42,6 +42,7 @@ vi.mock('next/navigation', () => ({
 
 const defaultSearchParams = Promise.resolve({});
 const oauthErrorSearchParams = Promise.resolve({ error: 'OAuthSignin' });
+const GOOGLE_SIGN_IN_LABEL = 'Продолжи со Google';
 
 const renderSignInPage = async (
   searchParams = defaultSearchParams,
@@ -57,11 +58,11 @@ describe('SignInPage', () => {
     vi.resetModules();
     authMock.mockReset();
     authMock.mockResolvedValue(null);
+    clientSignInMock.mockReset();
+    clientSignInMock.mockResolvedValue(undefined);
     getSafeCallbackUrlMock.mockClear();
     authState.providerMap = [{ id: 'google', name: 'Google' }];
     redirectMock.mockClear();
-    signInMock.mockReset();
-    signInMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -75,15 +76,71 @@ describe('SignInPage', () => {
       'Имаш прашање за ФИНКИ?',
     );
     expect(
-      screen.getByRole('button', { name: 'Продолжи со Google' }),
+      screen.getByRole('button', { name: GOOGLE_SIGN_IN_LABEL }),
     ).toBeVisible();
+  });
+
+  it('starts OAuth sign-in from the current browser build', async () => {
+    // Given
+    const user = userEvent.setup();
+    getSafeCallbackUrlMock.mockReturnValue('/chat');
+    await renderSignInPage(Promise.resolve({ callbackUrl: '/chat' }));
+
+    // When
+    await user.click(
+      screen.getByRole('button', { name: GOOGLE_SIGN_IN_LABEL }),
+    );
+
+    // Then
+    expect(clientSignInMock).toHaveBeenCalledWith('google', {
+      redirectTo: '/chat',
+    });
+  });
+
+  it('starts only one OAuth handshake for repeated clicks', async () => {
+    // Given
+    const user = userEvent.setup();
+    clientSignInMock.mockReturnValue(new Promise<void>(() => {}));
+    await renderSignInPage();
+    const providerButton = screen.getByRole('button', {
+      name: GOOGLE_SIGN_IN_LABEL,
+    });
+
+    // When
+    await user.dblClick(providerButton);
+
+    // Then
+    expect(clientSignInMock).toHaveBeenCalledOnce();
+    expect(providerButton).toBeDisabled();
+    expect(providerButton).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('allows retry after OAuth initiation rejects', async () => {
+    // Given
+    const user = userEvent.setup();
+    const signInError = new Error('network unavailable');
+    clientSignInMock.mockRejectedValueOnce(signInError);
+    await renderSignInPage();
+    const providerButton = screen.getByRole('button', {
+      name: GOOGLE_SIGN_IN_LABEL,
+    });
+
+    // When
+    await user.click(providerButton);
+
+    // Then
+    await waitFor(() => {
+      expect(providerButton).toBeEnabled();
+    });
+
+    expect(reportError).toHaveBeenCalledWith(signInError);
   });
 
   it('limits provider arrow movement to motion-safe preferences', async () => {
     await renderSignInPage();
 
     const providerButton = screen.getByRole('button', {
-      name: 'Продолжи со Google',
+      name: GOOGLE_SIGN_IN_LABEL,
     });
     const arrow = providerButton.querySelector('.lucide-arrow-right');
 


### PR DESCRIPTION
## Summary
- move OAuth initiation from a compiler-generated Server Action to Auth.js client sign-in
- prevent duplicate OAuth handshakes while navigation is pending
- stamp web builds with the Git commit SHA for Next.js deployment skew detection

## Root cause
Production logged two `Failed to find Server Action` errors immediately after the web container was replaced. Browsers still carrying the previous build submitted stale action IDs that the new build could not resolve. `deploymentId` alone did not recover stale Server Action submissions in Next.js 16.2.10 during manual reproduction, so the sign-in action is now client-side; deployment IDs remain enabled for navigation/version skew protection.

## Verification
- 496 web tests passed
- TypeScript check passed
- ESLint passed with 0 errors and 22 pre-existing warnings
- production Docker images built with the actual base and branch SHAs
- stale old-build page against the new container produced exactly one Auth.js sign-in POST, no `next-action` request, and zero browser/server errors
- responsive visual QA passed at mobile, tablet, desktop, hover, focus, and pending states
- final goal, QA, code-quality, security, and context reviews passed