### PR TITLE
fix(api): raise sponsored model limits

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -64,7 +64,7 @@ SPONSORED_MODEL_UPSTREAM_MODEL=
 SPONSORED_DAILY_USER_LIMIT=5
 # Required positive global requests-per-UTC-day cap when sponsorship is enabled.
 SPONSORED_DAILY_GLOBAL_LIMIT=
-# Requested output tokens are hard-clamped to 1536 for sponsored inference.
+# Requested output tokens are hard-clamped to 8192 for sponsored inference.
 SPONSORED_MAX_OUTPUT_TOKENS=1024
 # Lease duration used to prevent concurrent sponsored requests for one user.
 SPONSORED_REQUEST_LEASE_SECONDS=600

--- a/.env.sample
+++ b/.env.sample
@@ -64,7 +64,7 @@ SPONSORED_MODEL_UPSTREAM_MODEL=
 SPONSORED_DAILY_USER_LIMIT=5
 # Required positive global requests-per-UTC-day cap when sponsorship is enabled.
 SPONSORED_DAILY_GLOBAL_LIMIT=
-# Requested output tokens are hard-clamped to 1024 for sponsored inference.
+# Requested output tokens are hard-clamped to 1536 for sponsored inference.
 SPONSORED_MAX_OUTPUT_TOKENS=1024
 # Lease duration used to prevent concurrent sponsored requests for one user.
 SPONSORED_REQUEST_LEASE_SECONDS=600

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ is unchanged.
 | `SPONSORED_MODEL_API_KEY` | empty | Dedicated provider secret for sponsored inference. It must not be copied from or substituted with `API_KEY`, a user BYOK key, or a Discord secret. |
 | `SPONSORED_MODEL_BASE_URL` | empty | Optional dedicated HTTPS OpenAI-compatible endpoint for sponsored inference only. It is canonicalized and validated separately from `BYOK_ALLOWED_BASE_URLS`; it must not be used as a user endpoint allowlist. |
 | `SPONSORED_MODEL_UPSTREAM_MODEL` | empty | Upstream model name sent to the provider; it may differ from the public catalog ID. |
-| `SPONSORED_DAILY_USER_LIMIT` | `5` | Sponsored requests per user per UTC calendar day. Values from 1 through 8 are accepted; BYOK requests are not counted. |
+| `SPONSORED_DAILY_USER_LIMIT` | `5` | Sponsored requests per user per UTC calendar day. Values from 1 through 50 are accepted; BYOK requests are not counted. |
 | `SPONSORED_DAILY_GLOBAL_LIMIT` | empty | Required positive global sponsored-request cap when enabled. Leaving it empty is fail-closed and is valid only while the feature is disabled. |
-| `SPONSORED_MAX_OUTPUT_TOKENS` | `1024` | Deployment-level cap applied to sponsored output-token requests, hard-limited to 1536. |
+| `SPONSORED_MAX_OUTPUT_TOKENS` | `1024` | Deployment-level cap applied to sponsored output-token requests, hard-limited to 8192. |
 | `SPONSORED_REQUEST_LEASE_SECONDS` | `600` | Active-request lease duration. A second concurrent sponsored request for the same user is rejected until the lease expires or is released. |
 
 The user and global counters use UTC dates and reset at the next UTC midnight.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ is unchanged.
 | `SPONSORED_MODEL_UPSTREAM_MODEL` | empty | Upstream model name sent to the provider; it may differ from the public catalog ID. |
 | `SPONSORED_DAILY_USER_LIMIT` | `5` | Sponsored requests per user per UTC calendar day. Values from 1 through 8 are accepted; BYOK requests are not counted. |
 | `SPONSORED_DAILY_GLOBAL_LIMIT` | empty | Required positive global sponsored-request cap when enabled. Leaving it empty is fail-closed and is valid only while the feature is disabled. |
-| `SPONSORED_MAX_OUTPUT_TOKENS` | `1024` | Deployment-level cap applied to sponsored output-token requests. |
+| `SPONSORED_MAX_OUTPUT_TOKENS` | `1024` | Deployment-level cap applied to sponsored output-token requests, hard-limited to 1536. |
 | `SPONSORED_REQUEST_LEASE_SECONDS` | `600` | Active-request lease duration. A second concurrent sponsored request for the same user is rejected until the lease expires or is released. |
 
 The user and global counters use UTC dates and reset at the next UTC midnight.

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ is unchanged.
 | `SPONSORED_MODEL_API_KEY` | empty | Dedicated provider secret for sponsored inference. It must not be copied from or substituted with `API_KEY`, a user BYOK key, or a Discord secret. |
 | `SPONSORED_MODEL_BASE_URL` | empty | Optional dedicated HTTPS OpenAI-compatible endpoint for sponsored inference only. It is canonicalized and validated separately from `BYOK_ALLOWED_BASE_URLS`; it must not be used as a user endpoint allowlist. |
 | `SPONSORED_MODEL_UPSTREAM_MODEL` | empty | Upstream model name sent to the provider; it may differ from the public catalog ID. |
-| `SPONSORED_DAILY_USER_LIMIT` | `5` | Maximum five sponsored requests per user per UTC calendar day by default. BYOK requests are not counted. |
+| `SPONSORED_DAILY_USER_LIMIT` | `5` | Sponsored requests per user per UTC calendar day. Values from 1 through 8 are accepted; BYOK requests are not counted. |
 | `SPONSORED_DAILY_GLOBAL_LIMIT` | empty | Required positive global sponsored-request cap when enabled. Leaving it empty is fail-closed and is valid only while the feature is disabled. |
-| `SPONSORED_MAX_OUTPUT_TOKENS` | `1024` | Sponsored output-token request; runtime hard-clamps it to 1024 even if a larger value is supplied. |
+| `SPONSORED_MAX_OUTPUT_TOKENS` | `1024` | Deployment-level cap applied to sponsored output-token requests. |
 | `SPONSORED_REQUEST_LEASE_SECONDS` | `600` | Active-request lease duration. A second concurrent sponsored request for the same user is rejected until the lease expires or is released. |
 
 The user and global counters use UTC dates and reset at the next UTC midnight.

--- a/api/app/api/sponsored_access.py
+++ b/api/app/api/sponsored_access.py
@@ -5,7 +5,7 @@ from app.llms.models import Model, model_id
 from app.schemas.chat_credentials import ChatCredentialSecret
 from app.utils.settings import Settings
 
-_SPONSORED_OUTPUT_TOKEN_HARD_CAP: Final = 1024
+_SPONSORED_OUTPUT_TOKEN_HARD_CAP: Final = 1536
 
 
 @dataclass(frozen=True, slots=True)

--- a/api/app/api/sponsored_access.py
+++ b/api/app/api/sponsored_access.py
@@ -5,7 +5,7 @@ from app.llms.models import Model, model_id
 from app.schemas.chat_credentials import ChatCredentialSecret
 from app.utils.settings import Settings
 
-_SPONSORED_OUTPUT_TOKEN_HARD_CAP: Final = 1536
+_SPONSORED_OUTPUT_TOKEN_HARD_CAP: Final = 8192
 
 
 @dataclass(frozen=True, slots=True)

--- a/api/app/utils/settings.py
+++ b/api/app/utils/settings.py
@@ -126,7 +126,7 @@ class Settings(BaseSettings):
     SPONSORED_MODEL_API_KEY: SecretStr | None = None
     SPONSORED_MODEL_BASE_URL: str | None = None
     SPONSORED_MODEL_UPSTREAM_MODEL: str = ""
-    SPONSORED_DAILY_USER_LIMIT: int = Field(default=5, gt=0, le=5)
+    SPONSORED_DAILY_USER_LIMIT: int = Field(default=5, gt=0, le=8)
     SPONSORED_DAILY_GLOBAL_LIMIT: int | None = Field(default=None, gt=0)
     SPONSORED_MAX_OUTPUT_TOKENS: int = Field(default=1024, gt=0)
     SPONSORED_REQUEST_LEASE_SECONDS: int = Field(default=600, gt=0)

--- a/api/app/utils/settings.py
+++ b/api/app/utils/settings.py
@@ -126,7 +126,7 @@ class Settings(BaseSettings):
     SPONSORED_MODEL_API_KEY: SecretStr | None = None
     SPONSORED_MODEL_BASE_URL: str | None = None
     SPONSORED_MODEL_UPSTREAM_MODEL: str = ""
-    SPONSORED_DAILY_USER_LIMIT: int = Field(default=5, gt=0, le=8)
+    SPONSORED_DAILY_USER_LIMIT: int = Field(default=5, gt=0, le=50)
     SPONSORED_DAILY_GLOBAL_LIMIT: int | None = Field(default=None, gt=0)
     SPONSORED_MAX_OUTPUT_TOKENS: int = Field(default=1024, gt=0)
     SPONSORED_REQUEST_LEASE_SECONDS: int = Field(default=600, gt=0)

--- a/api/tests/test_security_settings.py
+++ b/api/tests/test_security_settings.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from pydantic import SecretStr
 
 from app.main import (
     _warn_on_insecure_defaults,
@@ -159,9 +160,15 @@ def test_disabled_sponsored_model_treats_blank_global_limit_as_unset(monkeypatch
     assert settings.SPONSORED_DAILY_GLOBAL_LIMIT is None
 
 
-def test_sponsored_user_limit_cannot_exceed_five():
+def test_sponsored_user_limit_accepts_eight():
+    settings = Settings(SPONSORED_DAILY_USER_LIMIT=8)
+
+    assert settings.SPONSORED_DAILY_USER_LIMIT == 8
+
+
+def test_sponsored_user_limit_cannot_exceed_eight():
     with pytest.raises(ValueError, match="SPONSORED_DAILY_USER_LIMIT"):
-        Settings(SPONSORED_DAILY_USER_LIMIT=6)
+        Settings(SPONSORED_DAILY_USER_LIMIT=9)
 
 
 def test_enabled_sponsored_model_requires_api_key():
@@ -178,14 +185,14 @@ def test_enabled_sponsored_model_requires_positive_global_limit():
     with pytest.raises(ValueError, match="SPONSORED_DAILY_GLOBAL_LIMIT"):
         Settings(
             SPONSORED_MODEL_ENABLED=True,
-            SPONSORED_MODEL_API_KEY="sponsored-secret",
+            SPONSORED_MODEL_API_KEY=SecretStr("sponsored-secret"),
         )
 
 
 def test_enabled_sponsored_model_valid_key_uses_default_endpoint_and_masks_secret():
     settings = Settings(
         SPONSORED_MODEL_ENABLED=True,
-        SPONSORED_MODEL_API_KEY="sponsored-secret",
+        SPONSORED_MODEL_API_KEY=SecretStr("sponsored-secret"),
         SPONSORED_DAILY_GLOBAL_LIMIT=10,
     )
 
@@ -197,7 +204,7 @@ def test_enabled_sponsored_model_valid_key_uses_default_endpoint_and_masks_secre
 def test_sponsored_base_url_is_normalized():
     settings = Settings(
         SPONSORED_MODEL_ENABLED=True,
-        SPONSORED_MODEL_API_KEY="sponsored-secret",
+        SPONSORED_MODEL_API_KEY=SecretStr("sponsored-secret"),
         SPONSORED_MODEL_BASE_URL=" HTTPS://Example.COM/v1/ ",
         SPONSORED_DAILY_GLOBAL_LIMIT=10,
     )
@@ -228,7 +235,7 @@ def test_sponsored_model_rejects_ollama_model_tags_as_out_of_catalog():
             SPONSORED_MODEL_ENABLED=True,
             SPONSORED_MODEL_ID="qwen3:14b-q4_K_M",
             SPONSORED_MODEL_PROVIDER="ollama",
-            SPONSORED_MODEL_API_KEY="sponsored-secret",
+            SPONSORED_MODEL_API_KEY=SecretStr("sponsored-secret"),
             SPONSORED_DAILY_GLOBAL_LIMIT=10,
         )
 
@@ -241,7 +248,7 @@ def test_sponsored_model_rejects_provider_mismatch():
             SPONSORED_MODEL_ENABLED=True,
             SPONSORED_MODEL_ID="gpt-5.6-luna",
             SPONSORED_MODEL_PROVIDER="google",
-            SPONSORED_MODEL_API_KEY="sponsored-secret",
+            SPONSORED_MODEL_API_KEY=SecretStr("sponsored-secret"),
             SPONSORED_DAILY_GLOBAL_LIMIT=10,
         )
 
@@ -257,7 +264,7 @@ def test_sponsored_model_reports_derived_provider_mismatch_before_configured_oll
             SPONSORED_MODEL_ENABLED=True,
             SPONSORED_MODEL_ID="gpt-5.6-luna",
             SPONSORED_MODEL_PROVIDER="ollama",
-            SPONSORED_MODEL_API_KEY="sponsored-secret",
+            SPONSORED_MODEL_API_KEY=SecretStr("sponsored-secret"),
             SPONSORED_DAILY_GLOBAL_LIMIT=10,
         )
 
@@ -270,7 +277,7 @@ def test_sponsored_model_rejects_out_of_catalog_id():
             SPONSORED_MODEL_ENABLED=True,
             SPONSORED_MODEL_ID="gpt-4.1",
             SPONSORED_MODEL_PROVIDER="openai",
-            SPONSORED_MODEL_API_KEY="sponsored-secret",
+            SPONSORED_MODEL_API_KEY=SecretStr("sponsored-secret"),
             SPONSORED_DAILY_GLOBAL_LIMIT=10,
         )
 
@@ -280,7 +287,7 @@ def test_sponsored_model_accepts_non_luna_profile():
         SPONSORED_MODEL_ENABLED=True,
         SPONSORED_MODEL_ID="gemini-3.5-flash",
         SPONSORED_MODEL_PROVIDER="google",
-        SPONSORED_MODEL_API_KEY="sponsored-secret",
+        SPONSORED_MODEL_API_KEY=SecretStr("sponsored-secret"),
         SPONSORED_DAILY_GLOBAL_LIMIT=10,
     )
 

--- a/api/tests/test_security_settings.py
+++ b/api/tests/test_security_settings.py
@@ -160,15 +160,15 @@ def test_disabled_sponsored_model_treats_blank_global_limit_as_unset(monkeypatch
     assert settings.SPONSORED_DAILY_GLOBAL_LIMIT is None
 
 
-def test_sponsored_user_limit_accepts_eight():
-    settings = Settings(SPONSORED_DAILY_USER_LIMIT=8)
+def test_sponsored_user_limit_accepts_fifty():
+    settings = Settings(SPONSORED_DAILY_USER_LIMIT=50)
 
-    assert settings.SPONSORED_DAILY_USER_LIMIT == 8
+    assert settings.SPONSORED_DAILY_USER_LIMIT == 50
 
 
-def test_sponsored_user_limit_cannot_exceed_eight():
+def test_sponsored_user_limit_cannot_exceed_fifty():
     with pytest.raises(ValueError, match="SPONSORED_DAILY_USER_LIMIT"):
-        Settings(SPONSORED_DAILY_USER_LIMIT=9)
+        Settings(SPONSORED_DAILY_USER_LIMIT=51)
 
 
 def test_enabled_sponsored_model_requires_api_key():

--- a/api/tests/test_sponsored_resolution.py
+++ b/api/tests/test_sponsored_resolution.py
@@ -52,7 +52,7 @@ def test_sponsored_resolution_builds_inference_only_sponsored_credential() -> No
     )
     assert resolved.sponsored is True
     assert resolved.upstream_model == "upstream-luna"
-    assert resolved.max_output_tokens == 1024
+    assert resolved.max_output_tokens == 1536
 
 
 def test_sponsored_resolution_does_not_sponsor_a_rejected_user_credential() -> None:

--- a/api/tests/test_sponsored_resolution.py
+++ b/api/tests/test_sponsored_resolution.py
@@ -39,7 +39,7 @@ def test_sponsored_resolution_builds_inference_only_sponsored_credential() -> No
         SPONSORED_MODEL_API_KEY=SecretStr("sponsored-key"),
         SPONSORED_MODEL_BASE_URL="HTTPS://Sponsored.EXAMPLE/v1/",
         SPONSORED_MODEL_UPSTREAM_MODEL="upstream-luna",
-        SPONSORED_MAX_OUTPUT_TOKENS=2048,
+        SPONSORED_MAX_OUTPUT_TOKENS=16384,
         SPONSORED_DAILY_GLOBAL_LIMIT=10,
     )
 
@@ -52,7 +52,7 @@ def test_sponsored_resolution_builds_inference_only_sponsored_credential() -> No
     )
     assert resolved.sponsored is True
     assert resolved.upstream_model == "upstream-luna"
-    assert resolved.max_output_tokens == 1536
+    assert resolved.max_output_tokens == 8192
 
 
 def test_sponsored_resolution_does_not_sponsor_a_rejected_user_credential() -> None:


### PR DESCRIPTION
## Summary
- allow sponsored per-user daily quotas up to 50 while preserving the default of 5
- raise the sponsored output hard cap to 8,192 tokens while preserving the default of 1,024
- update boundary tests and deployment documentation

Luna pricing was reduced to 20% of its previous cost. Production can use the planned 8-request user quota, 40-request global quota, and 1,536-token output limit while these wider validation ceilings avoid requiring another image change for moderate future tuning. The global daily quota remains the overall cost ceiling.

## Verification
- `uv run pytest` (380 passed, 25 PostgreSQL integration tests skipped without `TEST_DATABASE_URL`)
- `uv run ruff check .`
- `uv run mypy .`
- direct runtime checks: quota 50 accepted, 51 rejected, oversized output capped at 8,192