### PR TITLE
fix(api): degrade query transforms without losing retrieval

### DIFF
--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -47,6 +47,7 @@ from app.llms.models import model_id
 from app.llms.ollama import fetch_ollama_catalog
 from app.llms.pricing import cost_usd, is_self_hosted
 from app.llms.provider_credentials import provider_for_model
+from app.llms.query_modes import QueryTransformMode
 from app.llms.retrieval_result import RetrievedContext
 from app.schemas.chat import ChatSchema
 from app.schemas.sponsored_access import SponsoredQuotaSnapshot
@@ -237,6 +238,7 @@ def _capture_chat_response(
     observation: StreamObservation,
     answer_text: str,
     session_id: str | None,
+    effective_transform_mode: QueryTransformMode,
 ) -> None:
     model = payload.inference_model
     generation_ms: float | None = None
@@ -272,7 +274,8 @@ def _capture_chat_response(
         "query_transform_ms": _ms(_query_transform_ms(timings)),
         "query_rewrite_ms": _ms(timings.spans.get("retrieval.query_rewrite")),
         "hyde_ms": _ms(timings.spans.get("retrieval.hyde")),
-        "query_transform_mode": payload.query_transform_mode.value,
+        "requested_query_transform_mode": payload.query_transform_mode.value,
+        "query_transform_mode": effective_transform_mode.value,
         "candidate_count": timings.candidate_count,
         "top_distance": timings.top_distance,
         "context_char_len": observation.context_chars,
@@ -387,6 +390,7 @@ async def _instrument_stream(
     distinct_id: str,
     session_id: str | None,
     observation: StreamObservation,
+    effective_transform_mode: QueryTransformMode,
     sponsored_mode: str | None = None,
 ) -> AsyncGenerator[bytes | str | memoryview]:
     """Pass the SSE body through untouched, stamping TTFT, thinking and total, then
@@ -462,7 +466,8 @@ async def _instrument_stream(
                     "inference_model": model_id(payload.inference_model),
                     "embeddings_model": payload.embeddings_model.value,
                     "query_transform_model": model_id(payload.query_transform_model),
-                    "query_transform_mode": payload.query_transform_mode.value,
+                    "requested_query_transform_mode": payload.query_transform_mode.value,
+                    "query_transform_mode": effective_transform_mode.value,
                     "retrieval_hit": retrieval_hit,
                     "outcome": outcome,
                     **record,
@@ -483,6 +488,7 @@ async def _instrument_stream(
             observation=observation,
             answer_text="".join(answer_parts),
             session_id=session_id,
+            effective_transform_mode=effective_transform_mode,
         )
         if sponsored_mode is not None:
             capture_sponsored_event(
@@ -748,7 +754,8 @@ async def _chat_response_stream(
                         "query_transform_model": model_id(
                             payload.query_transform_model,
                         ),
-                        "query_transform_mode": payload.query_transform_mode.value,
+                        "requested_query_transform_mode": payload.query_transform_mode.value,
+                        "query_transform_mode": retrieved.effective_transform_mode.value,
                         "candidate_count": timings.candidate_count,
                         "top_distance": timings.top_distance,
                         "query_len": len(payload.query),
@@ -818,6 +825,7 @@ async def _chat_response_stream(
             distinct_id=distinct_id,
             observation=observation,
             session_id=session_id,
+            effective_transform_mode=retrieved.effective_transform_mode,
             sponsored_mode=sponsored_mode,
         )
 

--- a/api/app/llms/context.py
+++ b/api/app/llms/context.py
@@ -319,7 +319,7 @@ async def get_retrieved_context_with_sources(
 
     logger.info(
         "Query transform mode %s produced variants: %s",
-        effective_transform_mode.value,
+        variant_bundle.mode.value,
         [(variant.kind, len(variant.text)) for variant in variant_bundle.variants],
     )
 

--- a/api/app/llms/context.py
+++ b/api/app/llms/context.py
@@ -323,7 +323,7 @@ async def get_retrieved_context_with_sources(
         [(variant.kind, len(variant.text)) for variant in variant_bundle.variants],
     )
 
-    budget = retrieval_budget(effective_transform_mode, initial_k)
+    budget = retrieval_budget(variant_bundle.mode, initial_k)
 
     _stage("retrieve")
 
@@ -506,9 +506,12 @@ async def _contextualize_query(
     """
     if not history_text:
         return query
+    transform_input = (
+        f"Претходен разговор:\n{history_text}\n\nНово прашање: {query}"
+    )
     try:
         condensed = await transform_query(
-            f"Претходен разговор:\n{history_text}\n\nНово прашање: {query}",
+            transform_input,
             query_transform_model,
             system_prompt=CONTEXTUALIZE_SYSTEM_PROMPT,
             temperature=0.0,
@@ -523,6 +526,8 @@ async def _contextualize_query(
         )
         return query
     condensed = condensed.strip()
+    if condensed == transform_input:
+        return query
     if condensed and condensed != query:
         logger.info(
             "Contextualized query: query_len=%d condensed_len=%d history_char_len=%d",

--- a/api/app/llms/context.py
+++ b/api/app/llms/context.py
@@ -376,7 +376,10 @@ async def get_retrieved_context_with_sources(
             )
 
         if not candidates:
-            return RetrievedContext(text="")
+            return RetrievedContext(
+                text="",
+                effective_transform_mode=variant_bundle.mode,
+            )
 
     except Exception as e:
         raise RetrievalError("Failed during multi-query vector search") from e
@@ -490,6 +493,7 @@ async def get_retrieved_context_with_sources(
         text = await _expand_and_render(db, final, embedding_model)
     return RetrievedContext(
         text=text,
+        effective_transform_mode=variant_bundle.mode,
         sources=sources,
     )
 

--- a/api/app/llms/context.py
+++ b/api/app/llms/context.py
@@ -510,9 +510,7 @@ async def _contextualize_query(
     """
     if not history_text:
         return query
-    transform_input = (
-        f"Претходен разговор:\n{history_text}\n\nНово прашање: {query}"
-    )
+    transform_input = f"Претходен разговор:\n{history_text}\n\nНово прашање: {query}"
     try:
         condensed = await transform_query(
             transform_input,

--- a/api/app/llms/context.py
+++ b/api/app/llms/context.py
@@ -526,7 +526,7 @@ async def _contextualize_query(
         )
         return query
     condensed = condensed.strip()
-    if condensed == transform_input:
+    if condensed == transform_input.strip():
         return query
     if condensed and condensed != query:
         logger.info(

--- a/api/app/llms/query_variants.py
+++ b/api/app/llms/query_variants.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from dataclasses import dataclass
 from typing import Literal, assert_never
 
@@ -10,6 +11,8 @@ from app.llms.query_transform import transform_query
 from app.utils.timing import timed
 
 QueryVariantKind = Literal["raw", "rewrite", "hyde"]
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,6 +39,7 @@ class QueryVariantBundle:
                 return QueryTransformMode.HYDE
             case True, True:
                 return QueryTransformMode.REWRITE_HYDE
+        raise AssertionError("Unreachable query variant mode")
 
 
 def query_variant_count(mode: QueryTransformMode) -> int:
@@ -144,15 +148,22 @@ async def _rewrite_query(
     query_transform_model: ChatModel,
     credentials: LlmProviderCredentials | None = None,
 ) -> str | None:
-    with timed("retrieval.query_rewrite"):
-        rewritten = await transform_query(
-            search_query,
-            query_transform_model,
-            temperature=0.0,
-            top_p=1.0,
-            max_tokens=128,
-            credentials=credentials,
+    try:
+        with timed("retrieval.query_rewrite"):
+            rewritten = await transform_query(
+                search_query,
+                query_transform_model,
+                temperature=0.0,
+                top_p=1.0,
+                max_tokens=128,
+                credentials=credentials,
+            )
+    except Exception as exc:
+        logger.warning(
+            "Query rewrite failed; omitting variant error_type=%s",
+            type(exc).__name__,
         )
+        return None
     rewritten = rewritten.strip()
     return rewritten if rewritten and rewritten != search_query.strip() else None
 
@@ -162,15 +173,22 @@ async def _hyde_passage(
     query_transform_model: ChatModel,
     credentials: LlmProviderCredentials | None = None,
 ) -> str | None:
-    with timed("retrieval.hyde"):
-        hyde = await transform_query(
-            search_query,
-            query_transform_model,
-            system_prompt=HYDE_SYSTEM_PROMPT,
-            temperature=0.2,
-            top_p=1.0,
-            max_tokens=200,
-            credentials=credentials,
+    try:
+        with timed("retrieval.hyde"):
+            hyde = await transform_query(
+                search_query,
+                query_transform_model,
+                system_prompt=HYDE_SYSTEM_PROMPT,
+                temperature=0.2,
+                top_p=1.0,
+                max_tokens=200,
+                credentials=credentials,
+            )
+    except Exception as exc:
+        logger.warning(
+            "HyDE generation failed; omitting variant error_type=%s",
+            type(exc).__name__,
         )
+        return None
     hyde = hyde.strip()
     return hyde if hyde and hyde != search_query.strip() else None

--- a/api/app/llms/query_variants.py
+++ b/api/app/llms/query_variants.py
@@ -24,6 +24,19 @@ class QueryVariantBundle:
     variants: tuple[QueryVariant, ...]
     rerank_query: str
 
+    @property
+    def mode(self) -> QueryTransformMode:
+        kinds = {variant.kind for variant in self.variants}
+        match ("rewrite" in kinds, "hyde" in kinds):
+            case False, False:
+                return QueryTransformMode.RAW
+            case True, False:
+                return QueryTransformMode.REWRITE
+            case False, True:
+                return QueryTransformMode.HYDE
+            case True, True:
+                return QueryTransformMode.REWRITE_HYDE
+
 
 def query_variant_count(mode: QueryTransformMode) -> int:
     match mode:
@@ -55,35 +68,71 @@ async def build_query_variants(
                 query_transform_model,
                 credentials,
             )
-            return QueryVariantBundle(
-                variants=(
-                    QueryVariant(kind="rewrite", text=rewritten, is_document=False),
-                    raw,
-                ),
-                rerank_query=rewritten,
-            )
+            match rewritten:
+                case None:
+                    return QueryVariantBundle(
+                        variants=(raw,),
+                        rerank_query=search_query,
+                    )
+                case str():
+                    return QueryVariantBundle(
+                        variants=(
+                            QueryVariant(
+                                kind="rewrite",
+                                text=rewritten,
+                                is_document=False,
+                            ),
+                            raw,
+                        ),
+                        rerank_query=rewritten,
+                    )
         case QueryTransformMode.HYDE:
             hyde = await _hyde_passage(
                 search_query,
                 query_transform_model,
                 credentials,
             )
-            return QueryVariantBundle(
-                variants=(QueryVariant(kind="hyde", text=hyde, is_document=True), raw),
-                rerank_query=search_query,
-            )
+            match hyde:
+                case None:
+                    return QueryVariantBundle(
+                        variants=(raw,),
+                        rerank_query=search_query,
+                    )
+                case str():
+                    return QueryVariantBundle(
+                        variants=(
+                            QueryVariant(kind="hyde", text=hyde, is_document=True),
+                            raw,
+                        ),
+                        rerank_query=search_query,
+                    )
         case QueryTransformMode.REWRITE_HYDE:
             rewritten, hyde = await asyncio.gather(
                 _rewrite_query(search_query, query_transform_model, credentials),
                 _hyde_passage(search_query, query_transform_model, credentials),
             )
-            return QueryVariantBundle(
-                variants=(
-                    QueryVariant(kind="hyde", text=hyde, is_document=True),
-                    QueryVariant(kind="rewrite", text=rewritten, is_document=False),
-                    raw,
+            variants = (
+                *(
+                    (QueryVariant(kind="hyde", text=hyde, is_document=True),)
+                    if hyde is not None
+                    else ()
                 ),
-                rerank_query=rewritten,
+                *(
+                    (
+                        QueryVariant(
+                            kind="rewrite",
+                            text=rewritten,
+                            is_document=False,
+                        ),
+                    )
+                    if rewritten is not None
+                    else ()
+                ),
+                raw,
+            )
+            return QueryVariantBundle(
+                variants=variants,
+                rerank_query=rewritten or search_query,
             )
         case unreachable:
             assert_never(unreachable)
@@ -94,7 +143,7 @@ async def _rewrite_query(
     search_query: str,
     query_transform_model: ChatModel,
     credentials: LlmProviderCredentials | None = None,
-) -> str:
+) -> str | None:
     with timed("retrieval.query_rewrite"):
         rewritten = await transform_query(
             search_query,
@@ -104,14 +153,15 @@ async def _rewrite_query(
             max_tokens=128,
             credentials=credentials,
         )
-    return rewritten.strip() or search_query
+    rewritten = rewritten.strip()
+    return rewritten if rewritten and rewritten != search_query.strip() else None
 
 
 async def _hyde_passage(
     search_query: str,
     query_transform_model: ChatModel,
     credentials: LlmProviderCredentials | None = None,
-) -> str:
+) -> str | None:
     with timed("retrieval.hyde"):
         hyde = await transform_query(
             search_query,
@@ -122,4 +172,5 @@ async def _hyde_passage(
             max_tokens=200,
             credentials=credentials,
         )
-    return hyde.strip() or search_query
+    hyde = hyde.strip()
+    return hyde if hyde and hyde != search_query.strip() else None

--- a/api/app/llms/retrieval_result.py
+++ b/api/app/llms/retrieval_result.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Literal, NotRequired, TypedDict
 
+from app.llms.query_modes import QueryTransformMode
+
 
 class RetrievalSourceLinkPayload(TypedDict):
     label: str
@@ -56,6 +58,7 @@ class RetrievalSource:
 @dataclass(frozen=True, slots=True)
 class RetrievedContext:
     text: str
+    effective_transform_mode: QueryTransformMode
     sources: tuple[RetrievalSource, ...] = ()
 
     def sources_payload(self) -> list[RetrievalSourcePayload]:

--- a/api/tests/eval/README.md
+++ b/api/tests/eval/README.md
@@ -103,6 +103,10 @@ The comparison report shows bucket deltas, fixed cases, newly broken cases, and
 unchanged misses. It exits non-zero when new regressions exceed `--max-regressions`
 (default `0`), so it can be used as a manual release gate before changing embeddings,
 thresholds, reranking, query transformation, chunking, or corpus ingestion.
+Cases whose effective query-transform mode or retrieval budget differs from that run's
+requested configuration are reported as incomparable and make the comparison invalid
+instead of being counted as retrieval regressions. Intentional comparisons between two
+different requested modes remain valid when each run actually used its requested mode.
 
 Run the same golden set across modes to isolate query-transformation impact:
 

--- a/api/tests/eval/README.md
+++ b/api/tests/eval/README.md
@@ -67,6 +67,13 @@ Useful flags: `--transform-mode raw|rewrite|hyde|rewrite_hyde`, `--no-transform`
 (legacy alias for `--transform-mode raw`), `--top-k`, `--initial-k`, `--ideal-limit`,
 `--concurrency`, `--json out.json` (per-example dump for diffing across runs).
 
+JSON output keeps the legacy config keys `query_transform_mode`, `initial_k`,
+`per_query_k`, and `ideal_limit` for existing comparison tooling. Those values describe
+the requested mode's nominal budget. The explicit `requested_*` config keys preserve the
+CLI inputs, while each result's `effective_transform_mode`, `effective_initial_k`, and
+`effective_per_query_k` record the variants and retrieval budget actually used after a
+transform is omitted or fails.
+
 ## Comparing two runs
 
 Use the committed golden set as a decision tool by saving a known-good baseline and

--- a/api/tests/eval/compare_eval.py
+++ b/api/tests/eval/compare_eval.py
@@ -1,14 +1,17 @@
 import argparse
-import json
 import sys
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Final, Literal
+from typing import Final
 
-from . import eval_json_path, resolve_eval_json_path
-
-AnchorType = Literal["Q", "C", "none"]
-JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+from . import eval_json_path
+from .compare_eval_models import (
+    EffectiveRetrievalConfig,
+    EvalCase,
+    EvalJsonError,
+    JsonValue,
+    load_eval,
+    parse_cases,
+)
 
 BUCKETS: Final = (
     "overall",
@@ -18,42 +21,6 @@ BUCKETS: Final = (
     "difficulty=hard",
     "abstain",
 )
-
-
-class EvalJsonError(Exception):
-    pass
-
-
-@dataclass(frozen=True, slots=True)
-class EvalCase:
-    id: str
-    anchor_type: AnchorType
-    difficulty: str
-    category: str
-    ann_ideal: bool
-    ann_prod: bool
-    final: bool
-    rank: int | None
-
-    @property
-    def is_abstain(self) -> bool:
-        return self.anchor_type == "none"
-
-    @property
-    def succeeded(self) -> bool:
-        return not self.final if self.is_abstain else self.final
-
-    @property
-    def failure_reason(self) -> str:
-        if self.succeeded:
-            return "PASS"
-        if self.is_abstain:
-            return "ABSTAIN-LEAK"
-        if not self.ann_ideal:
-            return "ANN-MISS"
-        if not self.ann_prod:
-            return "ANN-PROD-MISS"
-        return "RERANK-MISS"
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,78 +46,7 @@ class EvalComparison:
     fixed: list[CaseDelta]
     new_regressions: list[CaseDelta]
     unchanged_misses: list[CaseDelta]
-
-
-def _mapping(value: JsonValue, path: str) -> dict[str, JsonValue]:
-    if isinstance(value, dict):
-        return value
-    raise EvalJsonError(f"{path}: expected object")
-
-
-def _items(value: JsonValue, path: str) -> list[JsonValue]:
-    if isinstance(value, list):
-        return value
-    raise EvalJsonError(f"{path}: expected array")
-
-
-def _text(value: JsonValue, path: str) -> str:
-    if isinstance(value, str):
-        return value
-    raise EvalJsonError(f"{path}: expected string")
-
-
-def _flag(value: JsonValue, path: str) -> bool:
-    if isinstance(value, bool):
-        return value
-    raise EvalJsonError(f"{path}: expected boolean")
-
-
-def _rank(value: JsonValue, path: str) -> int | None:
-    if value is None:
-        return None
-    if isinstance(value, int):
-        return value
-    raise EvalJsonError(f"{path}: expected integer or null")
-
-
-def _anchor_type(value: JsonValue, path: str) -> AnchorType:
-    raw = _text(_mapping(value, path).get("type"), f"{path}.type")
-    if raw == "Q":
-        return "Q"
-    if raw == "C":
-        return "C"
-    if raw == "none":
-        return "none"
-    raise EvalJsonError(f"{path}.type: expected Q, C, or none")
-
-
-def _case(value: JsonValue, path: str) -> EvalCase:
-    row = _mapping(value, path)
-    return EvalCase(
-        id=_text(row.get("id"), f"{path}.id"),
-        anchor_type=_anchor_type(row.get("anchor"), f"{path}.anchor"),
-        difficulty=_text(row.get("difficulty", ""), f"{path}.difficulty"),
-        category=_text(row.get("category", ""), f"{path}.category"),
-        ann_ideal=_flag(row.get("ann_ideal"), f"{path}.ann_ideal"),
-        ann_prod=_flag(row.get("ann_prod"), f"{path}.ann_prod"),
-        final=_flag(row.get("final"), f"{path}.final"),
-        rank=_rank(row.get("rank"), f"{path}.rank"),
-    )
-
-
-def _cases(data: dict[str, JsonValue], path: str) -> dict[str, EvalCase]:
-    rows = _items(data.get("results"), f"{path}.results")
-    parsed = [_case(row, f"{path}.results[{index}]") for index, row in enumerate(rows)]
-    return {case.id: case for case in parsed}
-
-
-def load_eval(path: Path) -> dict[str, EvalCase]:
-    try:
-        safe_path = resolve_eval_json_path(path)
-        data: JsonValue = json.loads(safe_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
-        raise EvalJsonError(f"{path}: {exc}") from exc
-    return _cases(_mapping(data, str(safe_path)), str(safe_path))
+    incomparable_configs: list[CaseDelta]
 
 
 def _in_bucket(case: EvalCase, bucket: str) -> bool:
@@ -185,7 +81,10 @@ def compare_runs(
     baseline: dict[str, JsonValue],
     current: dict[str, JsonValue],
 ) -> EvalComparison:
-    return compare_cases(_cases(baseline, "baseline"), _cases(current, "current"))
+    return compare_cases(
+        parse_cases(baseline, "baseline"),
+        parse_cases(current, "current"),
+    )
 
 
 def compare_cases(
@@ -201,25 +100,37 @@ def compare_cases(
     pairs = [
         (baseline[id_], current[id_]) for id_ in sorted(baseline_ids & current_ids)
     ]
-    baseline_cases = [baseline_case for baseline_case, _current_case in pairs]
-    current_cases = [current_case for _baseline_case, current_case in pairs]
+    incomparable_configs = [
+        CaseDelta(base, cur)
+        for base, cur in pairs
+        if not base.used_requested_config or not cur.used_requested_config
+    ]
+    comparable_pairs = [
+        (base, cur)
+        for base, cur in pairs
+        if base.used_requested_config and cur.used_requested_config
+    ]
+    baseline_cases = [
+        baseline_case for baseline_case, _current_case in comparable_pairs
+    ]
+    current_cases = [current_case for _baseline_case, current_case in comparable_pairs]
     bucket_deltas = {
         bucket: (_summary(baseline_cases, bucket), _summary(current_cases, bucket))
         for bucket in BUCKETS
     }
     fixed = [
         CaseDelta(base, cur)
-        for base, cur in pairs
+        for base, cur in comparable_pairs
         if not base.succeeded and cur.succeeded
     ]
     regressions = [
         CaseDelta(base, cur)
-        for base, cur in pairs
+        for base, cur in comparable_pairs
         if base.succeeded and not cur.succeeded
     ]
     unchanged = [
         CaseDelta(base, cur)
-        for base, cur in pairs
+        for base, cur in comparable_pairs
         if not base.succeeded and not cur.succeeded
     ]
     return EvalComparison(
@@ -227,6 +138,7 @@ def compare_cases(
         fixed=fixed,
         new_regressions=regressions,
         unchanged_misses=unchanged,
+        incomparable_configs=incomparable_configs,
     )
 
 
@@ -250,6 +162,15 @@ def _append_cases(lines: list[str], title: str, cases: list[CaseDelta]) -> None:
     )
 
 
+def _format_config(config: EffectiveRetrievalConfig | None) -> str:
+    if config is None:
+        return "unavailable"
+    return (
+        f"{config.transform_mode}(initial_k={config.initial_k}, "
+        f"per_query_k={config.per_query_k})"
+    )
+
+
 def render_report(comparison: EvalComparison, *, max_regressions: int = 0) -> str:
     lines = ["Retrieval eval comparison", "", "Buckets"]
     for bucket, (baseline, current) in comparison.bucket_deltas.items():
@@ -264,10 +185,31 @@ def render_report(comparison: EvalComparison, *, max_regressions: int = 0) -> st
     _append_cases(lines, "New regressions", comparison.new_regressions)
     lines.append("")
     _append_cases(lines, "Unchanged misses", comparison.unchanged_misses)
-    decision = "FAIL" if len(comparison.new_regressions) > max_regressions else "PASS"
+    lines.append("")
+    lines.append("Incomparable effective retrieval configurations")
+    lines.extend(
+        [
+            f"  {case.current.id}: baseline requested="
+            f"{_format_config(case.baseline.requested_config)} effective="
+            f"{_format_config(case.baseline.effective_config)}; current requested="
+            f"{_format_config(case.current.requested_config)} effective="
+            f"{_format_config(case.current.effective_config)}"
+            for case in comparison.incomparable_configs
+        ]
+        if comparison.incomparable_configs
+        else ["  none"],
+    )
+    if comparison.incomparable_configs:
+        decision = "INVALID"
+    elif len(comparison.new_regressions) > max_regressions:
+        decision = "FAIL"
+    else:
+        decision = "PASS"
     lines.append("")
     lines.append(
-        f"Decision: {decision} ({len(comparison.new_regressions)} new regressions, budget {max_regressions})",
+        f"Decision: {decision} ({len(comparison.new_regressions)} new regressions, "
+        f"{len(comparison.incomparable_configs)} incomparable configurations, "
+        f"budget {max_regressions})",
     )
     return "\n".join(lines)
 
@@ -284,6 +226,8 @@ def main(argv: list[str] | None = None) -> int:
         print(exc, file=sys.stderr)
         return 2
     print(render_report(comparison, max_regressions=ns.max_regressions))
+    if comparison.incomparable_configs:
+        return 2
     return 1 if len(comparison.new_regressions) > ns.max_regressions else 0
 
 

--- a/api/tests/eval/compare_eval_models.py
+++ b/api/tests/eval/compare_eval_models.py
@@ -1,0 +1,246 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from app.llms.query_modes import QueryTransformMode
+from app.llms.retrieval_budget import retrieval_budget
+
+from . import resolve_eval_json_path
+
+AnchorType = Literal["Q", "C", "none"]
+TransformMode = Literal["raw", "rewrite", "hyde", "rewrite_hyde"]
+JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+
+
+class EvalJsonError(Exception):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class EffectiveRetrievalConfig:
+    transform_mode: TransformMode
+    initial_k: int
+    per_query_k: int
+
+
+@dataclass(frozen=True, slots=True)
+class EvalCase:
+    id: str
+    anchor_type: AnchorType
+    difficulty: str
+    category: str
+    ann_ideal: bool
+    ann_prod: bool
+    final: bool
+    rank: int | None
+    requested_config: EffectiveRetrievalConfig
+    effective_config: EffectiveRetrievalConfig | None
+
+    @property
+    def is_abstain(self) -> bool:
+        return self.anchor_type == "none"
+
+    @property
+    def succeeded(self) -> bool:
+        return not self.final if self.is_abstain else self.final
+
+    @property
+    def used_requested_config(self) -> bool:
+        return self.effective_config == self.requested_config
+
+    @property
+    def failure_reason(self) -> str:
+        if self.succeeded:
+            return "PASS"
+        if self.is_abstain:
+            return "ABSTAIN-LEAK"
+        if not self.ann_ideal:
+            return "ANN-MISS"
+        if not self.ann_prod:
+            return "ANN-PROD-MISS"
+        return "RERANK-MISS"
+
+
+def _mapping(value: JsonValue, path: str) -> dict[str, JsonValue]:
+    if isinstance(value, dict):
+        return value
+    raise EvalJsonError(f"{path}: expected object")
+
+
+def _items(value: JsonValue, path: str) -> list[JsonValue]:
+    if isinstance(value, list):
+        return value
+    raise EvalJsonError(f"{path}: expected array")
+
+
+def _text(value: JsonValue, path: str) -> str:
+    if isinstance(value, str):
+        return value
+    raise EvalJsonError(f"{path}: expected string")
+
+
+def _flag(value: JsonValue, path: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    raise EvalJsonError(f"{path}: expected boolean")
+
+
+def _optional_int(value: JsonValue, path: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    raise EvalJsonError(f"{path}: expected integer or null")
+
+
+def _required_int(value: JsonValue, path: str) -> int:
+    parsed = _optional_int(value, path)
+    if parsed is None:
+        raise EvalJsonError(f"{path}: expected integer")
+    return parsed
+
+
+def _transform_mode(value: JsonValue, path: str) -> TransformMode:
+    raw = _text(value, path)
+    if raw == "raw":
+        return "raw"
+    if raw == "rewrite":
+        return "rewrite"
+    if raw == "hyde":
+        return "hyde"
+    if raw == "rewrite_hyde":
+        return "rewrite_hyde"
+    raise EvalJsonError(f"{path}: expected raw, rewrite, hyde, or rewrite_hyde")
+
+
+def _anchor_type(value: JsonValue, path: str) -> AnchorType:
+    raw = _text(_mapping(value, path).get("type"), f"{path}.type")
+    if raw == "Q":
+        return "Q"
+    if raw == "C":
+        return "C"
+    if raw == "none":
+        return "none"
+    raise EvalJsonError(f"{path}.type: expected Q, C, or none")
+
+
+def _effective_config(
+    row: dict[str, JsonValue],
+    path: str,
+    requested_config: EffectiveRetrievalConfig,
+) -> EffectiveRetrievalConfig | None:
+    keys = (
+        "effective_transform_mode",
+        "effective_initial_k",
+        "effective_per_query_k",
+    )
+    present = [key in row for key in keys]
+    if not any(present):
+        return requested_config
+    if not all(present):
+        raise EvalJsonError(f"{path}: effective retrieval configuration is partial")
+    values = [row[key] for key in keys]
+    if all(value is None for value in values):
+        return None
+    if any(value is None for value in values):
+        raise EvalJsonError(f"{path}: effective retrieval configuration is partial")
+    return EffectiveRetrievalConfig(
+        transform_mode=_transform_mode(
+            values[0],
+            f"{path}.effective_transform_mode",
+        ),
+        initial_k=_required_int(values[1], f"{path}.effective_initial_k"),
+        per_query_k=_required_int(values[2], f"{path}.effective_per_query_k"),
+    )
+
+
+def _case(
+    value: JsonValue,
+    path: str,
+    requested_config: EffectiveRetrievalConfig,
+) -> EvalCase:
+    row = _mapping(value, path)
+    return EvalCase(
+        id=_text(row.get("id"), f"{path}.id"),
+        anchor_type=_anchor_type(row.get("anchor"), f"{path}.anchor"),
+        difficulty=_text(row.get("difficulty", ""), f"{path}.difficulty"),
+        category=_text(row.get("category", ""), f"{path}.category"),
+        ann_ideal=_flag(row.get("ann_ideal"), f"{path}.ann_ideal"),
+        ann_prod=_flag(row.get("ann_prod"), f"{path}.ann_prod"),
+        final=_flag(row.get("final"), f"{path}.final"),
+        rank=_optional_int(row.get("rank"), f"{path}.rank"),
+        requested_config=requested_config,
+        effective_config=_effective_config(row, path, requested_config),
+    )
+
+
+def _requested_config(
+    config: dict[str, JsonValue],
+    path: str,
+) -> EffectiveRetrievalConfig:
+    nominal_keys = ("query_transform_mode", "initial_k", "per_query_k")
+    nominal_present = [key in config for key in nominal_keys]
+    if all(nominal_present):
+        return EffectiveRetrievalConfig(
+            transform_mode=_transform_mode(
+                config["query_transform_mode"],
+                f"{path}.query_transform_mode",
+            ),
+            initial_k=_required_int(config["initial_k"], f"{path}.initial_k"),
+            per_query_k=_required_int(
+                config["per_query_k"],
+                f"{path}.per_query_k",
+            ),
+        )
+    if any(nominal_present):
+        raise EvalJsonError(f"{path}: requested retrieval configuration is partial")
+
+    prior_keys = ("requested_query_transform_mode", "requested_initial_k")
+    prior_present = [key in config for key in prior_keys]
+    if all(prior_present):
+        transform_mode = _transform_mode(
+            config["requested_query_transform_mode"],
+            f"{path}.requested_query_transform_mode",
+        )
+        requested_initial_k = _required_int(
+            config["requested_initial_k"],
+            f"{path}.requested_initial_k",
+        )
+        budget = retrieval_budget(
+            QueryTransformMode(transform_mode),
+            requested_initial_k,
+        )
+        return EffectiveRetrievalConfig(
+            transform_mode=transform_mode,
+            initial_k=budget.initial_k,
+            per_query_k=budget.per_query_k,
+        )
+    if any(prior_present):
+        raise EvalJsonError(f"{path}: requested retrieval configuration is partial")
+    raise EvalJsonError(f"{path}: requested retrieval configuration is missing")
+
+
+def parse_cases(data: dict[str, JsonValue], path: str) -> dict[str, EvalCase]:
+    config_path = f"{path}.config"
+    config = _mapping(data.get("config"), config_path)
+    requested_config = _requested_config(config, config_path)
+    rows = _items(data.get("results"), f"{path}.results")
+    parsed: dict[str, EvalCase] = {}
+    for index, row in enumerate(rows):
+        case = _case(row, f"{path}.results[{index}]", requested_config)
+        if case.id in parsed:
+            raise EvalJsonError(
+                f"{path}.results[{index}]: duplicate case id: {case.id}",
+            )
+        parsed[case.id] = case
+    return parsed
+
+
+def load_eval(path: Path) -> dict[str, EvalCase]:
+    try:
+        safe_path = resolve_eval_json_path(path)
+        data: JsonValue = json.loads(safe_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise EvalJsonError(f"{path}: {exc}") from exc
+    return parse_cases(_mapping(data, str(safe_path)), str(safe_path))

--- a/api/tests/eval/run_eval.py
+++ b/api/tests/eval/run_eval.py
@@ -474,10 +474,15 @@ async def main_async(ns: argparse.Namespace) -> int:
     print(agg.report())
 
     if ns.json:
+        requested_budget = retrieval_budget(transform_mode, ns.initial_k)
         out = {
             "config": {
                 "embedding_model": embedding_model.value,
                 "query_transform_model": qt_model.value,
+                "query_transform_mode": transform_mode.value,
+                "initial_k": requested_budget.initial_k,
+                "per_query_k": requested_budget.per_query_k,
+                "ideal_limit": max(ns.ideal_limit, requested_budget.per_query_k),
                 "requested_query_transform_mode": transform_mode.value,
                 "requested_initial_k": ns.initial_k,
                 "budget_scope": "per_example_effective_mode",

--- a/api/tests/eval/run_eval.py
+++ b/api/tests/eval/run_eval.py
@@ -125,6 +125,9 @@ class Result:
     rank: int | None = None
     n_candidates: int = 0
     best_distance: float | None = None
+    effective_transform_mode: QueryTransformMode | None = None
+    effective_initial_k: int | None = None
+    effective_per_query_k: int | None = None
 
 
 @dataclass
@@ -394,6 +397,9 @@ async def evaluate_one(
         rank=rank,
         n_candidates=len(cand_keys),
         best_distance=round(best_distance, 4) if best_distance is not None else None,
+        effective_transform_mode=variant_bundle.mode,
+        effective_initial_k=budget.initial_k,
+        effective_per_query_k=budget.per_query_k,
     )
 
 
@@ -423,8 +429,6 @@ async def main_async(ns: argparse.Namespace) -> int:
     embedding_model = Model(ns.embedding_model)
     qt_model = Model(ns.query_transform_model)
     transform_mode = QueryTransformMode.RAW if ns.no_transform else ns.transform_mode
-    budget = retrieval_budget(transform_mode, ns.initial_k)
-    ideal_probe_limit = max(ns.ideal_limit, budget.per_query_k)
 
     init_http_client()
     db = Database(dsn=settings.DATABASE_URL)
@@ -444,7 +448,7 @@ async def main_async(ns: argparse.Namespace) -> int:
                         qt_model=qt_model,
                         initial_k=ns.initial_k,
                         top_k=ns.top_k,
-                        ideal_limit=ideal_probe_limit,
+                        ideal_limit=ns.ideal_limit,
                         transform_mode=transform_mode,
                     )
                 except Exception as exc:  # one bad example shouldn't abort the run
@@ -461,8 +465,10 @@ async def main_async(ns: argparse.Namespace) -> int:
 
     header = (
         f"golden={ns.golden}  n={len(examples)}  embed={embedding_model.value}  "
-        f"qt={qt_model.value}  transform_mode={transform_mode.value}  "
-        f"initial_k={budget.initial_k}  per_query_k={budget.per_query_k}  ideal_limit={ideal_probe_limit}  top_k={ns.top_k}  reranker_min={settings.RERANKER_MIN_SCORE}"
+        f"qt={qt_model.value}  requested_transform_mode={transform_mode.value}  "
+        f"requested_initial_k={ns.initial_k}  budget=per-example-effective-mode  "
+        f"ideal_limit_floor={ns.ideal_limit}  top_k={ns.top_k}  "
+        f"reranker_min={settings.RERANKER_MIN_SCORE}"
     )
     print(header)
     print(agg.report())
@@ -472,10 +478,10 @@ async def main_async(ns: argparse.Namespace) -> int:
             "config": {
                 "embedding_model": embedding_model.value,
                 "query_transform_model": qt_model.value,
-                "query_transform_mode": transform_mode.value,
-                "initial_k": budget.initial_k,
-                "per_query_k": budget.per_query_k,
-                "ideal_limit": ideal_probe_limit,
+                "requested_query_transform_mode": transform_mode.value,
+                "requested_initial_k": ns.initial_k,
+                "budget_scope": "per_example_effective_mode",
+                "ideal_limit_floor": ns.ideal_limit,
                 "top_k": ns.top_k,
                 "reranker_min_score": settings.RERANKER_MIN_SCORE,
             },
@@ -490,6 +496,13 @@ async def main_async(ns: argparse.Namespace) -> int:
                     "final": r.final,
                     "rank": r.rank,
                     "best_distance": r.best_distance,
+                    "effective_transform_mode": (
+                        r.effective_transform_mode.value
+                        if r.effective_transform_mode is not None
+                        else None
+                    ),
+                    "effective_initial_k": r.effective_initial_k,
+                    "effective_per_query_k": r.effective_per_query_k,
                 }
                 for r in agg.results
             ],

--- a/api/tests/eval/run_eval.py
+++ b/api/tests/eval/run_eval.py
@@ -253,7 +253,7 @@ async def evaluate_one(
     variants = [
         (variant.text, variant.is_document) for variant in variant_bundle.variants
     ]
-    budget = retrieval_budget(transform_mode, initial_k)
+    budget = retrieval_budget(variant_bundle.mode, initial_k)
     ideal_probe_limit = max(ideal_limit, budget.per_query_k)
 
     embeddings = await asyncio.gather(

--- a/api/tests/eval/test_compare_eval.py
+++ b/api/tests/eval/test_compare_eval.py
@@ -4,6 +4,7 @@ from math import isclose
 
 from . import eval_json_path
 from .compare_eval import (
+    JsonValue,
     _non_negative_int,
     compare_runs,
     main,
@@ -20,15 +21,15 @@ def _result(
     ann_ideal: bool = True,
     ann_prod: bool = True,
     difficulty: str = "easy",
-) -> dict:
-    anchor: dict[str, int | str] = {"type": anchor_type}
+) -> dict[str, JsonValue]:
+    anchor: dict[str, JsonValue] = {"type": anchor_type}
     if anchor_type == "Q":
         anchor["name"] = f"question-{example_id}"
     if anchor_type == "C":
         anchor["document_name"] = f"document-{example_id}"
         anchor["chunk_index"] = 1
 
-    return {
+    result: dict[str, JsonValue] = {
         "id": example_id,
         "difficulty": difficulty,
         "category": "test",
@@ -39,16 +40,19 @@ def _result(
         "rank": 1 if final else None,
         "best_distance": 0.24,
     }
+    return result
 
 
-def _run(results: list[dict]) -> dict:
-    return {
-        "config": {
-            "embedding_model": "BAAI/bge-m3",
-            "query_transform_mode": "rewrite_hyde",
-        },
-        "results": results,
+def _run(results: list[dict[str, JsonValue]]) -> dict[str, JsonValue]:
+    config: dict[str, JsonValue] = {
+        "embedding_model": "BAAI/bge-m3",
+        "query_transform_mode": "rewrite_hyde",
+        "initial_k": 40,
+        "per_query_k": 10,
     }
+    result_values: list[JsonValue] = []
+    result_values.extend(results)
+    return {"config": config, "results": result_values}
 
 
 def test_compare_runs_identifies_decision_cases_by_bucket():

--- a/api/tests/eval/test_compare_eval_config.py
+++ b/api/tests/eval/test_compare_eval_config.py
@@ -1,0 +1,107 @@
+import json
+from pathlib import Path
+
+from .compare_eval import JsonValue, main
+
+
+def _result(
+    case_id: str,
+    final: bool,
+    effective_mode: str,
+) -> dict[str, JsonValue]:
+    per_query_k = 40 if effective_mode == "raw" else 10
+    return {
+        "id": case_id,
+        "difficulty": "hard",
+        "category": "test",
+        "anchor": {"type": "C"},
+        "ann_ideal": final,
+        "ann_prod": final,
+        "final": final,
+        "rank": 1 if final else None,
+        "effective_transform_mode": effective_mode,
+        "effective_initial_k": 40,
+        "effective_per_query_k": per_query_k,
+    }
+
+
+def _run(results: list[JsonValue], mode: str = "rewrite_hyde") -> dict[str, JsonValue]:
+    return {
+        "config": {
+            "query_transform_mode": mode,
+            "initial_k": 40,
+            "per_query_k": 40 if mode == "raw" else 10,
+        },
+        "results": results,
+    }
+
+
+def _write(path: Path, run: dict[str, JsonValue]) -> None:
+    path.write_text(json.dumps(run), encoding="utf-8")
+
+
+def test_cli_rejects_fallback_from_requested_retrieval_config(tmp_path, capsys):
+    baseline_path = tmp_path / "baseline.json"
+    current_path = tmp_path / "current.json"
+    _write(baseline_path, _run([_result("fallback-miss", True, "rewrite_hyde")]))
+    _write(current_path, _run([_result("fallback-miss", False, "raw")]))
+
+    exit_code = main(
+        ["--baseline", str(baseline_path), "--current", str(current_path)],
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "rewrite_hyde(initial_k=40, per_query_k=10)" in captured.out
+    assert "raw(initial_k=40, per_query_k=40)" in captured.out
+    assert "0 new regressions" in captured.out
+    assert "Decision: INVALID" in captured.out
+
+
+def test_cli_allows_intentional_comparison_between_requested_modes(tmp_path, capsys):
+    baseline_path = tmp_path / "baseline.json"
+    current_path = tmp_path / "current.json"
+    _write(baseline_path, _run([_result("mode-ab", True, "rewrite_hyde")]))
+    _write(current_path, _run([_result("mode-ab", False, "raw")], "raw"))
+
+    exit_code = main(
+        ["--baseline", str(baseline_path), "--current", str(current_path)],
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "1 new regressions" in captured.out
+    assert "0 incomparable configurations" in captured.out
+    assert "Decision: FAIL" in captured.out
+
+
+def test_cli_keeps_comparable_regressions_when_another_case_falls_back(
+    tmp_path,
+    capsys,
+):
+    baseline_path = tmp_path / "baseline.json"
+    current_path = tmp_path / "current.json"
+    baseline = _run(
+        [
+            _result("genuine-regression", True, "rewrite_hyde"),
+            _result("fallback", True, "rewrite_hyde"),
+        ],
+    )
+    current = _run(
+        [
+            _result("genuine-regression", False, "rewrite_hyde"),
+            _result("fallback", False, "raw"),
+        ],
+    )
+    _write(baseline_path, baseline)
+    _write(current_path, current)
+
+    exit_code = main(
+        ["--baseline", str(baseline_path), "--current", str(current_path)],
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "overall: 1/1 (100.0%) -> 0/1 (0.0%)" in captured.out
+    assert "1 new regressions" in captured.out
+    assert "1 incomparable configurations" in captured.out

--- a/api/tests/eval/test_compare_eval_models.py
+++ b/api/tests/eval/test_compare_eval_models.py
@@ -1,0 +1,191 @@
+import pytest
+
+from .compare_eval import compare_runs
+from .compare_eval_models import (
+    EffectiveRetrievalConfig,
+    EvalJsonError,
+    JsonValue,
+    parse_cases,
+)
+
+
+def _result(**effective_config: JsonValue) -> dict[str, JsonValue]:
+    result: dict[str, JsonValue] = {
+        "id": "case-1",
+        "difficulty": "easy",
+        "category": "test",
+        "anchor": {"type": "Q"},
+        "ann_ideal": True,
+        "ann_prod": True,
+        "final": True,
+        "rank": 1,
+    }
+    result.update(effective_config)
+    return result
+
+
+def _run(
+    results: list[JsonValue],
+    *,
+    mode: str = "rewrite_hyde",
+) -> dict[str, JsonValue]:
+    return {
+        "config": {
+            "query_transform_mode": mode,
+            "initial_k": 40,
+            "per_query_k": 40 if mode == "raw" else 10,
+        },
+        "results": results,
+    }
+
+
+def test_legacy_result_uses_run_config_when_compared_with_modern_result():
+    legacy = _run([_result()])
+    modern = _run(
+        [
+            _result(
+                effective_transform_mode="rewrite_hyde",
+                effective_initial_k=40,
+                effective_per_query_k=10,
+            ),
+        ],
+    )
+
+    comparison = compare_runs(legacy, modern)
+
+    assert comparison.incomparable_configs == []
+
+
+def test_null_effective_config_is_incomparable():
+    unavailable = _run(
+        [
+            _result(
+                effective_transform_mode=None,
+                effective_initial_k=None,
+                effective_per_query_k=None,
+            ),
+        ],
+    )
+
+    comparison = compare_runs(_run([_result()]), unavailable)
+
+    assert [case.current.id for case in comparison.incomparable_configs] == ["case-1"]
+
+
+@pytest.mark.parametrize(
+    "effective_config",
+    [
+        {"effective_transform_mode": "raw"},
+        {
+            "effective_transform_mode": "raw",
+            "effective_initial_k": True,
+            "effective_per_query_k": 40,
+        },
+        {
+            "effective_transform_mode": "unknown",
+            "effective_initial_k": 40,
+            "effective_per_query_k": 40,
+        },
+    ],
+)
+def test_malformed_effective_config_is_rejected(
+    effective_config: dict[str, JsonValue],
+):
+    with pytest.raises(EvalJsonError):
+        compare_runs(_run([_result(**effective_config)]), _run([_result()]))
+
+
+def test_duplicate_case_ids_are_rejected():
+    duplicate = _run([_result(), _result()])
+
+    with pytest.raises(EvalJsonError, match="duplicate case id: case-1"):
+        compare_runs(duplicate, _run([_result()]))
+
+
+def test_prior_requested_only_schema_derives_nominal_budget():
+    prior: dict[str, JsonValue] = {
+        "config": {
+            "requested_query_transform_mode": "rewrite_hyde",
+            "requested_initial_k": 30,
+        },
+        "results": [_result()],
+    }
+    modern: dict[str, JsonValue] = {
+        "config": {
+            "query_transform_mode": "rewrite_hyde",
+            "initial_k": 60,
+            "per_query_k": 21,
+            "requested_query_transform_mode": "rewrite_hyde",
+            "requested_initial_k": 30,
+        },
+        "results": [
+            _result(
+                effective_transform_mode="rewrite_hyde",
+                effective_initial_k=60,
+                effective_per_query_k=21,
+            ),
+        ],
+    }
+
+    prior_case = parse_cases(prior, "prior")["case-1"]
+    comparison = compare_runs(prior, modern)
+
+    assert prior_case.requested_config == EffectiveRetrievalConfig(
+        transform_mode="rewrite_hyde",
+        initial_k=60,
+        per_query_k=21,
+    )
+    assert comparison.incomparable_configs == []
+
+
+@pytest.mark.parametrize("missing_key", ["initial_k", "per_query_k"])
+def test_partial_nominal_run_config_is_rejected(missing_key: str):
+    malformed = _run([_result()])
+    config = malformed["config"]
+    assert isinstance(config, dict)
+    del config[missing_key]
+
+    with pytest.raises(EvalJsonError, match="requested retrieval configuration"):
+        compare_runs(malformed, _run([_result()]))
+
+
+@pytest.mark.parametrize("null_key", ["initial_k", "per_query_k"])
+def test_null_nominal_run_budget_is_rejected(null_key: str):
+    malformed = _run([_result()])
+    config = malformed["config"]
+    assert isinstance(config, dict)
+    config[null_key] = None
+
+    with pytest.raises(EvalJsonError):
+        compare_runs(malformed, _run([_result()]))
+
+
+@pytest.mark.parametrize(
+    "effective_config",
+    [
+        {
+            "effective_transform_mode": "raw",
+            "effective_initial_k": 40,
+            "effective_per_query_k": 10,
+        },
+        {
+            "effective_transform_mode": "rewrite_hyde",
+            "effective_initial_k": 41,
+            "effective_per_query_k": 10,
+        },
+        {
+            "effective_transform_mode": "rewrite_hyde",
+            "effective_initial_k": 40,
+            "effective_per_query_k": 11,
+        },
+    ],
+)
+def test_each_effective_config_field_can_make_case_incomparable(
+    effective_config: dict[str, JsonValue],
+):
+    comparison = compare_runs(
+        _run([_result()]),
+        _run([_result(**effective_config)]),
+    )
+
+    assert [case.current.id for case in comparison.incomparable_configs] == ["case-1"]

--- a/api/tests/eval/test_run_eval.py
+++ b/api/tests/eval/test_run_eval.py
@@ -1,3 +1,7 @@
+import argparse
+import json
+from pathlib import Path
+
 import anyio
 import pytest
 
@@ -6,6 +10,77 @@ from app.llms.models import Model
 from app.llms.query_modes import QueryTransformMode
 from app.llms.query_variants import QueryVariant, QueryVariantBundle
 from tests.eval import run_eval
+
+
+def test_main_async_json_preserves_legacy_config_and_reports_effective_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    golden_path = tmp_path / "golden.jsonl"
+    output_path = tmp_path / "results.json"
+    golden_path.write_text(
+        '{"id":"case","query":"query","anchor":{"type":"none"}}\n',
+        encoding="utf-8",
+    )
+
+    class FakeDatabase:
+        async def init(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            return None
+
+    async def close_http_client() -> None:
+        return None
+
+    async def evaluate_one(*args, **kwargs) -> run_eval.Result:
+        return run_eval.Result(
+            example=args[1],
+            effective_transform_mode=QueryTransformMode.RAW,
+            effective_initial_k=30,
+            effective_per_query_k=31,
+        )
+
+    monkeypatch.setattr(run_eval, "Database", lambda dsn: FakeDatabase())
+    monkeypatch.setattr(run_eval, "init_http_client", lambda: None)
+    monkeypatch.setattr(run_eval, "close_http_client", close_http_client)
+    monkeypatch.setattr(run_eval, "evaluate_one", evaluate_one)
+
+    namespace = argparse.Namespace(
+        concurrency=1,
+        embedding_model=Model.BGE_M3_LOCAL.value,
+        golden=str(golden_path),
+        ideal_limit=60,
+        initial_k=30,
+        json=str(output_path),
+        limit=None,
+        no_transform=False,
+        query_transform_model=Model.GPT_5_4_MINI.value,
+        top_k=10,
+        transform_mode=QueryTransformMode.REWRITE_HYDE,
+    )
+
+    exit_code = anyio.run(run_eval.main_async, namespace)
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert exit_code == 0
+    assert payload["config"] == {
+        "embedding_model": Model.BGE_M3_LOCAL.value,
+        "query_transform_model": Model.GPT_5_4_MINI.value,
+        "query_transform_mode": QueryTransformMode.REWRITE_HYDE.value,
+        "initial_k": 60,
+        "per_query_k": 21,
+        "ideal_limit": 60,
+        "requested_query_transform_mode": QueryTransformMode.REWRITE_HYDE.value,
+        "requested_initial_k": 30,
+        "budget_scope": "per_example_effective_mode",
+        "ideal_limit_floor": 60,
+        "top_k": 10,
+        "reranker_min_score": run_eval.settings.RERANKER_MIN_SCORE,
+    }
+    assert payload["results"][0]["effective_transform_mode"] == "raw"
+    assert payload["results"][0]["effective_initial_k"] == 30
+    assert payload["results"][0]["effective_per_query_k"] == 31
 
 
 def test_evaluate_one_budgets_from_retained_query_variants(

--- a/api/tests/eval/test_run_eval.py
+++ b/api/tests/eval/test_run_eval.py
@@ -8,43 +8,42 @@ from app.llms.query_variants import QueryVariant, QueryVariantBundle
 from tests.eval import run_eval
 
 
-class _BudgetProbeError(RuntimeError):
-    pass
-
-
 def test_evaluate_one_budgets_from_retained_query_variants(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    seen_modes: list[QueryTransformMode] = []
-
     async def return_raw_bundle(*args, **kwargs):
         raw = QueryVariant(kind="raw", text="query", is_document=False)
         return QueryVariantBundle(variants=(raw,), rerank_query="query")
 
-    def capture_budget(mode: QueryTransformMode, requested_initial_k: int):
-        seen_modes.append(mode)
-        raise _BudgetProbeError
+    async def return_embedding(*args, **kwargs):
+        return [0.1]
+
+    async def return_no_results(*args, **kwargs):
+        return []
 
     monkeypatch.setattr(run_eval, "build_query_variants", return_raw_bundle)
-    monkeypatch.setattr(run_eval, "retrieval_budget", capture_budget)
+    monkeypatch.setattr(run_eval, "_embed_variant", return_embedding)
+    monkeypatch.setattr(run_eval, "get_closest_questions", return_no_results)
+    monkeypatch.setattr(run_eval, "get_closest_chunks", return_no_results)
 
-    async def evaluate() -> None:
-        with pytest.raises(_BudgetProbeError):
-            await run_eval.evaluate_one(
-                Database("postgresql://unused"),
-                run_eval.Example(
-                    id="raw-fallback",
-                    query="query",
-                    anchor={"type": "none"},
-                ),
-                embedding_model=Model.BGE_M3_LOCAL,
-                qt_model=Model.GPT_5_4_MINI,
-                initial_k=30,
-                top_k=10,
-                ideal_limit=60,
-                transform_mode=QueryTransformMode.REWRITE_HYDE,
-            )
+    async def evaluate() -> run_eval.Result:
+        return await run_eval.evaluate_one(
+            Database("postgresql://unused"),
+            run_eval.Example(
+                id="raw-fallback",
+                query="query",
+                anchor={"type": "none"},
+            ),
+            embedding_model=Model.BGE_M3_LOCAL,
+            qt_model=Model.GPT_5_4_MINI,
+            initial_k=30,
+            top_k=10,
+            ideal_limit=60,
+            transform_mode=QueryTransformMode.REWRITE_HYDE,
+        )
 
-    anyio.run(evaluate)
+    result = anyio.run(evaluate)
 
-    assert seen_modes == [QueryTransformMode.RAW]
+    assert result.effective_transform_mode == QueryTransformMode.RAW
+    assert result.effective_initial_k == 30
+    assert result.effective_per_query_k == 31

--- a/api/tests/eval/test_run_eval.py
+++ b/api/tests/eval/test_run_eval.py
@@ -1,0 +1,50 @@
+import anyio
+import pytest
+
+from app.data.connection import Database
+from app.llms.models import Model
+from app.llms.query_modes import QueryTransformMode
+from app.llms.query_variants import QueryVariant, QueryVariantBundle
+from tests.eval import run_eval
+
+
+class _BudgetProbeError(RuntimeError):
+    pass
+
+
+def test_evaluate_one_budgets_from_retained_query_variants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_modes: list[QueryTransformMode] = []
+
+    async def return_raw_bundle(*args, **kwargs):
+        raw = QueryVariant(kind="raw", text="query", is_document=False)
+        return QueryVariantBundle(variants=(raw,), rerank_query="query")
+
+    def capture_budget(mode: QueryTransformMode, requested_initial_k: int):
+        seen_modes.append(mode)
+        raise _BudgetProbeError
+
+    monkeypatch.setattr(run_eval, "build_query_variants", return_raw_bundle)
+    monkeypatch.setattr(run_eval, "retrieval_budget", capture_budget)
+
+    async def evaluate() -> None:
+        with pytest.raises(_BudgetProbeError):
+            await run_eval.evaluate_one(
+                Database("postgresql://unused"),
+                run_eval.Example(
+                    id="raw-fallback",
+                    query="query",
+                    anchor={"type": "none"},
+                ),
+                embedding_model=Model.BGE_M3_LOCAL,
+                qt_model=Model.GPT_5_4_MINI,
+                initial_k=30,
+                top_k=10,
+                ideal_limit=60,
+                transform_mode=QueryTransformMode.REWRITE_HYDE,
+            )
+
+    anyio.run(evaluate)
+
+    assert seen_modes == [QueryTransformMode.RAW]

--- a/api/tests/test_chat_cost_meta.py
+++ b/api/tests/test_chat_cost_meta.py
@@ -62,6 +62,7 @@ def _run_captured_stream(
             distinct_id="user-1",
             session_id="session-1",
             observation=observation,
+            effective_transform_mode=payload.query_transform_mode,
         )
         return [str(chunk) async for chunk in stream]
 

--- a/api/tests/test_chat_query_transform_telemetry.py
+++ b/api/tests/test_chat_query_transform_telemetry.py
@@ -1,0 +1,48 @@
+from uuid import uuid4
+
+import pytest
+
+from app.api import chat as chat_api
+from app.llms.agents import StreamObservation
+from app.llms.query_modes import QueryTransformMode
+from app.schemas.chat import ChatSchema
+from app.utils.timing import RequestTimings
+
+
+def test_generation_telemetry_distinguishes_requested_and_effective_transform_modes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = []
+
+    def capture(distinct_id, event, properties):
+        captured.append((distinct_id, event, properties))
+
+    monkeypatch.setattr(chat_api, "capture", capture)
+    response_id = uuid4()
+    payload = ChatSchema.model_validate(
+        {
+            "messages": [{"role": "user", "content": "query"}],
+            "query_transform_mode": QueryTransformMode.REWRITE_HYDE,
+        },
+    )
+
+    chat_api._capture_chat_response(  # noqa: SLF001
+        distinct_id="user",
+        payload=payload,
+        response_id=response_id,
+        timings=RequestTimings(),
+        retrieval_hit=False,
+        usage=None,
+        outcome="empty_answer",
+        observation=StreamObservation(
+            distinct_id="user",
+            response_id=str(response_id),
+        ),
+        answer_text="",
+        session_id=None,
+        effective_transform_mode=QueryTransformMode.RAW,
+    )
+
+    properties = captured[0][2]
+    assert properties["requested_query_transform_mode"] == "rewrite_hyde"
+    assert properties["query_transform_mode"] == "raw"

--- a/api/tests/test_chat_sponsored_admission.py
+++ b/api/tests/test_chat_sponsored_admission.py
@@ -18,6 +18,7 @@ from app.data.sponsored_usage import (
     SponsoredUsageAdmission,
 )
 from app.llms.models import Model
+from app.llms.query_modes import QueryTransformMode
 from app.llms.retrieval_result import RetrievedContext
 from app.utils import posthog_client
 from tests.chat_models_access_support import credentials, settings, usage_snapshot
@@ -102,7 +103,10 @@ async def _run_stream(
     async def get_context(*args, **kwargs):
         if retrieve is not None:
             return await retrieve(*args, **kwargs)
-        return RetrievedContext(text="context")
+        return RetrievedContext(
+            text="context",
+            effective_transform_mode=QueryTransformMode.REWRITE_HYDE,
+        )
 
     monkeypatch.setattr(chat_api, "resolve_provider_credentials", resolve_credentials)
     monkeypatch.setattr(chat_api, "admit_sponsored_request", admit)

--- a/api/tests/test_query_transform_credentials.py
+++ b/api/tests/test_query_transform_credentials.py
@@ -65,10 +65,10 @@ def test_retrieval_uses_raw_query_when_hosted_transform_credential_is_missing(
 def test_contextualization_uses_latest_query_when_provider_returns_input(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    latest_query = "Колку чини тоа?"
+    latest_query = "Колку чини тоа?   "
 
     async def return_input(query, *args, **kwargs):
-        return query
+        return query.strip()
 
     monkeypatch.setattr(context_module, "transform_query", return_input)
 

--- a/api/tests/test_query_transform_credentials.py
+++ b/api/tests/test_query_transform_credentials.py
@@ -59,6 +59,7 @@ def test_retrieval_uses_raw_query_when_hosted_transform_credential_is_missing(
     result = anyio.run(collect)
 
     assert result.text == ""
+    assert result.effective_transform_mode == QueryTransformMode.RAW
     assert seen_modes == [QueryTransformMode.RAW]
 
 
@@ -119,4 +120,5 @@ def test_retrieval_uses_raw_depth_when_transformed_variants_are_omitted(
     result = anyio.run(collect)
 
     assert result.text == ""
+    assert result.effective_transform_mode == QueryTransformMode.RAW
     assert search_limits == [31]

--- a/api/tests/test_query_transform_credentials.py
+++ b/api/tests/test_query_transform_credentials.py
@@ -1,3 +1,5 @@
+import logging
+
 import anyio
 import pytest
 
@@ -84,6 +86,7 @@ def test_contextualization_uses_latest_query_when_provider_returns_input(
 
 
 def test_retrieval_uses_raw_depth_when_transformed_variants_are_omitted(
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     search_limits: list[int] = []
@@ -107,6 +110,7 @@ def test_retrieval_uses_raw_depth_when_transformed_variants_are_omitted(
     monkeypatch.setattr(context_module, "build_query_variants", return_raw_bundle)
     monkeypatch.setattr(context_module, "_embed_variant", fake_embed_variant)
     monkeypatch.setattr(context_module, "_search_both", capture_search_limit)
+    caplog.set_level(logging.INFO, logger="app.llms.context")
 
     async def collect():
         return await get_retrieved_context_with_sources(
@@ -122,3 +126,4 @@ def test_retrieval_uses_raw_depth_when_transformed_variants_are_omitted(
     assert result.text == ""
     assert result.effective_transform_mode == QueryTransformMode.RAW
     assert search_limits == [31]
+    assert "Query transform mode raw produced variants" in caplog.text

--- a/api/tests/test_query_transform_credentials.py
+++ b/api/tests/test_query_transform_credentials.py
@@ -3,7 +3,7 @@ import pytest
 
 from app.data.connection import Database
 from app.llms import context as context_module
-from app.llms.context import get_retrieved_context_with_sources
+from app.llms.context import _contextualize_query, get_retrieved_context_with_sources
 from app.llms.models import Model
 from app.llms.query_modes import QueryTransformMode
 from app.llms.query_variants import QueryVariant, QueryVariantBundle
@@ -60,3 +60,63 @@ def test_retrieval_uses_raw_query_when_hosted_transform_credential_is_missing(
 
     assert result.text == ""
     assert seen_modes == [QueryTransformMode.RAW]
+
+
+def test_contextualization_uses_latest_query_when_provider_returns_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest_query = "Колку чини тоа?"
+
+    async def return_input(query, *args, **kwargs):
+        return query
+
+    monkeypatch.setattr(context_module, "transform_query", return_input)
+
+    result = anyio.run(
+        _contextualize_query,
+        latest_query,
+        Model.GPT_5_4_MINI,
+        "Корисник: Колку чини пријавувањето?",
+    )
+
+    assert result == latest_query
+
+
+def test_retrieval_uses_raw_depth_when_transformed_variants_are_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    search_limits: list[int] = []
+
+    async def return_query(query, *args, **kwargs):
+        return query
+
+    async def return_raw_bundle(search_query, *args, **kwargs):
+        raw = QueryVariant(kind="raw", text=search_query, is_document=False)
+        return QueryVariantBundle(variants=(raw,), rerank_query=search_query)
+
+    async def fake_embed_variant(*args, **kwargs):
+        return [0.1]
+
+    async def capture_search_limit(db, embedding, embedding_model, limit):
+        search_limits.append(limit)
+        return [], []
+
+    monkeypatch.setattr(context_module, "has_provider_credential", lambda *args: True)
+    monkeypatch.setattr(context_module, "_contextualize_query", return_query)
+    monkeypatch.setattr(context_module, "build_query_variants", return_raw_bundle)
+    monkeypatch.setattr(context_module, "_embed_variant", fake_embed_variant)
+    monkeypatch.setattr(context_module, "_search_both", capture_search_limit)
+
+    async def collect():
+        return await get_retrieved_context_with_sources(
+            Database("postgresql://unused"),
+            "original query",
+            Model.BGE_M3_LOCAL,
+            Model.GPT_5_4_MINI,
+            query_transform_mode=QueryTransformMode.REWRITE_HYDE,
+        )
+
+    result = anyio.run(collect)
+
+    assert result.text == ""
+    assert search_limits == [31]

--- a/api/tests/test_query_variants.py
+++ b/api/tests/test_query_variants.py
@@ -1,0 +1,35 @@
+import anyio
+import pytest
+from anyio.lowlevel import checkpoint
+
+from app.llms import query_variants
+from app.llms.models import Model
+from app.llms.query_modes import QueryTransformMode
+
+
+def test_rewrite_hyde_omits_variants_unchanged_from_search_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    search_query = "Како се пријавува испит?"
+
+    async def unchanged_transform(*args, **kwargs):
+        await checkpoint()
+        return search_query
+
+    monkeypatch.setattr(query_variants, "transform_query", unchanged_transform)
+
+    result = anyio.run(
+        query_variants.build_query_variants,
+        search_query,
+        Model.GPT_5_4_MINI,
+        QueryTransformMode.REWRITE_HYDE,
+    )
+
+    assert result.variants == (
+        query_variants.QueryVariant(
+            kind="raw",
+            text=search_query,
+            is_document=False,
+        ),
+    )
+    assert result.rerank_query == search_query

--- a/api/tests/test_query_variants.py
+++ b/api/tests/test_query_variants.py
@@ -33,3 +33,58 @@ def test_rewrite_hyde_omits_variants_unchanged_from_search_query(
         ),
     )
     assert result.rerank_query == search_query
+
+
+@pytest.mark.parametrize(
+    ("rewrite_result", "hyde_result", "expected_kinds", "expected_rerank_query"),
+    [
+        (RuntimeError("rewrite failed"), "Хипотетички пасус", ("hyde", "raw"), "query"),
+        ("rewritten query", RuntimeError("hyde failed"), ("rewrite", "raw"), "rewritten query"),
+        (RuntimeError("rewrite failed"), RuntimeError("hyde failed"), ("raw",), "query"),
+    ],
+)
+def test_rewrite_hyde_omits_each_failed_transform_independently(
+    monkeypatch: pytest.MonkeyPatch,
+    rewrite_result: str | RuntimeError,
+    hyde_result: str | RuntimeError,
+    expected_kinds: tuple[str, ...],
+    expected_rerank_query: str,
+) -> None:
+    async def transform(*args, **kwargs):
+        await checkpoint()
+        result = hyde_result if "system_prompt" in kwargs else rewrite_result
+        if isinstance(result, RuntimeError):
+            raise result
+        return result
+
+    monkeypatch.setattr(query_variants, "transform_query", transform)
+
+    result = anyio.run(
+        query_variants.build_query_variants,
+        "query",
+        Model.GPT_5_4_MINI,
+        QueryTransformMode.REWRITE_HYDE,
+    )
+
+    assert tuple(variant.kind for variant in result.variants) == expected_kinds
+    assert result.rerank_query == expected_rerank_query
+
+
+def test_rewrite_hyde_propagates_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def cancel(*args, **kwargs):
+        await checkpoint()
+        raise anyio.get_cancelled_exc_class()
+
+    monkeypatch.setattr(query_variants, "transform_query", cancel)
+
+    async def collect() -> None:
+        with pytest.raises(anyio.get_cancelled_exc_class()):
+            await query_variants.build_query_variants(
+                "query",
+                Model.GPT_5_4_MINI,
+                QueryTransformMode.REWRITE_HYDE,
+            )
+
+    anyio.run(collect)

--- a/api/tests/test_query_variants.py
+++ b/api/tests/test_query_variants.py
@@ -39,8 +39,18 @@ def test_rewrite_hyde_omits_variants_unchanged_from_search_query(
     ("rewrite_result", "hyde_result", "expected_kinds", "expected_rerank_query"),
     [
         (RuntimeError("rewrite failed"), "Хипотетички пасус", ("hyde", "raw"), "query"),
-        ("rewritten query", RuntimeError("hyde failed"), ("rewrite", "raw"), "rewritten query"),
-        (RuntimeError("rewrite failed"), RuntimeError("hyde failed"), ("raw",), "query"),
+        (
+            "rewritten query",
+            RuntimeError("hyde failed"),
+            ("rewrite", "raw"),
+            "rewritten query",
+        ),
+        (
+            RuntimeError("rewrite failed"),
+            RuntimeError("hyde failed"),
+            ("raw",),
+            "query",
+        ),
     ],
 )
 def test_rewrite_hyde_omits_each_failed_transform_independently(


### PR DESCRIPTION
## Summary

- omit unchanged or failed rewrite/HyDE variants independently while always retaining raw retrieval
- derive retrieval budgets and runtime telemetry from the variants actually retained
- preserve legacy evaluator JSON config keys while adding requested and per-result effective fields
- keep FAQ-first source ordering unchanged

## Verification

- `uv run pytest -q --ignore=tests/test_compose_embedding_worker.py --ignore=tests/test_sponsored_preflight.py`: 387 passed, 25 skipped
- focused query-transform, telemetry, evaluator, and source-priority suites: passed
- `ruff check .`: passed
- `mypy .`: no issues in 213 source files
- five-lane goal, QA, quality, security, and context review: passed

The unfiltered Windows suite has three environment-only failures because Docker Compose v2 and `/bin/sh` are unavailable; Linux CI covers those platform-dependent checks.
