### PR TITLE
feat(api): link retrieved document sources

### DIFF
--- a/api/app/data/documents.py
+++ b/api/app/data/documents.py
@@ -136,6 +136,7 @@ async def get_closest_chunks(
         c.section,
         d.name AS document_name,
         d.title AS document_title,
+        d.metadata->>'source_url' AS document_url,
         {embedding.distance_operand} <=> {embedding.query_operand} AS distance
     FROM chunk c
     JOIN document d ON d.id = c.document_id
@@ -159,6 +160,7 @@ async def get_closest_chunks(
             document_id=row["document_id"],
             document_name=row["document_name"],
             document_title=row["document_title"],
+            document_url=row.get("document_url"),
             chunk_index=row["chunk_index"],
             section=row["section"],
             content=row["content"],
@@ -200,7 +202,8 @@ async def get_chunks_window(
     )
     window_sql = f"""
         SELECT c.id, c.document_id, c.chunk_index, c.content, c.section,
-               d.name AS document_name, d.title AS document_title
+               d.name AS document_name, d.title AS document_title,
+               d.metadata->>'source_url' AS document_url
         FROM chunk c
         JOIN document d ON d.id = c.document_id
         WHERE c.document_id = ANY($1::uuid[]) AND c.chunk_index = ANY($2::int[])
@@ -226,6 +229,7 @@ def _window_chunk(row: Record) -> ChunkSchema:
         document_id=row["document_id"],
         document_name=row["document_name"],
         document_title=row["document_title"],
+        document_url=row.get("document_url"),
         chunk_index=row["chunk_index"],
         section=row["section"],
         content=row["content"],

--- a/api/app/data/documents.py
+++ b/api/app/data/documents.py
@@ -19,6 +19,7 @@ from app.llms.models import (
     Model,
     is_bge_m3_lifecycle_model,
 )
+from app.schemas.document_sources import resolve_document_source_url
 from app.schemas.documents import ChunkSchema, DocumentSchema, IngestDocumentSchema
 from app.utils.database import embedding_to_pgvector
 
@@ -136,7 +137,8 @@ async def get_closest_chunks(
         c.section,
         d.name AS document_name,
         d.title AS document_title,
-        d.metadata->>'source_url' AS document_url,
+        d.metadata->>'source_url' AS document_source_url,
+        d.metadata->>'source_file' AS document_source_file,
         {embedding.distance_operand} <=> {embedding.query_operand} AS distance
     FROM chunk c
     JOIN document d ON d.id = c.document_id
@@ -160,7 +162,10 @@ async def get_closest_chunks(
             document_id=row["document_id"],
             document_name=row["document_name"],
             document_title=row["document_title"],
-            document_url=row.get("document_url"),
+            document_url=resolve_document_source_url(
+                row.get("document_source_url"),
+                row.get("document_source_file"),
+            ),
             chunk_index=row["chunk_index"],
             section=row["section"],
             content=row["content"],
@@ -202,8 +207,7 @@ async def get_chunks_window(
     )
     window_sql = f"""
         SELECT c.id, c.document_id, c.chunk_index, c.content, c.section,
-               d.name AS document_name, d.title AS document_title,
-               d.metadata->>'source_url' AS document_url
+               d.name AS document_name, d.title AS document_title
         FROM chunk c
         JOIN document d ON d.id = c.document_id
         WHERE c.document_id = ANY($1::uuid[]) AND c.chunk_index = ANY($2::int[])
@@ -229,7 +233,6 @@ def _window_chunk(row: Record) -> ChunkSchema:
         document_id=row["document_id"],
         document_name=row["document_name"],
         document_title=row["document_title"],
-        document_url=row.get("document_url"),
         chunk_index=row["chunk_index"],
         section=row["section"],
         content=row["content"],

--- a/api/app/llms/context.py
+++ b/api/app/llms/context.py
@@ -169,6 +169,16 @@ def _chunk_candidate(c: ChunkSchema) -> _Candidate:
             kind="chunk",
             title=c.document_title,
             chunk_index=c.chunk_index,
+            links=(
+                (
+                    RetrievalSourceLink(
+                        label=c.document_title,
+                        url=str(c.document_url),
+                    ),
+                )
+                if c.document_url
+                else ()
+            ),
             section=c.section,
             snippet=c.content,
         ),

--- a/api/app/schemas/document_sources.py
+++ b/api/app/schemas/document_sources.py
@@ -32,16 +32,25 @@ def resolve_document_source_url(
     source_url: str | None,
     source_file: str | None,
 ) -> HttpUrl | None:
-    fallback = (
-        parse_document_source_url(
+    try:
+        explicit_url = parse_document_source_url(source_url) if source_url else None
+    except InvalidDocumentSourceUrlError, ValidationError:
+        explicit_url = None
+    if explicit_url is not None:
+        return explicit_url
+    if (
+        not source_file
+        or source_file in {".", ".."}
+        or "/" in source_file
+        or "\\" in source_file
+        or any(
+            ord(character) < 32 or ord(character) == 127 for character in source_file
+        )
+    ):
+        return None
+    try:
+        return parse_document_source_url(
             f"{DOCUMENTS_RAW_BASE_URL}{quote(source_file, safe='')}",
         )
-        if source_file
-        else None
-    )
-    if source_url:
-        try:
-            return parse_document_source_url(source_url)
-        except InvalidDocumentSourceUrlError, ValidationError:
-            return fallback
-    return fallback
+    except InvalidDocumentSourceUrlError, ValidationError:
+        return None

--- a/api/app/schemas/document_sources.py
+++ b/api/app/schemas/document_sources.py
@@ -1,0 +1,47 @@
+from typing import Final
+from urllib.parse import quote
+
+from pydantic import HttpUrl, ValidationError
+
+DOCUMENTS_RAW_BASE_URL: Final = (
+    "https://raw.githubusercontent.com/finki-hub/documents/main/raw/"
+)
+
+
+class InvalidDocumentSourceUrlError(ValueError):
+    def __init__(self) -> None:
+        super().__init__(
+            "source_url must be an HTTPS URL without credentials, query, or fragment",
+        )
+
+
+def parse_document_source_url(value: str) -> HttpUrl:
+    url = HttpUrl(value)
+    if (
+        url.scheme != "https"
+        or url.username is not None
+        or url.password is not None
+        or url.query is not None
+        or url.fragment is not None
+    ):
+        raise InvalidDocumentSourceUrlError
+    return url
+
+
+def resolve_document_source_url(
+    source_url: str | None,
+    source_file: str | None,
+) -> HttpUrl | None:
+    fallback = (
+        parse_document_source_url(
+            f"{DOCUMENTS_RAW_BASE_URL}{quote(source_file, safe='')}",
+        )
+        if source_file
+        else None
+    )
+    if source_url:
+        try:
+            return parse_document_source_url(source_url)
+        except InvalidDocumentSourceUrlError, ValidationError:
+            return fallback
+    return fallback

--- a/api/app/schemas/documents.py
+++ b/api/app/schemas/documents.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, HttpUrl, field_validator
 
 from app.constants.defaults import DEFAULT_EMBEDDINGS_MODEL
 from app.llms.models import Model
+from app.schemas.document_sources import parse_document_source_url
 
 
 class DocumentSchema(BaseModel):
@@ -106,6 +107,17 @@ class IngestDocumentSchema(BaseModel):
         if not stripped:
             raise ValueError("must not be blank or whitespace-only")
         return stripped
+
+    @field_validator("metadata")
+    @classmethod
+    def _normalize_source_url(
+        cls,
+        value: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        if value is None or value.get("source_url") is None:
+            return value
+        source_url = parse_document_source_url(value["source_url"])
+        return {**value, "source_url": str(source_url)}
 
 
 class FillChunkEmbeddingsSchema(BaseModel):

--- a/api/app/schemas/documents.py
+++ b/api/app/schemas/documents.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, HttpUrl, field_validator
 
 from app.constants.defaults import DEFAULT_EMBEDDINGS_MODEL
 from app.llms.models import Model
@@ -53,6 +53,10 @@ class ChunkSchema(BaseModel):
     document_id: UUID = Field(examples=["3fa85f64-5717-4562-b3fc-2c963f66afa6"])
     document_name: str = Field(examples=["statut-finki-2019"])
     document_title: str = Field(examples=["Статут на ФИНКИ"])
+    document_url: HttpUrl | None = Field(
+        default=None,
+        description="Canonical URL for the original document",
+    )
     chunk_index: int = Field(examples=[0])
     section: str | None = Field(
         default=None,

--- a/api/tests/integration/test_embedding_lifecycle_data_paths_postgres.py
+++ b/api/tests/integration/test_embedding_lifecycle_data_paths_postgres.py
@@ -53,8 +53,14 @@ async def _seed_current_and_old_rows(database: Database) -> None:
     document_id = UUID("00000000-0000-0000-0000-000000000301")
     async with database.transaction() as connection:
         await connection.execute(
-            "INSERT INTO document (id, name, title) VALUES ($1, 'document', 'Document')",
+            "INSERT INTO document (id, name, title, metadata) VALUES ($1, 'document', 'Document', $2::jsonb)",
             document_id,
+            json.dumps(
+                {
+                    "source_file": "акт.pdf",
+                    "source_url": "https://www.finki.ukim.mk/document.pdf",
+                },
+            ),
         )
         await connection.executemany(
             "INSERT INTO question (id, name, content, embedding_bge_m3, embedding_bge_m3_version) VALUES ($1, $2, 'answer', $3::vector, $4)",
@@ -169,6 +175,9 @@ def test_real_postgres_data_paths_only_use_current_bge_vectors_for_both_aliases(
 
                 assert [question.name for question in questions] == ["current-question"]
                 assert [chunk.content for chunk in chunks] == ["current-chunk"]
+                assert str(chunks[0].document_url) == (
+                    "https://www.finki.ukim.mk/document.pdf"
+                )
                 assert [diploma.external_id for diploma in diplomas] == [
                     "current-diploma",
                 ]
@@ -182,6 +191,26 @@ def test_real_postgres_data_paths_only_use_current_bge_vectors_for_both_aliases(
                     "old-diploma",
                 ]
                 assert [row["title"] for row in dirty_papers] == ["old paper"]
+
+            await database.execute(
+                "UPDATE document SET metadata = $1::jsonb WHERE id = $2",
+                json.dumps(
+                    {
+                        "source_file": "акт.pdf",
+                        "source_url": "javascript:alert(1)",
+                    },
+                ),
+                UUID("00000000-0000-0000-0000-000000000301"),
+            )
+            chunks = await get_closest_chunks(
+                database,
+                [1.0] + [0.0] * 1023,
+                Model.BGE_M3,
+            )
+            assert str(chunks[0].document_url) == (
+                "https://raw.githubusercontent.com/finki-hub/documents/main/raw/"
+                "%D0%B0%D0%BA%D1%82.pdf"
+            )
 
     anyio.run(run)
 

--- a/api/tests/test_document_source_urls.py
+++ b/api/tests/test_document_source_urls.py
@@ -23,6 +23,15 @@ def test_explicit_source_url_takes_precedence() -> None:
     assert str(url) == "https://www.finki.ukim.mk/documents/akt.pdf"
 
 
+def test_explicit_source_url_ignores_malformed_source_file() -> None:
+    url = resolve_document_source_url(
+        "https://www.finki.ukim.mk/documents/akt.pdf",
+        "a" * 3_000,
+    )
+
+    assert str(url) == "https://www.finki.ukim.mk/documents/akt.pdf"
+
+
 def test_invalid_legacy_source_url_falls_back_to_source_file() -> None:
     url = resolve_document_source_url("javascript:alert(1)", "akt.pdf")
 
@@ -36,12 +45,29 @@ def test_invalid_legacy_source_url_without_source_file_is_omitted() -> None:
 
 
 @pytest.mark.parametrize(
+    "source_file",
+    [
+        "a" * 3_000,
+        ".",
+        "..",
+        "../README.md",
+        "directory/document.pdf",
+        "directory\\document.pdf",
+        "document\n.pdf",
+    ],
+)
+def test_malformed_source_file_is_omitted(source_file: str) -> None:
+    assert resolve_document_source_url("javascript:alert(1)", source_file) is None
+
+
+@pytest.mark.parametrize(
     "source_url",
     [
         "javascript:alert(1)",
         "http://www.finki.ukim.mk/document.pdf",
         "https://user:password@example.com/document.pdf",
         "https://www.finki.ukim.mk/document.pdf?token=secret",
+        "https://www.finki.ukim.mk/document.pdf#section",
     ],
 )
 def test_ingest_rejects_non_public_source_url(source_url: str) -> None:

--- a/api/tests/test_document_source_urls.py
+++ b/api/tests/test_document_source_urls.py
@@ -1,0 +1,71 @@
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.document_sources import resolve_document_source_url
+from app.schemas.documents import IngestDocumentSchema
+
+
+def test_source_file_derives_encoded_raw_document_url() -> None:
+    url = resolve_document_source_url(None, "акт.pdf")
+
+    assert str(url) == (
+        "https://raw.githubusercontent.com/finki-hub/documents/main/raw/"
+        "%D0%B0%D0%BA%D1%82.pdf"
+    )
+
+
+def test_explicit_source_url_takes_precedence() -> None:
+    url = resolve_document_source_url(
+        "https://www.finki.ukim.mk/documents/akt.pdf",
+        "акт.pdf",
+    )
+
+    assert str(url) == "https://www.finki.ukim.mk/documents/akt.pdf"
+
+
+def test_invalid_legacy_source_url_falls_back_to_source_file() -> None:
+    url = resolve_document_source_url("javascript:alert(1)", "akt.pdf")
+
+    assert str(url) == (
+        "https://raw.githubusercontent.com/finki-hub/documents/main/raw/akt.pdf"
+    )
+
+
+def test_invalid_legacy_source_url_without_source_file_is_omitted() -> None:
+    assert resolve_document_source_url("javascript:alert(1)", None) is None
+
+
+@pytest.mark.parametrize(
+    "source_url",
+    [
+        "javascript:alert(1)",
+        "http://www.finki.ukim.mk/document.pdf",
+        "https://user:password@example.com/document.pdf",
+        "https://www.finki.ukim.mk/document.pdf?token=secret",
+    ],
+)
+def test_ingest_rejects_non_public_source_url(source_url: str) -> None:
+    with pytest.raises(ValidationError):
+        _ = IngestDocumentSchema(
+            name="document",
+            title="Document",
+            content="# Document",
+            metadata={"source_url": source_url},
+        )
+
+
+def test_ingest_normalizes_public_source_url() -> None:
+    payload = IngestDocumentSchema(
+        name="document",
+        title="Document",
+        content="# Document",
+        metadata={
+            "source_file": "document.pdf",
+            "source_url": "https://www.finki.ukim.mk/document.pdf",
+        },
+    )
+
+    assert payload.metadata == {
+        "source_file": "document.pdf",
+        "source_url": "https://www.finki.ukim.mk/document.pdf",
+    }

--- a/api/tests/test_retrieval_sources.py
+++ b/api/tests/test_retrieval_sources.py
@@ -205,7 +205,7 @@ def test_chunk_candidate_omits_link_without_document_url() -> None:
     assert "links" not in payload
 
 
-def test_chunk_retrieval_projects_document_url(
+def test_chunk_retrieval_derives_document_url_from_source_file(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     document_url = (
@@ -219,7 +219,8 @@ def test_chunk_retrieval_projects_document_url(
                 "document_id": uuid4(),
                 "document_name": "statut-finki",
                 "document_title": "Статут на ФИНКИ",
-                "document_url": document_url,
+                "document_source_url": None,
+                "document_source_file": "statut_i_delovnik.pdf",
                 "chunk_index": 4,
                 "section": "Член 12",
                 "content": "Правилата се наведени во членот.",
@@ -238,8 +239,6 @@ def test_chunk_retrieval_projects_document_url(
         )
 
         assert str(chunks[0].document_url) == document_url
-        assert state.last_query is not None
-        assert "d.metadata->>'source_url' AS document_url" in state.last_query
 
     anyio.run(run)
 

--- a/api/tests/test_retrieval_sources.py
+++ b/api/tests/test_retrieval_sources.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import HttpUrl
 
 from app.data.connection import Database
+from app.data.documents import get_closest_chunks
 from app.llms.agents import sources_event
 from app.llms.context import (
     _chunk_candidate,
@@ -22,9 +23,11 @@ from app.schemas.questions import QuestionSchema
 
 class WindowState:
     def __init__(self, rows: list[dict[str, object]]) -> None:
-        self.rows = rows
+        self.rows: list[dict[str, object]] = rows
+        self.last_query: str | None = None
 
     def fetch(self, query: str, *_args: object) -> list[dict[str, object]]:
+        self.last_query = query
         return self.rows[:1] if "embedding_bge_m3_version" in query else self.rows
 
 
@@ -160,7 +163,7 @@ def test_question_candidate_keeps_structured_links():
     }
 
 
-def test_chunk_candidate_keeps_document_section_and_index():
+def test_chunk_candidate_keeps_document_link_section_and_index():
     chunk_id = uuid4()
     doc_id = uuid4()
     c = ChunkSchema(
@@ -168,6 +171,9 @@ def test_chunk_candidate_keeps_document_section_and_index():
         document_id=doc_id,
         document_name="statut-finki",
         document_title="Статут на ФИНКИ",
+        document_url=HttpUrl(
+            "https://raw.githubusercontent.com/finki-hub/documents/main/raw/statut_i_delovnik.pdf",
+        ),
         chunk_index=4,
         section="Член 12",
         content="Правилата се наведени во членот.",
@@ -179,10 +185,63 @@ def test_chunk_candidate_keeps_document_section_and_index():
         "chunk_index": 4,
         "id": str(chunk_id),
         "kind": "chunk",
+        "links": [
+            {
+                "label": "Статут на ФИНКИ",
+                "url": "https://raw.githubusercontent.com/finki-hub/documents/main/raw/statut_i_delovnik.pdf",
+            },
+        ],
         "section": "Член 12",
         "snippet": "Правилата се наведени во членот.",
         "title": "Статут на ФИНКИ",
     }
+
+
+def test_chunk_candidate_omits_link_without_document_url() -> None:
+    chunk = _chunk(document_id=uuid4(), chunk_index=0, content="Содржина.")
+
+    payload = _chunk_candidate(chunk).retrieval_source.as_payload()
+
+    assert "links" not in payload
+
+
+def test_chunk_retrieval_projects_document_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    document_url = (
+        "https://raw.githubusercontent.com/finki-hub/documents/main/raw/"
+        "statut_i_delovnik.pdf"
+    )
+    state = WindowState(
+        [
+            {
+                "id": uuid4(),
+                "document_id": uuid4(),
+                "document_name": "statut-finki",
+                "document_title": "Статут на ФИНКИ",
+                "document_url": document_url,
+                "chunk_index": 4,
+                "section": "Член 12",
+                "content": "Правилата се наведени во членот.",
+                "distance": 0.1,
+            },
+        ],
+    )
+    database = _database(state, monkeypatch)
+
+    async def run() -> None:
+        chunks = await get_closest_chunks(
+            database,
+            [0.0] * 3072,
+            Model.TEXT_EMBEDDING_3_LARGE,
+            limit=1,
+        )
+
+        assert str(chunks[0].document_url) == document_url
+        assert state.last_query is not None
+        assert "d.metadata->>'source_url' AS document_url" in state.last_query
+
+    anyio.run(run)
 
 
 def test_sources_event_serializes_sources_frame():

--- a/api/tests/test_retrieval_sources.py
+++ b/api/tests/test_retrieval_sources.py
@@ -24,10 +24,8 @@ from app.schemas.questions import QuestionSchema
 class WindowState:
     def __init__(self, rows: list[dict[str, object]]) -> None:
         self.rows: list[dict[str, object]] = rows
-        self.last_query: str | None = None
 
     def fetch(self, query: str, *_args: object) -> list[dict[str, object]]:
-        self.last_query = query
         return self.rows[:1] if "embedding_bge_m3_version" in query else self.rows
 
 

--- a/web/test/sse.test.ts
+++ b/web/test/sse.test.ts
@@ -183,7 +183,7 @@ describe('parseProtocolV2', () => {
 
   it('maps source frames to typed retrieved sources and drops malformed entries', async () => {
     const events = await collect(
-      'event: sources\ndata: {"sources":[{"id":"q1","kind":"faq","title":"Упис","links":[{"label":"iKnow","url":"https://iknow.ukim.mk/"}],"snippet":"Упис преку iKnow."},{"id":"bad","kind":"unknown","title":"bad"},{"id":"c1","kind":"chunk","title":"Статут","section":"Член 12","chunk_index":4,"snippet":"Правила."}]}\n\n',
+      'event: sources\ndata: {"sources":[{"id":"q1","kind":"faq","title":"Упис","links":[{"label":"iKnow","url":"https://iknow.ukim.mk/"}],"snippet":"Упис преку iKnow."},{"id":"bad","kind":"unknown","title":"bad"},{"id":"c1","kind":"chunk","title":"Статут","section":"Член 12","chunk_index":4,"links":[{"label":"Статут","url":"https://raw.githubusercontent.com/finki-hub/documents/main/raw/statut_i_delovnik.pdf"}],"snippet":"Правила."}]}\n\n',
       DONE_FRAME,
     );
 
@@ -201,6 +201,12 @@ describe('parseProtocolV2', () => {
             chunkIndex: 4,
             id: 'c1',
             kind: 'chunk',
+            links: [
+              {
+                label: 'Статут',
+                url: 'https://raw.githubusercontent.com/finki-hub/documents/main/raw/statut_i_delovnik.pdf',
+              },
+            ],
             section: 'Член 12',
             snippet: 'Правила.',
             title: 'Статут',

--- a/web/test/thread.test.tsx
+++ b/web/test/thread.test.tsx
@@ -486,6 +486,12 @@ describe('AssistantMessage', () => {
             chunkIndex: 4,
             id: 'c1',
             kind: 'chunk',
+            links: [
+              {
+                label: 'Статут на ФИНКИ',
+                url: 'https://raw.githubusercontent.com/finki-hub/documents/main/raw/statut_i_delovnik.pdf',
+              },
+            ],
             section: 'Член 12',
             snippet: chunkSnippet,
             title: 'Статут на ФИНКИ',
@@ -527,6 +533,9 @@ describe('AssistantMessage', () => {
 
     const iKnowLink = screen.getByRole('link', { name: 'Врска: iKnow' });
     const finkiLink = screen.getByRole('link', { name: 'Врска: ФИНКИ' });
+    const documentLink = screen.getByRole('link', {
+      name: 'Врска: Статут на ФИНКИ',
+    });
 
     expect(iKnowLink).toHaveAttribute('href', 'https://iknow.ukim.mk/');
     expect(iKnowLink).toHaveClass(
@@ -536,6 +545,10 @@ describe('AssistantMessage', () => {
       'pointer-fine:min-w-0',
     );
     expect(finkiLink).toHaveAttribute('href', 'https://www.finki.ukim.mk/');
+    expect(documentLink).toHaveAttribute(
+      'href',
+      'https://raw.githubusercontent.com/finki-hub/documents/main/raw/statut_i_delovnik.pdf',
+    );
 
     await user.click(screen.getByRole('button', { name: HIDE_SOURCES_LABEL }));
 


### PR DESCRIPTION
## Summary
- attach validated original-document URLs to retrieved document chunks
- prefer explicit HTTPS `source_url` metadata and derive a percent-encoded canonical GitHub raw URL from `source_file` when needed
- fail safely for malformed legacy metadata, oversized filenames, controls, and path-like fallback values
- cover PostgreSQL JSONB retrieval, SSE parsing, and accessible web link rendering

## Validation
- API: 388 tests passed against disposable PostgreSQL/pgvector
- API: Ruff and mypy passed
- Web: 496 tests passed; TypeScript and lint completed with zero errors
- Web: Next.js 16.2.11 production build passed with required server environment variables
- Independent goal, QA, code-quality, security, and context review lanes passed

## Deployment
- No deployment changes are included. This PR must merge before any further deployment changes.