### PR TITLE
fix(api): handle link context task failures

### DIFF
--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import json
 import logging
 from collections.abc import AsyncGenerator, AsyncIterable
@@ -724,10 +723,18 @@ async def _chat_response_stream(
         retrieval_task = asyncio.create_task(run_retrieval())
         links_task = asyncio.create_task(get_links_context(db, query=payload.query))
 
+        def on_links_done(task: asyncio.Task[str]) -> None:
+            if not task.cancelled() and task.exception() is not None:
+                stage_queue.put_nowait(None)
+
+        links_task.add_done_callback(on_links_done)
+
         try:
             while (event := await stage_queue.get()) is not None:
                 yield event
 
+            if links_task.done():
+                links_task.result()
             retrieved = await retrieval_task
             links_context = await links_task
 
@@ -794,11 +801,13 @@ async def _chat_response_stream(
                 "Chat context build failed before streaming error_type=%s",
                 type(exc).__name__,
             )
-            links_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await links_task
             yield error_event("agent_error", _PRE_STREAM_ERROR_MSG)
             return
+        finally:
+            for task in (retrieval_task, links_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(retrieval_task, links_task, return_exceptions=True)
 
         response.body_iterator = _instrument_stream(
             response.body_iterator,

--- a/api/tests/test_chat_context_task_failure.py
+++ b/api/tests/test_chat_context_task_failure.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import anyio
+import pytest
+
+from app.api import chat as chat_api
+from app.data.connection import Database
+from app.llms.models import Model
+from tests.chat_models_access_support import credentials, settings
+
+USER_ID = UUID("00000000-0000-4000-8000-000000000002")
+
+
+def _request():
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(settings=settings())),
+        headers={"X-Distinct-Id": "test-distinct-id"},
+    )
+
+
+def _payload() -> chat_api.ChatSchema:
+    return chat_api.ChatSchema.model_validate(
+        {
+            "user_id": USER_ID,
+            "interface": "web",
+            "inference_model": Model.GPT_5_6_LUNA,
+            "messages": [{"role": "user", "content": "Question"}],
+        },
+    )
+
+
+@pytest.mark.anyio
+async def test_failed_links_context_wakes_stream_and_cleans_context_tasks(
+    monkeypatch,
+) -> None:
+    retrieval_started = anyio.Event()
+    retrieval_finished = anyio.Event()
+    links_finished = anyio.Event()
+    internal_message = "private link lookup failure"
+
+    async def resolve_credentials(*args, **kwargs):
+        return credentials(openai=True)
+
+    async def retrieve(*args, **kwargs):
+        retrieval_started.set()
+        try:
+            await anyio.sleep_forever()
+        finally:
+            retrieval_finished.set()
+
+    async def fail_links(*args, **kwargs):
+        try:
+            raise RuntimeError(internal_message)
+        finally:
+            links_finished.set()
+
+    async def fail_if_agent_starts(*args, **kwargs):
+        raise AssertionError("agent must not start after link lookup fails")
+
+    monkeypatch.setattr(
+        chat_api,
+        "resolve_provider_credentials",
+        resolve_credentials,
+    )
+    monkeypatch.setattr(
+        chat_api,
+        "get_retrieved_context_with_sources",
+        retrieve,
+    )
+    monkeypatch.setattr(chat_api, "get_links_context", fail_links)
+    monkeypatch.setattr(chat_api, "handle_chat", fail_if_agent_starts)
+    monkeypatch.setattr(chat_api, "capture", lambda *args, **kwargs: None)
+
+    with anyio.fail_after(0.2):
+        chunks = [
+            str(chunk)
+            async for chunk in chat_api._chat_response_stream(  # noqa: SLF001
+                _payload(),
+                _request(),
+                Database.__new__(Database),
+                uuid4(),
+            )
+        ]
+
+    rendered = "".join(chunks)
+    assert rendered.count('"code": "agent_error"') == 1
+    assert internal_message not in rendered
+    assert retrieval_started.is_set()
+    assert retrieval_finished.is_set()
+    assert links_finished.is_set()


### PR DESCRIPTION
## Summary

- wake the chat stage queue when link-context loading fails before retrieval completes
- propagate the failure through the existing safe `agent_error` boundary and cancel/await both context tasks
- add a bounded regression covering prompt error delivery, exception privacy, and task cleanup

## Verification

- `uv run pytest tests/test_chat_context_task_failure.py -vv` (1 passed)
- `uv run pytest tests/test_chat_context_task_failure.py tests/test_chat_sponsored_admission.py -vv` (15 passed)
- `uv run ruff check .`
- `uv run mypy .` (207 files, no issues)
- direct generator driver: one safe `agent_error`, no internal exception text, retrieval and links tasks both complete
- `uv run pytest` (362 passed, 24 skipped; 3 pre-existing Windows-only failures because Docker Compose and `/bin/sh` are unavailable)
