### PR TITLE
feat(api): add privacy-safe retrieval analytics

### DIFF
--- a/api/app/api/chat.py
+++ b/api/app/api/chat.py
@@ -67,7 +67,7 @@ from app.utils.timing import (
     start_request_timings,
     timed,
 )
-from app.utils.topic import classify_language, classify_topic
+from app.utils.topic import classify_language, classify_script, classify_topic
 
 logger = logging.getLogger(__name__)
 
@@ -265,6 +265,7 @@ def _capture_chat_response(
         "retrieval_hit": retrieval_hit,
         "outcome": outcome,
         "language": classify_language(payload.query),
+        "query_script": classify_script(payload.query),
         "ttft_ms": _ms(timings.ttft_ms),
         "thinking_ms": _ms(timings.thinking_ms),
         "llm_generation_ms": _ms(generation_ms),
@@ -278,6 +279,16 @@ def _capture_chat_response(
         "query_transform_mode": effective_transform_mode.value,
         "candidate_count": timings.candidate_count,
         "top_distance": timings.top_distance,
+        "transliteration_variant_added": timings.transliteration_variant_added,
+        "lexical_search_outcome": timings.lexical_search_outcome,
+        "dense_faq_candidate_count": timings.dense_faq_candidate_count,
+        "dense_document_candidate_count": timings.dense_document_candidate_count,
+        "lexical_faq_candidate_count": timings.lexical_faq_candidate_count,
+        "final_faq_count": timings.final_faq_count,
+        "final_document_count": timings.final_document_count,
+        "lexical_only_final_count": timings.lexical_only_final_count,
+        "retrieval_path": timings.retrieval_path,
+        "reranker_fallback": timings.reranker_fallback,
         "context_char_len": observation.context_chars,
         "context_chunk_count": len(timings.retrieval_ids),
         "answer_char_len": observation.answer_chars,

--- a/api/app/llms/context.py
+++ b/api/app/llms/context.py
@@ -1,8 +1,8 @@
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
-from typing import assert_never
+from dataclasses import dataclass, replace
+from typing import Literal, assert_never
 from uuid import UUID
 
 from asyncpg import PostgresError
@@ -40,8 +40,14 @@ from app.utils.discord_content import redact_unresolved_discord_tokens
 from app.utils.exceptions import RetrievalError
 from app.utils.settings import Settings
 from app.utils.timing import (
+    LexicalSearchOutcome,
+    RetrievalCandidateMetrics,
+    RetrievalPath,
+    RetrievalSelectionMetrics,
     record_reranker_scores,
+    record_retrieval_candidates,
     record_retrieval_ids,
+    record_retrieval_selection,
     record_retrieval_shape,
     timed,
 )
@@ -53,15 +59,17 @@ settings = Settings()
 # Chunks pulled in on each side of a retrieved chunk, to give the model a contiguous passage.
 _NEIGHBOR_WINDOW: int = 1
 _RETRIEVAL_IDS_CAP: int = 10
+type _CandidateRetrievalPath = Literal["dense", "lexical", "hybrid"]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _Candidate:
     key: str  # dedup key, namespaced 'Q:'/'C:' so a chunk never collides with a FAQ
     source: str  # 'faq' | 'chunk'
     rerank_text: str  # the candidate text scored by the cross-encoder
     context_text: str  # rendered into the final context string
     retrieval_source: RetrievalSource
+    retrieval_path: _CandidateRetrievalPath
     distance: float | None = None  # carried only for the DEBUG trace
     doc_id: UUID | None = None  # chunk identity for neighbor expansion (None for FAQ)
     chunk_index: int | None = None
@@ -124,7 +132,10 @@ def _embedding_for_variant(
     raise AssertionError(f"Unhandled query variant kind: {kind}")
 
 
-def _question_candidate(q: QuestionSchema) -> _Candidate:
+def _question_candidate(
+    q: QuestionSchema,
+    retrieval_path: _CandidateRetrievalPath = "dense",
+) -> _Candidate:
     name = redact_unresolved_discord_tokens(q.name)
     content = redact_unresolved_discord_tokens(q.content)
     links = [
@@ -161,6 +172,7 @@ def _question_candidate(q: QuestionSchema) -> _Candidate:
             ),
             snippet=content,
         ),
+        retrieval_path=retrieval_path,
         distance=q.distance,
     )
 
@@ -192,6 +204,7 @@ def _chunk_candidate(c: ChunkSchema) -> _Candidate:
             section=c.section,
             snippet=c.content,
         ),
+        retrieval_path="dense",
         distance=c.distance,
         doc_id=c.document_id,
         chunk_index=c.chunk_index,
@@ -199,20 +212,25 @@ def _chunk_candidate(c: ChunkSchema) -> _Candidate:
 
 
 def _build_candidates(
-    question_lists: list[list[QuestionSchema]],
-    chunk_lists: list[list[ChunkSchema]],
+    search_results: list[tuple[list[QuestionSchema], list[ChunkSchema]]],
+    lexical_results: list[list[QuestionSchema]],
 ) -> list[_Candidate]:
-    seen: set[str] = set()
-    merged: list[_Candidate] = []
-    for questions, chunks in zip(question_lists, chunk_lists, strict=True):
+    merged: dict[str, _Candidate] = {}
+    for questions, chunks in search_results:
         for cand in (
-            *map(_question_candidate, questions),
+            *(_question_candidate(question, "dense") for question in questions),
             *map(_chunk_candidate, chunks),
         ):
-            if cand.key not in seen:
-                seen.add(cand.key)
-                merged.append(cand)
-    return merged
+            merged.setdefault(cand.key, cand)
+    for questions in lexical_results:
+        for question in questions:
+            candidate = _question_candidate(question, "lexical")
+            existing = merged.get(candidate.key)
+            if existing is None:
+                merged[candidate.key] = candidate
+            elif existing.retrieval_path == "dense":
+                merged[candidate.key] = replace(existing, retrieval_path="hybrid")
+    return list(merged.values())
 
 
 def _select_with_source_priority(
@@ -357,6 +375,7 @@ async def get_retrieved_context_with_sources(
 
         lexical_results: list[list[QuestionSchema]] = []
         lexical_queries = query_search_variants(search_query)
+        lexical_search_outcome: LexicalSearchOutcome = "skipped"
         if lexical_faq_expansion_allowed(
             (
                 question.distance
@@ -378,21 +397,40 @@ async def get_retrieved_context_with_sources(
                             for lexical_query in lexical_queries
                         ),
                     )
+                    lexical_search_outcome = (
+                        "matched" if any(lexical_results) else "no_match"
+                    )
                 except PostgresError:
+                    lexical_search_outcome = "error"
                     logger.warning(
                         "Lexical FAQ search unavailable; continuing with vector candidates",
                         exc_info=True,
                     )
 
         candidates = _build_candidates(
-            [
-                *[questions for questions, _ in search_results],
-                *lexical_results,
-            ],
-            [
-                *[chunks for _, chunks in search_results],
-                *[[] for _ in lexical_results],
-            ],
+            search_results,
+            lexical_results,
+        )
+        dense_faq_candidate_count = sum(
+            candidate.source == "faq"
+            and candidate.retrieval_path in {"dense", "hybrid"}
+            for candidate in candidates
+        )
+        dense_document_candidate_count = sum(
+            candidate.source == "chunk" for candidate in candidates
+        )
+        lexical_faq_candidate_count = sum(
+            candidate.retrieval_path in {"lexical", "hybrid"}
+            for candidate in candidates
+        )
+        record_retrieval_candidates(
+            RetrievalCandidateMetrics(
+                transliteration_variant_added=len(lexical_queries) > 1,
+                lexical_search_outcome=lexical_search_outcome,
+                dense_faq_candidate_count=dense_faq_candidate_count,
+                dense_document_candidate_count=dense_document_candidate_count,
+                lexical_faq_candidate_count=lexical_faq_candidate_count,
+            ),
         )
 
         distances = [c.distance for c in candidates if c.distance is not None]
@@ -424,6 +462,8 @@ async def get_retrieved_context_with_sources(
         raise RetrievalError("Failed during multi-query vector search") from e
 
     rerank_texts = [c.rerank_text for c in candidates]
+    reranker_fallback = False
+    dense_fallback = False
 
     _stage("rerank")
 
@@ -500,6 +540,7 @@ async def get_retrieved_context_with_sources(
                     settings.RERANKER_MIN_SCORE,
                 )
                 ranked_candidates = [candidates[best_idx]]
+                reranker_fallback = True
 
         final = _select_with_source_priority(ranked_candidates, top_k)
         sources = visible_sources(
@@ -517,6 +558,8 @@ async def get_retrieved_context_with_sources(
             sum(1 for c in final if c.source == "chunk"),
         )
     except Exception as exc:
+        reranker_fallback = True
+        dense_fallback = True
         logger.warning(
             "Reranking failed; using vector order error_type=%s",
             type(exc).__name__,
@@ -527,6 +570,36 @@ async def get_retrieved_context_with_sources(
         final = _select_with_source_priority(dense_candidates, top_k)
         sources = ()
 
+    final_has_dense = any(
+        candidate.retrieval_path in {"dense", "hybrid"} for candidate in final
+    )
+    final_has_lexical = any(
+        candidate.retrieval_path in {"lexical", "hybrid"} for candidate in final
+    )
+    retrieval_path: RetrievalPath
+    if dense_fallback and final:
+        retrieval_path = "dense"
+    elif final_has_dense and final_has_lexical:
+        retrieval_path = "hybrid"
+    elif final_has_lexical:
+        retrieval_path = "lexical"
+    elif final_has_dense:
+        retrieval_path = "dense"
+    else:
+        retrieval_path = "none"
+    record_retrieval_selection(
+        RetrievalSelectionMetrics(
+            final_faq_count=sum(candidate.source == "faq" for candidate in final),
+            final_document_count=sum(
+                candidate.source == "chunk" for candidate in final
+            ),
+            lexical_only_final_count=sum(
+                candidate.retrieval_path == "lexical" for candidate in final
+            ),
+            reranker_fallback=reranker_fallback,
+            retrieval_path=retrieval_path,
+        ),
+    )
     record_retrieval_ids([c.key for c in final[:_RETRIEVAL_IDS_CAP]])
 
     _stage("context")

--- a/api/app/utils/timing.py
+++ b/api/app/utils/timing.py
@@ -2,6 +2,29 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import Literal
+
+type LexicalSearchOutcome = Literal["skipped", "no_match", "matched", "error"]
+type RetrievalPath = Literal["none", "dense", "lexical", "hybrid"]
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalCandidateMetrics:
+    transliteration_variant_added: bool
+    lexical_search_outcome: LexicalSearchOutcome
+    dense_faq_candidate_count: int
+    dense_document_candidate_count: int
+    lexical_faq_candidate_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalSelectionMetrics:
+    final_faq_count: int
+    final_document_count: int
+    lexical_only_final_count: int
+    reranker_fallback: bool
+    retrieval_path: RetrievalPath
 
 
 def _round(value: float | None, digits: int = 1) -> float | None:
@@ -28,6 +51,16 @@ class RequestTimings:
         self.reranker_score_max: float | None = None
         self.reranker_score_min: float | None = None
         self.reranker_above_threshold: int | None = None
+        self.transliteration_variant_added = False
+        self.lexical_search_outcome: LexicalSearchOutcome = "skipped"
+        self.dense_faq_candidate_count = 0
+        self.dense_document_candidate_count = 0
+        self.lexical_faq_candidate_count = 0
+        self.final_faq_count = 0
+        self.final_document_count = 0
+        self.lexical_only_final_count = 0
+        self.retrieval_path: RetrievalPath = "none"
+        self.reranker_fallback = False
         self.response_id: str | None = None
         self.distinct_id: str | None = None
 
@@ -97,6 +130,26 @@ def record_reranker_scores(scores: list[float], above_threshold: int) -> None:
     timings.reranker_score_max = max(scores)
     timings.reranker_score_min = min(scores)
     timings.reranker_above_threshold = above_threshold
+
+
+def record_retrieval_candidates(metrics: RetrievalCandidateMetrics) -> None:
+    timings = _current.get()
+    if timings is not None:
+        timings.transliteration_variant_added = metrics.transliteration_variant_added
+        timings.lexical_search_outcome = metrics.lexical_search_outcome
+        timings.dense_faq_candidate_count = metrics.dense_faq_candidate_count
+        timings.dense_document_candidate_count = metrics.dense_document_candidate_count
+        timings.lexical_faq_candidate_count = metrics.lexical_faq_candidate_count
+
+
+def record_retrieval_selection(metrics: RetrievalSelectionMetrics) -> None:
+    timings = _current.get()
+    if timings is not None:
+        timings.final_faq_count = metrics.final_faq_count
+        timings.final_document_count = metrics.final_document_count
+        timings.lexical_only_final_count = metrics.lexical_only_final_count
+        timings.reranker_fallback = metrics.reranker_fallback
+        timings.retrieval_path = metrics.retrieval_path
 
 
 def record_response_id(response_id: str) -> None:

--- a/api/app/utils/topic.py
+++ b/api/app/utils/topic.py
@@ -1,5 +1,10 @@
 """Residency-safe coarse topic labelling for chat queries (keyword match; label only)."""
 
+from typing import Literal
+from unicodedata import name
+
+type QueryScript = Literal["latin", "cyrillic", "mixed", "other"]
+
 OTHER_TOPIC = "other"
 
 _TOPIC_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
@@ -176,3 +181,15 @@ def classify_language(query: str) -> str:
     if cyrillic >= latin:
         return "mk"
     return "en"
+
+
+def classify_script(query: str) -> QueryScript:
+    has_cyrillic = any("CYRILLIC" in name(character, "") for character in query)
+    has_latin = any("LATIN" in name(character, "") for character in query)
+    if has_cyrillic and has_latin:
+        return "mixed"
+    if has_cyrillic:
+        return "cyrillic"
+    if has_latin:
+        return "latin"
+    return "other"

--- a/api/app/utils/topic.py
+++ b/api/app/utils/topic.py
@@ -184,10 +184,14 @@ def classify_language(query: str) -> str:
 
 
 def classify_script(query: str) -> QueryScript:
-    has_cyrillic = any("CYRILLIC" in name(character, "") for character in query)
-    has_latin = any("LATIN" in name(character, "") for character in query)
-    if has_cyrillic and has_latin:
-        return "mixed"
+    has_cyrillic = False
+    has_latin = False
+    for character in query:
+        character_name = name(character, "")
+        has_cyrillic = has_cyrillic or "CYRILLIC" in character_name
+        has_latin = has_latin or "LATIN" in character_name
+        if has_cyrillic and has_latin:
+            return "mixed"
     if has_cyrillic:
         return "cyrillic"
     if has_latin:

--- a/api/tests/test_chat_query_transform_telemetry.py
+++ b/api/tests/test_chat_query_transform_telemetry.py
@@ -9,9 +9,11 @@ from app.schemas.chat import ChatSchema
 from app.utils.timing import RequestTimings
 
 
-def test_generation_telemetry_distinguishes_requested_and_effective_transform_modes(
+def _capture_properties(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+    query: str,
+    timings: RequestTimings | None = None,
+):
     captured = []
 
     def capture(distinct_id, event, properties):
@@ -21,7 +23,7 @@ def test_generation_telemetry_distinguishes_requested_and_effective_transform_mo
     response_id = uuid4()
     payload = ChatSchema.model_validate(
         {
-            "messages": [{"role": "user", "content": "query"}],
+            "messages": [{"role": "user", "content": query}],
             "query_transform_mode": QueryTransformMode.REWRITE_HYDE,
         },
     )
@@ -30,7 +32,7 @@ def test_generation_telemetry_distinguishes_requested_and_effective_transform_mo
         distinct_id="user",
         payload=payload,
         response_id=response_id,
-        timings=RequestTimings(),
+        timings=timings or RequestTimings(),
         retrieval_hit=False,
         usage=None,
         outcome="empty_answer",
@@ -43,6 +45,64 @@ def test_generation_telemetry_distinguishes_requested_and_effective_transform_mo
         effective_transform_mode=QueryTransformMode.RAW,
     )
 
-    properties = captured[0][2]
+    return captured[0][2]
+
+
+def test_generation_telemetry_distinguishes_requested_and_effective_transform_modes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    properties = _capture_properties(monkeypatch, "query")
+
     assert properties["requested_query_transform_mode"] == "rewrite_hyde"
     assert properties["query_transform_mode"] == "raw"
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_script"),
+    [
+        ("smerovi na finki", "latin"),
+        ("š č ž ǵ ḱ", "latin"),
+        ("смерови на финки", "cyrillic"),
+        ("smerovi на finki", "mixed"),
+        ("12345?!", "other"),
+    ],
+)
+def test_generation_telemetry_records_query_script(
+    monkeypatch: pytest.MonkeyPatch,
+    query: str,
+    expected_script: str,
+) -> None:
+    properties = _capture_properties(monkeypatch, query)
+
+    assert properties["query_script"] == expected_script
+
+
+def test_generation_telemetry_emits_content_free_retrieval_aggregates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    timings = RequestTimings()
+    timings.transliteration_variant_added = True
+    timings.lexical_search_outcome = "matched"
+    timings.dense_faq_candidate_count = 1
+    timings.dense_document_candidate_count = 2
+    timings.lexical_faq_candidate_count = 3
+    timings.final_faq_count = 1
+    timings.final_document_count = 2
+    timings.lexical_only_final_count = 1
+    timings.retrieval_path = "hybrid"
+    timings.reranker_fallback = False
+    private_query = "sakam privaten odgovor"
+
+    properties = _capture_properties(monkeypatch, private_query, timings)
+
+    assert properties["transliteration_variant_added"] is True
+    assert properties["lexical_search_outcome"] == "matched"
+    assert properties["dense_faq_candidate_count"] == 1
+    assert properties["dense_document_candidate_count"] == 2
+    assert properties["lexical_faq_candidate_count"] == 3
+    assert properties["final_faq_count"] == 1
+    assert properties["final_document_count"] == 2
+    assert properties["lexical_only_final_count"] == 1
+    assert properties["retrieval_path"] == "hybrid"
+    assert properties["reranker_fallback"] is False
+    assert private_query not in repr(properties)

--- a/api/tests/test_hybrid_faq_retrieval.py
+++ b/api/tests/test_hybrid_faq_retrieval.py
@@ -13,8 +13,22 @@ from app.llms.context import get_retrieved_context_with_sources
 from app.llms.models import Model
 from app.llms.query_modes import QueryTransformMode
 from app.llms.query_variants import QueryVariant, QueryVariantBundle
+from app.llms.retrieval_result import RetrievedContext
 from app.schemas.documents import ChunkSchema
 from app.schemas.questions import QuestionSchema
+from app.utils.timing import (
+    RequestTimings,
+    reset_request_timings,
+    start_request_timings,
+)
+
+
+def _run_with_timings(run) -> tuple[RetrievedContext, RequestTimings]:
+    timings, token = start_request_timings()
+    try:
+        return anyio.run(run), timings
+    finally:
+        reset_request_timings(token)
 
 
 def test_lexical_faq_search_uses_weighted_or_query(
@@ -56,8 +70,18 @@ def test_lexical_faq_search_uses_weighted_or_query(
     assert limit == 7
 
 
+@pytest.mark.parametrize(
+    ("vector_score", "expected_final_faq_count", "expected_retrieval_path"),
+    [
+        (0.05, 1, "lexical"),
+        (0.5, 2, "hybrid"),
+    ],
+)
 def test_normalized_lexical_faq_reaches_existing_reranker(
     monkeypatch: pytest.MonkeyPatch,
+    vector_score: float,
+    expected_final_faq_count: int,
+    expected_retrieval_path: str,
 ) -> None:
     faq = QuestionSchema(
         id=uuid4(),
@@ -91,14 +115,14 @@ def test_normalized_lexical_faq_reaches_existing_reranker(
 
     async def lexical_search(_db, query, *, limit):
         lexical_limits.append(limit)
-        return [faq] if query.startswith("смерови") else []
+        return [vector_faq, faq] if query.startswith("смерови") else []
 
     class RerankResponse:
         def json(self):
             return {
                 "reranked_documents": [
                     {"index": 1, "score": 0.9},
-                    {"index": 0, "score": 0.05},
+                    {"index": 0, "score": vector_score},
                 ],
             }
 
@@ -121,7 +145,7 @@ def test_normalized_lexical_faq_reaches_existing_reranker(
             query_transform_mode=QueryTransformMode.RAW,
         )
 
-    result = anyio.run(run)
+    result, timings = _run_with_timings(run)
 
     assert result.sources[0].title == faq.name
     assert faq.content in result.text
@@ -130,6 +154,16 @@ def test_normalized_lexical_faq_reaches_existing_reranker(
         f"Наслов: {faq.name}\nСодржина: {faq.content}",
     ]
     assert lexical_limits == [31, 31]
+    assert timings.transliteration_variant_added is True
+    assert timings.lexical_search_outcome == "matched"
+    assert timings.dense_faq_candidate_count == 1
+    assert timings.dense_document_candidate_count == 0
+    assert timings.lexical_faq_candidate_count == 2
+    assert timings.final_faq_count == expected_final_faq_count
+    assert timings.final_document_count == 0
+    assert timings.lexical_only_final_count == 1
+    assert timings.retrieval_path == expected_retrieval_path
+    assert timings.reranker_fallback is False
 
 
 def test_lexical_faq_failure_preserves_dense_retrieval(
@@ -176,10 +210,16 @@ def test_lexical_faq_failure_preserves_dense_retrieval(
             query_transform_mode=QueryTransformMode.RAW,
         )
 
-    result = anyio.run(run)
+    result, timings = _run_with_timings(run)
 
     assert result.sources[0].title == vector_faq.name
     assert any(record.exc_info is not None for record in caplog.records)
+    assert timings.lexical_search_outcome == "error"
+    assert timings.dense_faq_candidate_count == 1
+    assert timings.lexical_faq_candidate_count == 0
+    assert timings.final_faq_count == 1
+    assert timings.retrieval_path == "dense"
+    assert timings.reranker_fallback is False
 
 
 def test_lexical_faq_search_is_skipped_without_vector_domain_signal(
@@ -211,19 +251,92 @@ def test_lexical_faq_search_is_skipped_without_vector_domain_signal(
             query_transform_mode=QueryTransformMode.RAW,
         )
 
-    result = anyio.run(run)
+    result, timings = _run_with_timings(run)
 
     assert result.text == ""
     assert lexical_calls == 0
+    assert timings.lexical_search_outcome == "skipped"
+    assert timings.dense_faq_candidate_count == 0
+    assert timings.dense_document_candidate_count == 0
+    assert timings.lexical_faq_candidate_count == 0
+    assert timings.final_faq_count == 0
+    assert timings.final_document_count == 0
+    assert timings.lexical_only_final_count == 0
+    assert timings.retrieval_path == "none"
+    assert timings.reranker_fallback is False
+
+
+def test_lexical_faq_search_records_no_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lexical_calls = 0
+    vector_faq = QuestionSchema(
+        id=uuid4(),
+        name="Контакт",
+        content="Контакт информации.",
+        links={},
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        distance=0.2,
+    )
+
+    async def embed(*args, **kwargs):
+        return [0.1]
+
+    async def vector_search(*args, **kwargs):
+        return [vector_faq], []
+
+    async def lexical_search(*args, **kwargs):
+        nonlocal lexical_calls
+        lexical_calls += 1
+        return []
+
+    class RerankResponse:
+        def json(self):
+            return {"reranked_documents": [{"index": 0, "score": 0.9}]}
+
+    async def rerank(*args, **kwargs):
+        return RerankResponse()
+
+    monkeypatch.setattr(context_module, "_embed_variant", embed)
+    monkeypatch.setattr(context_module, "_search_both", vector_search)
+    monkeypatch.setattr(context_module, "get_matching_questions", lexical_search)
+    monkeypatch.setattr(context_module, "_post_rerank", rerank)
+
+    async def run():
+        return await get_retrieved_context_with_sources(
+            Database("postgresql://unused"),
+            "smerovi na finki",
+            Model.BGE_M3_LOCAL,
+            Model.GPT_5_4_MINI,
+            query_transform_mode=QueryTransformMode.RAW,
+        )
+
+    result, timings = _run_with_timings(run)
+
+    assert vector_faq.content in result.text
+    assert lexical_calls == 2
+    assert timings.transliteration_variant_added is True
+    assert timings.lexical_search_outcome == "no_match"
+    assert timings.retrieval_path == "dense"
 
 
 def test_reranker_failure_falls_back_to_dense_candidates_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    lexical_faq = QuestionSchema(
+    overlapping_faq = QuestionSchema(
         id=uuid4(),
         name="Студиски програми",
-        content="Лексички FAQ кандидат.",
+        content="Густ и лексички FAQ кандидат.",
+        links={},
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        distance=0.1,
+    )
+    lexical_only_faq = QuestionSchema(
+        id=uuid4(),
+        name="Изборни предмети",
+        content="Само лексички FAQ кандидат.",
         links={},
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
@@ -242,18 +355,22 @@ def test_reranker_failure_falls_back_to_dense_candidates_only(
         return [0.1]
 
     async def vector_search(*args, **kwargs):
-        return [], [dense_chunk]
+        return [overlapping_faq], [dense_chunk]
 
     async def lexical_search(*args, **kwargs):
-        return [lexical_faq]
+        return [overlapping_faq, lexical_only_faq]
 
     async def failing_reranker(*args, **kwargs):
         raise RuntimeError("reranker unavailable")
+
+    async def no_neighbor_chunks(*args, **kwargs):
+        return []
 
     monkeypatch.setattr(context_module, "_embed_variant", embed)
     monkeypatch.setattr(context_module, "_search_both", vector_search)
     monkeypatch.setattr(context_module, "get_matching_questions", lexical_search)
     monkeypatch.setattr(context_module, "_post_rerank", failing_reranker)
+    monkeypatch.setattr(context_module, "get_chunks_window", no_neighbor_chunks)
 
     async def run():
         return await get_retrieved_context_with_sources(
@@ -262,10 +379,20 @@ def test_reranker_failure_falls_back_to_dense_candidates_only(
             Model.BGE_M3_LOCAL,
             Model.GPT_5_4_MINI,
             query_transform_mode=QueryTransformMode.RAW,
-            top_k=1,
+            top_k=2,
         )
 
-    result = anyio.run(run)
+    result, timings = _run_with_timings(run)
 
+    assert overlapping_faq.content in result.text
     assert dense_chunk.content in result.text
-    assert lexical_faq.content not in result.text
+    assert lexical_only_faq.content not in result.text
+    assert timings.lexical_search_outcome == "matched"
+    assert timings.dense_faq_candidate_count == 1
+    assert timings.dense_document_candidate_count == 1
+    assert timings.lexical_faq_candidate_count == 2
+    assert timings.final_faq_count == 1
+    assert timings.final_document_count == 1
+    assert timings.lexical_only_final_count == 0
+    assert timings.retrieval_path == "dense"
+    assert timings.reranker_fallback is True


### PR DESCRIPTION
## Summary

- record content-free dense, lexical, hybrid, and final-selection retrieval metrics
- preserve dense/lexical provenance through deduplication and report truthful final retrieval paths
- expose bounded script, outcome, count, and fallback properties on the existing `$ai_generation` event
- cover matched, no-match, skipped, lexical-error, overlap, and reranker-fallback paths without external analytics writes

## Privacy

The new properties contain only booleans, bounded enums, and counts. They do not include questions, answers, source titles, URLs, snippets, credentials, or new identifiers.

## Verification

- `uv run pytest -q --ignore=tests/test_compose_embedding_worker.py --ignore=tests/test_sponsored_preflight.py` (`437 passed, 26 skipped`)
- `uv run ruff check .`
- `uv run ruff format --check ...` on all changed files
- `uv run mypy .` (`222 source files`)
- live stubbed `/chat/` HTTP QA: `200` SSE response, content-free `$ai_generation` payload with `retrieval_path=lexical`, sanitized malformed-input `422`
- five-lane post-implementation review passed after correcting final-route semantics and offline test isolation

The two excluded baseline test files require Docker Compose v2 and `/bin/sh`, which are unavailable in the Windows development environment.
